### PR TITLE
chore: prepare v0.0.1-alpha.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,8 +30,8 @@ body:
     id: version
     attributes:
       label: syu version
-      description: "Example: `0.0.1-alpha.5` or `v0.0.1-alpha.4`"
-      placeholder: 0.0.1-alpha.5
+      description: "Example: `0.0.1-alpha.6` or `v0.0.1-alpha.4`"
+      placeholder: 0.0.1-alpha.6
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "syu"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syu"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.6"
 edition = "2024"
 description = "Specification-driven development helper CLI"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu
 Install a specific prerelease:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.5 bash
+curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.6 bash
 ```
 
 ## Quick start
@@ -139,7 +139,7 @@ The self-hosted repository keeps its latest generated report at
 `syu` looks for `syu.yaml` in the workspace root:
 
 ```yaml
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -9,7 +9,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ### Version
 
-- 0.0.1-alpha.5
+- 0.0.1-alpha.6
 
 ### Updated
 
@@ -41,7 +41,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 ## Source YAML
 
 ```yaml
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 updated: "2026-03"
 
 files:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -7,7 +7,7 @@
 ## Minimal configuration
 
 ```yaml
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 updated: "2026-03"
 
 files:

--- a/examples/polyglot/docs/syu/features/features.yaml
+++ b/examples/polyglot/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 files:
   - kind: polyglot
     file: polyglot.yaml

--- a/examples/polyglot/syu.yaml
+++ b/examples/polyglot/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/examples/python-only/docs/syu/features/features.yaml
+++ b/examples/python-only/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 files:
   - kind: python
     file: python.yaml

--- a/examples/python-only/syu.yaml
+++ b/examples/python-only/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/examples/rust-only/docs/syu/features/features.yaml
+++ b/examples/rust-only/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 files:
   - kind: rust
     file: rust.yaml

--- a/examples/rust-only/syu.yaml
+++ b/examples/rust-only/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/syu.yaml
+++ b/syu.yaml
@@ -1,5 +1,5 @@
 # FEAT-CHECK-001
-version: 0.0.1-alpha.5
+version: 0.0.1-alpha.6
 spec:
   root: docs/syu
 validate:

--- a/tests/fixtures/workspaces/failing/docs/syu/features/features.yaml
+++ b/tests/fixtures/workspaces/failing/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 updated: "2026-03"
 
 files:

--- a/tests/fixtures/workspaces/passing/docs/syu/features/features.yaml
+++ b/tests/fixtures/workspaces/passing/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.5"
+version: "0.0.1-alpha.6"
 updated: "2026-03"
 
 files:


### PR DESCRIPTION
## Summary
- bump the checked-in project version from `0.0.1-alpha.5` to `0.0.1-alpha.6`
- refresh self-hosted spec and example workspace version markers
- keep README, config examples, and fixtures aligned for the upcoming alpha release

## Validation
- python3 scripts/generate-site-docs.py
- scripts/ci/quality-gates.sh
- cd website && npm install --no-package-lock && npm run build