### PR TITLE
feat: refine validation rule taxonomy

### DIFF
--- a/docs/generated/site-spec/features/cli/check.md
+++ b/docs/generated/site-spec/features/cli/check.md
@@ -65,7 +65,7 @@ description: "Generated reference for docs/syu/features/cli/check.yaml"
         - **symbols**:
           - SYU-workspace-load-001
           - SYU-graph-reference-001
-          - SYU-coverage-test-003
+          - SYU-coverage-test-001
 
 ## Source YAML
 
@@ -122,5 +122,5 @@ features:
           symbols:
             - SYU-workspace-load-001
             - SYU-graph-reference-001
-            - SYU-coverage-test-003
+            - SYU-coverage-test-001
 ```

--- a/docs/generated/site-spec/features/cli/validation.md
+++ b/docs/generated/site-spec/features/cli/validation.md
@@ -25,7 +25,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       becomes untrustworthy because `syu` no longer knows which definitions,
       paths, or trace mappings should exist. This rule exists to fail early and
       honestly when the repository shape itself is broken.
-- **code**: SYU-workspace-blank-002
+- **code**: SYU-workspace-blank-001
   - **genre**: workspace
   - **severity**: error
   - **title**: Required specification fields must not be blank
@@ -38,7 +38,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       prose, and status fields to be explicitly populated. The goal is to keep
       the spec usable both for humans trying to understand intent and for
       automation trying to verify it.
-- **code**: SYU-workspace-duplicate-003
+- **code**: SYU-workspace-duplicate-001
   - **genre**: workspace
   - **severity**: error
   - **title**: Definition IDs must be unique
@@ -62,7 +62,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       implementation and make it impossible to explain why a change exists.
       This rule forces contributors to either declare the missing item or remove
       the stale relationship before the graph drifts further.
-- **code**: SYU-graph-reciprocal-002
+- **code**: SYU-graph-reciprocal-001
   - **genre**: graph
   - **severity**: error
   - **title**: Adjacent-layer links must be reciprocal
@@ -74,7 +74,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       navigate from cause to effect or from implementation back to intent. This
       rule preserves explainability by requiring each adjacent layer to confirm
       the relationship from its own point of view.
-- **code**: SYU-graph-links-003
+- **code**: SYU-graph-links-001
   - **genre**: graph
   - **severity**: warning
   - **title**: Adjacent-layer expectations should be explicit
@@ -85,7 +85,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       links are a strong smell that the spec is becoming harder to navigate.
       This warning nudges authors to keep the graph richly connected so the
       repository remains easy to browse, audit, and evolve over time.
-- **code**: SYU-graph-orphaned-004
+- **code**: SYU-graph-orphaned-001
   - **genre**: graph
   - **severity**: error
   - **title**: Definitions must not be isolated from the layered graph
@@ -109,7 +109,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       tell whether traces should exist, be absent, or be considered complete.
       This rule keeps workflow semantics predictable by limiting the state
       vocabulary to supported values.
-- **code**: SYU-delivery-status-002
+- **code**: SYU-delivery-planned-001
   - **genre**: delivery
   - **severity**: error
   - **title**: Planned items can be forbidden by project policy
@@ -121,7 +121,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       workspace. This rule lets a project tighten that policy without rewriting
       the entire validation engine. The goal is to support both exploratory
       workflows and locked-down release workflows through explicit config.
-- **code**: SYU-delivery-planned-003
+- **code**: SYU-delivery-planned-002
   - **genre**: delivery
   - **severity**: error
   - **title**: Planned items must not claim delivered traces
@@ -133,7 +133,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       evidence disagree, which makes reports and roadmap conversations harder to
       trust. This rule preserves the meaning of planning by keeping future work
       distinct from delivered work.
-- **code**: SYU-delivery-implemented-004
+- **code**: SYU-delivery-implemented-001
   - **genre**: delivery
   - **severity**: error
   - **title**: Implemented items must prove delivery
@@ -144,7 +144,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       already demonstrate it. Without traces, that promise becomes a belief
       rather than evidence. This rule exists to make implementation status
       reviewable and to keep status labels from drifting away from reality.
-- **code**: SYU-delivery-missing-005
+- **code**: SYU-delivery-missing-001
   - **genre**: delivery
   - **severity**: warning
   - **title**: Undefined delivery state leaves trace expectations unclear
@@ -167,19 +167,30 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       refers to. This rule prevents repositories from gaining a false sense of
       security by declaring traces in languages the current validator cannot
       actually inspect.
+- **code**: SYU-trace-file-001
+  - **genre**: trace
+  - **severity**: error
+  - **title**: Trace mappings must declare a file path
+  - **summary**: A trace without an explicit file path cannot identify repository evidence.
+  - **description**:
+    - |
+      Traceability depends on concrete, inspectable files. If a mapping omits the
+      file path entirely, the validator has nowhere to look for evidence and
+      reviewers cannot tell which artifact is supposed to satisfy the spec. This
+      rule keeps every declared trace grounded in an explicit repository path.
 - **code**: SYU-trace-file-002
   - **genre**: trace
   - **severity**: error
-  - **title**: Trace files must exist and be named explicitly
-  - **summary**: A trace without a real file cannot prove anything about the repository.
+  - **title**: Declared trace files must exist
+  - **summary**: A trace that points to a missing file cannot prove anything about the repository.
   - **description**:
     - |
-      Traceability depends on concrete, inspectable files. If a path is absent,
-      blank, or stale, the spec stops pointing to real evidence and starts
-      pointing to an aspiration. This rule ensures that every declared trace is
-      grounded in a repository artifact that reviewers and automation can both
-      inspect.
-- **code**: SYU-trace-unreadable-003
+      Traceability depends on concrete, inspectable files. If a path is stale or
+      points outside the current repository contents, the spec stops pointing to
+      real evidence and starts pointing to an aspiration. This rule ensures that
+      every declared trace remains grounded in a repository artifact that both
+      reviewers and automation can actually inspect.
+- **code**: SYU-trace-unreadable-001
   - **genre**: trace
   - **severity**: error
   - **title**: Trace files must be readable to the validator
@@ -191,7 +202,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       broken trace because the validator cannot confirm the promised behavior.
       This rule exists to surface those operational failures instead of silently
       assuming the trace is probably fine.
-- **code**: SYU-trace-extension-004
+- **code**: SYU-trace-extension-001
   - **genre**: trace
   - **severity**: error
   - **title**: The declared trace language must match the traced file
@@ -203,7 +214,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       invalid interpretation and reviewers lose confidence in what the trace
       means. This rule keeps the declared language and the referenced artifact in
       sync.
-- **code**: SYU-trace-id-005
+- **code**: SYU-trace-id-001
   - **genre**: trace
   - **severity**: error
   - **title**: Traced files must mention the owning specification ID
@@ -215,18 +226,41 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       also mention that ownership so someone reading the code or test can see the
       link without consulting another system. This rule keeps traceability visible
       at the point where work actually happens.
-- **code**: SYU-trace-symbol-006
+- **code**: SYU-trace-symbol-001
   - **genre**: trace
   - **severity**: error
-  - **title**: Trace mappings must identify concrete symbols
-  - **summary**: Validation needs a real symbol to inspect instead of a vague file-level hint.
+  - **title**: Trace mappings must identify at least one symbol
+  - **summary**: Validation needs a concrete symbol target instead of an empty mapping.
   - **description**:
     - |
-      Files often contain many behaviors. Without a symbol target, a trace may
-      point at a broad area of the repository while still leaving uncertainty
-      about what actually satisfies the requirement or feature. This rule keeps
-      traces precise enough to support audits, refactors, and future maintenance.
-- **code**: SYU-trace-inspection-007
+      Files often contain many behaviors. If a trace mapping does not name any
+      symbols at all, the validator cannot tell which implementation or test case
+      is supposed to satisfy the requirement or feature. This rule keeps traces
+      precise enough to support audits, refactors, and future maintenance.
+- **code**: SYU-trace-symbol-002
+  - **genre**: trace
+  - **severity**: error
+  - **title**: Trace symbol entries must not be blank
+  - **summary**: Whitespace-only symbol entries hide which repository behavior the trace intends to verify.
+  - **description**:
+    - |
+      A symbol list that contains blank entries looks more complete than it is.
+      Reviewers and tooling still lack a usable target, but the mapping no longer
+      reads as obviously empty. This rule keeps symbol declarations explicit by
+      requiring every listed entry to name a real symbol.
+- **code**: SYU-trace-symbol-003
+  - **genre**: trace
+  - **severity**: error
+  - **title**: Declared trace symbols must exist in the traced file
+  - **summary**: A trace can only prove ownership when the named symbol is present in the referenced file.
+  - **description**:
+    - |
+      Symbol-level traces are useful because they point to the exact behavior a
+      requirement or feature relies on. If the named symbol is missing, the spec
+      no longer identifies real evidence and may be drifting behind refactors or
+      stale documentation. This rule keeps symbol traces anchored to actual code
+      and tests.
+- **code**: SYU-trace-inspection-001
   - **genre**: trace
   - **severity**: error
   - **title**: Rich symbol inspection must succeed when required
@@ -238,7 +272,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       surface the failure immediately instead of falling back to a weaker,
       success-shaped assumption. This rule protects trust in the validator's
       conclusions.
-- **code**: SYU-trace-doc-008
+- **code**: SYU-trace-doc-001
   - **genre**: trace
   - **severity**: error
   - **title**: Required trace documentation snippets must be present
@@ -249,11 +283,23 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       explanatory text to remain maintainable. This rule enforces those declared
       documentation snippets so that code, tests, and generated reports all
       preserve the rationale the spec asked for.
-- **code**: SYU-trace-support-009
+- **code**: SYU-trace-docscope-001
   - **genre**: trace
   - **severity**: error
-  - **title**: Documentation assertions need a language that can verify them
-  - **summary**: `doc_contains` promises should only be made where the validator can inspect docs.
+  - **title**: Wildcard traces cannot carry symbol-level doc assertions
+  - **summary**: `doc_contains` checks need a single symbol target instead of a wildcard file claim.
+  - **description**:
+    - |
+      Wildcard ownership is useful when one specification item intentionally owns
+      every relevant symbol in a file. Documentation assertions are different:
+      they need one concrete symbol so the validator knows exactly which docs to
+      inspect. This rule keeps doc-level checks precise instead of letting them
+      ride on an ambiguous wildcard mapping.
+- **code**: SYU-trace-docsupport-001
+  - **genre**: trace
+  - **severity**: error
+  - **title**: Documentation assertions require rich symbol inspection
+  - **summary**: `doc_contains` promises should only be made where the validator can inspect symbol docs.
   - **description**:
     - |
       A repository should not declare documentation constraints that the current
@@ -261,19 +307,42 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       tool can honestly enforce. This rule preserves integrity by requiring
       doc-level checks to stay within languages with meaningful documentation
       inspection support.
-- **code**: SYU-coverage-scan-001
+- **code**: SYU-coverage-walk-001
   - **genre**: coverage
   - **severity**: error
-  - **title**: Coverage inventory must be inspectable
-  - **summary**: Opt-in trace coverage cannot be enforced unless `syu` can scan the workspace.
+  - **title**: Coverage inventory paths must be walkable
+  - **summary**: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
   - **description**:
     - |
-      The strict trace coverage rule only means something when `syu` can read and
-      parse the files it is supposed to inventory. If source or test files cannot
-      be scanned, the safest behavior is to fail loudly instead of pretending the
-      workspace is fully covered. This rule protects the credibility of the
-      100-percent coverage claim.
-- **code**: SYU-coverage-public-002
+      The strict trace coverage rule only means something when `syu` can walk the
+      repository paths that are supposed to contain owned Rust source and test
+      files. If directory discovery fails, the inventory itself is incomplete and
+      any 100-percent coverage conclusion would be misleading. This rule surfaces
+      repository layout problems before coverage claims become untrustworthy.
+- **code**: SYU-coverage-read-001
+  - **genre**: coverage
+  - **severity**: error
+  - **title**: Coverage inventory files must be readable
+  - **summary**: Unreadable Rust sources prevent honest trace coverage verification.
+  - **description**:
+    - |
+      Trace coverage can only be enforced when `syu` can read the Rust source and
+      test files it is supposed to inventory. If a file is unreadable, the safest
+      behavior is to fail loudly instead of pretending the workspace was fully
+      scanned. This rule protects the credibility of strict coverage mode.
+- **code**: SYU-coverage-parse-001
+  - **genre**: coverage
+  - **severity**: error
+  - **title**: Coverage inventory sources must parse successfully
+  - **summary**: Broken Rust syntax prevents reliable coverage inventory.
+  - **description**:
+    - |
+      Strict trace coverage relies on understanding the Rust items that appear in
+      the workspace. When a source file does not parse, `syu` cannot build a
+      trustworthy inventory of public APIs or tests. This rule keeps coverage
+      results explicit by surfacing syntax failures instead of hiding them behind
+      incomplete scans.
+- **code**: SYU-coverage-public-001
   - **genre**: coverage
   - **severity**: error
   - **title**: Public API symbols must belong to at least one feature
@@ -285,7 +354,7 @@ description: "Generated reference for docs/syu/features/cli/validation.yaml"
       the repository has no durable explanation for why that surface area exists
       or which behavior owns it. This rule encourages deliberate API growth by
       forcing public surface area to stay attached to an explicit feature.
-- **code**: SYU-coverage-test-003
+- **code**: SYU-coverage-test-001
   - **genre**: coverage
   - **severity**: error
   - **title**: Tests must belong to at least one requirement
@@ -317,7 +386,7 @@ rules:
       paths, or trace mappings should exist. This rule exists to fail early and
       honestly when the repository shape itself is broken.
 
-  - code: SYU-workspace-blank-002
+  - code: SYU-workspace-blank-001
     genre: workspace
     severity: error
     title: Required specification fields must not be blank
@@ -330,7 +399,7 @@ rules:
       the spec usable both for humans trying to understand intent and for
       automation trying to verify it.
 
-  - code: SYU-workspace-duplicate-003
+  - code: SYU-workspace-duplicate-001
     genre: workspace
     severity: error
     title: Definition IDs must be unique
@@ -354,7 +423,7 @@ rules:
       This rule forces contributors to either declare the missing item or remove
       the stale relationship before the graph drifts further.
 
-  - code: SYU-graph-reciprocal-002
+  - code: SYU-graph-reciprocal-001
     genre: graph
     severity: error
     title: Adjacent-layer links must be reciprocal
@@ -366,7 +435,7 @@ rules:
       rule preserves explainability by requiring each adjacent layer to confirm
       the relationship from its own point of view.
 
-  - code: SYU-graph-links-003
+  - code: SYU-graph-links-001
     genre: graph
     severity: warning
     title: Adjacent-layer expectations should be explicit
@@ -377,7 +446,7 @@ rules:
       This warning nudges authors to keep the graph richly connected so the
       repository remains easy to browse, audit, and evolve over time.
 
-  - code: SYU-graph-orphaned-004
+  - code: SYU-graph-orphaned-001
     genre: graph
     severity: error
     title: Definitions must not be isolated from the layered graph
@@ -401,7 +470,7 @@ rules:
       This rule keeps workflow semantics predictable by limiting the state
       vocabulary to supported values.
 
-  - code: SYU-delivery-status-002
+  - code: SYU-delivery-planned-001
     genre: delivery
     severity: error
     title: Planned items can be forbidden by project policy
@@ -413,7 +482,7 @@ rules:
       the entire validation engine. The goal is to support both exploratory
       workflows and locked-down release workflows through explicit config.
 
-  - code: SYU-delivery-planned-003
+  - code: SYU-delivery-planned-002
     genre: delivery
     severity: error
     title: Planned items must not claim delivered traces
@@ -425,7 +494,7 @@ rules:
       trust. This rule preserves the meaning of planning by keeping future work
       distinct from delivered work.
 
-  - code: SYU-delivery-implemented-004
+  - code: SYU-delivery-implemented-001
     genre: delivery
     severity: error
     title: Implemented items must prove delivery
@@ -436,7 +505,7 @@ rules:
       rather than evidence. This rule exists to make implementation status
       reviewable and to keep status labels from drifting away from reality.
 
-  - code: SYU-delivery-missing-005
+  - code: SYU-delivery-missing-001
     genre: delivery
     severity: warning
     title: Undefined delivery state leaves trace expectations unclear
@@ -459,19 +528,30 @@ rules:
       security by declaring traces in languages the current validator cannot
       actually inspect.
 
+  - code: SYU-trace-file-001
+    genre: trace
+    severity: error
+    title: Trace mappings must declare a file path
+    summary: A trace without an explicit file path cannot identify repository evidence.
+    description: |
+      Traceability depends on concrete, inspectable files. If a mapping omits the
+      file path entirely, the validator has nowhere to look for evidence and
+      reviewers cannot tell which artifact is supposed to satisfy the spec. This
+      rule keeps every declared trace grounded in an explicit repository path.
+
   - code: SYU-trace-file-002
     genre: trace
     severity: error
-    title: Trace files must exist and be named explicitly
-    summary: A trace without a real file cannot prove anything about the repository.
+    title: Declared trace files must exist
+    summary: A trace that points to a missing file cannot prove anything about the repository.
     description: |
-      Traceability depends on concrete, inspectable files. If a path is absent,
-      blank, or stale, the spec stops pointing to real evidence and starts
-      pointing to an aspiration. This rule ensures that every declared trace is
-      grounded in a repository artifact that reviewers and automation can both
-      inspect.
+      Traceability depends on concrete, inspectable files. If a path is stale or
+      points outside the current repository contents, the spec stops pointing to
+      real evidence and starts pointing to an aspiration. This rule ensures that
+      every declared trace remains grounded in a repository artifact that both
+      reviewers and automation can actually inspect.
 
-  - code: SYU-trace-unreadable-003
+  - code: SYU-trace-unreadable-001
     genre: trace
     severity: error
     title: Trace files must be readable to the validator
@@ -483,7 +563,7 @@ rules:
       This rule exists to surface those operational failures instead of silently
       assuming the trace is probably fine.
 
-  - code: SYU-trace-extension-004
+  - code: SYU-trace-extension-001
     genre: trace
     severity: error
     title: The declared trace language must match the traced file
@@ -495,7 +575,7 @@ rules:
       means. This rule keeps the declared language and the referenced artifact in
       sync.
 
-  - code: SYU-trace-id-005
+  - code: SYU-trace-id-001
     genre: trace
     severity: error
     title: Traced files must mention the owning specification ID
@@ -507,18 +587,41 @@ rules:
       link without consulting another system. This rule keeps traceability visible
       at the point where work actually happens.
 
-  - code: SYU-trace-symbol-006
+  - code: SYU-trace-symbol-001
     genre: trace
     severity: error
-    title: Trace mappings must identify concrete symbols
-    summary: Validation needs a real symbol to inspect instead of a vague file-level hint.
+    title: Trace mappings must identify at least one symbol
+    summary: Validation needs a concrete symbol target instead of an empty mapping.
     description: |
-      Files often contain many behaviors. Without a symbol target, a trace may
-      point at a broad area of the repository while still leaving uncertainty
-      about what actually satisfies the requirement or feature. This rule keeps
-      traces precise enough to support audits, refactors, and future maintenance.
+      Files often contain many behaviors. If a trace mapping does not name any
+      symbols at all, the validator cannot tell which implementation or test case
+      is supposed to satisfy the requirement or feature. This rule keeps traces
+      precise enough to support audits, refactors, and future maintenance.
 
-  - code: SYU-trace-inspection-007
+  - code: SYU-trace-symbol-002
+    genre: trace
+    severity: error
+    title: Trace symbol entries must not be blank
+    summary: Whitespace-only symbol entries hide which repository behavior the trace intends to verify.
+    description: |
+      A symbol list that contains blank entries looks more complete than it is.
+      Reviewers and tooling still lack a usable target, but the mapping no longer
+      reads as obviously empty. This rule keeps symbol declarations explicit by
+      requiring every listed entry to name a real symbol.
+
+  - code: SYU-trace-symbol-003
+    genre: trace
+    severity: error
+    title: Declared trace symbols must exist in the traced file
+    summary: A trace can only prove ownership when the named symbol is present in the referenced file.
+    description: |
+      Symbol-level traces are useful because they point to the exact behavior a
+      requirement or feature relies on. If the named symbol is missing, the spec
+      no longer identifies real evidence and may be drifting behind refactors or
+      stale documentation. This rule keeps symbol traces anchored to actual code
+      and tests.
+
+  - code: SYU-trace-inspection-001
     genre: trace
     severity: error
     title: Rich symbol inspection must succeed when required
@@ -530,7 +633,7 @@ rules:
       success-shaped assumption. This rule protects trust in the validator's
       conclusions.
 
-  - code: SYU-trace-doc-008
+  - code: SYU-trace-doc-001
     genre: trace
     severity: error
     title: Required trace documentation snippets must be present
@@ -541,11 +644,23 @@ rules:
       documentation snippets so that code, tests, and generated reports all
       preserve the rationale the spec asked for.
 
-  - code: SYU-trace-support-009
+  - code: SYU-trace-docscope-001
     genre: trace
     severity: error
-    title: Documentation assertions need a language that can verify them
-    summary: "`doc_contains` promises should only be made where the validator can inspect docs."
+    title: Wildcard traces cannot carry symbol-level doc assertions
+    summary: "`doc_contains` checks need a single symbol target instead of a wildcard file claim."
+    description: |
+      Wildcard ownership is useful when one specification item intentionally owns
+      every relevant symbol in a file. Documentation assertions are different:
+      they need one concrete symbol so the validator knows exactly which docs to
+      inspect. This rule keeps doc-level checks precise instead of letting them
+      ride on an ambiguous wildcard mapping.
+
+  - code: SYU-trace-docsupport-001
+    genre: trace
+    severity: error
+    title: Documentation assertions require rich symbol inspection
+    summary: "`doc_contains` promises should only be made where the validator can inspect symbol docs."
     description: |
       A repository should not declare documentation constraints that the current
       adapter cannot verify. Otherwise the spec would appear stricter than the
@@ -553,19 +668,42 @@ rules:
       doc-level checks to stay within languages with meaningful documentation
       inspection support.
 
-  - code: SYU-coverage-scan-001
+  - code: SYU-coverage-walk-001
     genre: coverage
     severity: error
-    title: Coverage inventory must be inspectable
-    summary: Opt-in trace coverage cannot be enforced unless `syu` can scan the workspace.
+    title: Coverage inventory paths must be walkable
+    summary: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
     description: |
-      The strict trace coverage rule only means something when `syu` can read and
-      parse the files it is supposed to inventory. If source or test files cannot
-      be scanned, the safest behavior is to fail loudly instead of pretending the
-      workspace is fully covered. This rule protects the credibility of the
-      100-percent coverage claim.
+      The strict trace coverage rule only means something when `syu` can walk the
+      repository paths that are supposed to contain owned Rust source and test
+      files. If directory discovery fails, the inventory itself is incomplete and
+      any 100-percent coverage conclusion would be misleading. This rule surfaces
+      repository layout problems before coverage claims become untrustworthy.
 
-  - code: SYU-coverage-public-002
+  - code: SYU-coverage-read-001
+    genre: coverage
+    severity: error
+    title: Coverage inventory files must be readable
+    summary: Unreadable Rust sources prevent honest trace coverage verification.
+    description: |
+      Trace coverage can only be enforced when `syu` can read the Rust source and
+      test files it is supposed to inventory. If a file is unreadable, the safest
+      behavior is to fail loudly instead of pretending the workspace was fully
+      scanned. This rule protects the credibility of strict coverage mode.
+
+  - code: SYU-coverage-parse-001
+    genre: coverage
+    severity: error
+    title: Coverage inventory sources must parse successfully
+    summary: Broken Rust syntax prevents reliable coverage inventory.
+    description: |
+      Strict trace coverage relies on understanding the Rust items that appear in
+      the workspace. When a source file does not parse, `syu` cannot build a
+      trustworthy inventory of public APIs or tests. This rule keeps coverage
+      results explicit by surfacing syntax failures instead of hiding them behind
+      incomplete scans.
+
+  - code: SYU-coverage-public-001
     genre: coverage
     severity: error
     title: Public API symbols must belong to at least one feature
@@ -577,7 +715,7 @@ rules:
       or which behavior owns it. This rule encourages deliberate API growth by
       forcing public surface area to stay attached to an explicit feature.
 
-  - code: SYU-coverage-test-003
+  - code: SYU-coverage-test-001
     genre: coverage
     severity: error
     title: Tests must belong to at least one requirement

--- a/docs/syu/features/cli/check.yaml
+++ b/docs/syu/features/cli/check.yaml
@@ -50,4 +50,4 @@ features:
           symbols:
             - SYU-workspace-load-001
             - SYU-graph-reference-001
-            - SYU-coverage-test-003
+            - SYU-coverage-test-001

--- a/docs/syu/features/cli/validation.yaml
+++ b/docs/syu/features/cli/validation.yaml
@@ -14,7 +14,7 @@ rules:
       paths, or trace mappings should exist. This rule exists to fail early and
       honestly when the repository shape itself is broken.
 
-  - code: SYU-workspace-blank-002
+  - code: SYU-workspace-blank-001
     genre: workspace
     severity: error
     title: Required specification fields must not be blank
@@ -27,7 +27,7 @@ rules:
       the spec usable both for humans trying to understand intent and for
       automation trying to verify it.
 
-  - code: SYU-workspace-duplicate-003
+  - code: SYU-workspace-duplicate-001
     genre: workspace
     severity: error
     title: Definition IDs must be unique
@@ -51,7 +51,7 @@ rules:
       This rule forces contributors to either declare the missing item or remove
       the stale relationship before the graph drifts further.
 
-  - code: SYU-graph-reciprocal-002
+  - code: SYU-graph-reciprocal-001
     genre: graph
     severity: error
     title: Adjacent-layer links must be reciprocal
@@ -63,7 +63,7 @@ rules:
       rule preserves explainability by requiring each adjacent layer to confirm
       the relationship from its own point of view.
 
-  - code: SYU-graph-links-003
+  - code: SYU-graph-links-001
     genre: graph
     severity: warning
     title: Adjacent-layer expectations should be explicit
@@ -74,7 +74,7 @@ rules:
       This warning nudges authors to keep the graph richly connected so the
       repository remains easy to browse, audit, and evolve over time.
 
-  - code: SYU-graph-orphaned-004
+  - code: SYU-graph-orphaned-001
     genre: graph
     severity: error
     title: Definitions must not be isolated from the layered graph
@@ -98,7 +98,7 @@ rules:
       This rule keeps workflow semantics predictable by limiting the state
       vocabulary to supported values.
 
-  - code: SYU-delivery-status-002
+  - code: SYU-delivery-planned-001
     genre: delivery
     severity: error
     title: Planned items can be forbidden by project policy
@@ -110,7 +110,7 @@ rules:
       the entire validation engine. The goal is to support both exploratory
       workflows and locked-down release workflows through explicit config.
 
-  - code: SYU-delivery-planned-003
+  - code: SYU-delivery-planned-002
     genre: delivery
     severity: error
     title: Planned items must not claim delivered traces
@@ -122,7 +122,7 @@ rules:
       trust. This rule preserves the meaning of planning by keeping future work
       distinct from delivered work.
 
-  - code: SYU-delivery-implemented-004
+  - code: SYU-delivery-implemented-001
     genre: delivery
     severity: error
     title: Implemented items must prove delivery
@@ -133,7 +133,7 @@ rules:
       rather than evidence. This rule exists to make implementation status
       reviewable and to keep status labels from drifting away from reality.
 
-  - code: SYU-delivery-missing-005
+  - code: SYU-delivery-missing-001
     genre: delivery
     severity: warning
     title: Undefined delivery state leaves trace expectations unclear
@@ -156,19 +156,30 @@ rules:
       security by declaring traces in languages the current validator cannot
       actually inspect.
 
+  - code: SYU-trace-file-001
+    genre: trace
+    severity: error
+    title: Trace mappings must declare a file path
+    summary: A trace without an explicit file path cannot identify repository evidence.
+    description: |
+      Traceability depends on concrete, inspectable files. If a mapping omits the
+      file path entirely, the validator has nowhere to look for evidence and
+      reviewers cannot tell which artifact is supposed to satisfy the spec. This
+      rule keeps every declared trace grounded in an explicit repository path.
+
   - code: SYU-trace-file-002
     genre: trace
     severity: error
-    title: Trace files must exist and be named explicitly
-    summary: A trace without a real file cannot prove anything about the repository.
+    title: Declared trace files must exist
+    summary: A trace that points to a missing file cannot prove anything about the repository.
     description: |
-      Traceability depends on concrete, inspectable files. If a path is absent,
-      blank, or stale, the spec stops pointing to real evidence and starts
-      pointing to an aspiration. This rule ensures that every declared trace is
-      grounded in a repository artifact that reviewers and automation can both
-      inspect.
+      Traceability depends on concrete, inspectable files. If a path is stale or
+      points outside the current repository contents, the spec stops pointing to
+      real evidence and starts pointing to an aspiration. This rule ensures that
+      every declared trace remains grounded in a repository artifact that both
+      reviewers and automation can actually inspect.
 
-  - code: SYU-trace-unreadable-003
+  - code: SYU-trace-unreadable-001
     genre: trace
     severity: error
     title: Trace files must be readable to the validator
@@ -180,7 +191,7 @@ rules:
       This rule exists to surface those operational failures instead of silently
       assuming the trace is probably fine.
 
-  - code: SYU-trace-extension-004
+  - code: SYU-trace-extension-001
     genre: trace
     severity: error
     title: The declared trace language must match the traced file
@@ -192,7 +203,7 @@ rules:
       means. This rule keeps the declared language and the referenced artifact in
       sync.
 
-  - code: SYU-trace-id-005
+  - code: SYU-trace-id-001
     genre: trace
     severity: error
     title: Traced files must mention the owning specification ID
@@ -204,18 +215,41 @@ rules:
       link without consulting another system. This rule keeps traceability visible
       at the point where work actually happens.
 
-  - code: SYU-trace-symbol-006
+  - code: SYU-trace-symbol-001
     genre: trace
     severity: error
-    title: Trace mappings must identify concrete symbols
-    summary: Validation needs a real symbol to inspect instead of a vague file-level hint.
+    title: Trace mappings must identify at least one symbol
+    summary: Validation needs a concrete symbol target instead of an empty mapping.
     description: |
-      Files often contain many behaviors. Without a symbol target, a trace may
-      point at a broad area of the repository while still leaving uncertainty
-      about what actually satisfies the requirement or feature. This rule keeps
-      traces precise enough to support audits, refactors, and future maintenance.
+      Files often contain many behaviors. If a trace mapping does not name any
+      symbols at all, the validator cannot tell which implementation or test case
+      is supposed to satisfy the requirement or feature. This rule keeps traces
+      precise enough to support audits, refactors, and future maintenance.
 
-  - code: SYU-trace-inspection-007
+  - code: SYU-trace-symbol-002
+    genre: trace
+    severity: error
+    title: Trace symbol entries must not be blank
+    summary: Whitespace-only symbol entries hide which repository behavior the trace intends to verify.
+    description: |
+      A symbol list that contains blank entries looks more complete than it is.
+      Reviewers and tooling still lack a usable target, but the mapping no longer
+      reads as obviously empty. This rule keeps symbol declarations explicit by
+      requiring every listed entry to name a real symbol.
+
+  - code: SYU-trace-symbol-003
+    genre: trace
+    severity: error
+    title: Declared trace symbols must exist in the traced file
+    summary: A trace can only prove ownership when the named symbol is present in the referenced file.
+    description: |
+      Symbol-level traces are useful because they point to the exact behavior a
+      requirement or feature relies on. If the named symbol is missing, the spec
+      no longer identifies real evidence and may be drifting behind refactors or
+      stale documentation. This rule keeps symbol traces anchored to actual code
+      and tests.
+
+  - code: SYU-trace-inspection-001
     genre: trace
     severity: error
     title: Rich symbol inspection must succeed when required
@@ -227,7 +261,7 @@ rules:
       success-shaped assumption. This rule protects trust in the validator's
       conclusions.
 
-  - code: SYU-trace-doc-008
+  - code: SYU-trace-doc-001
     genre: trace
     severity: error
     title: Required trace documentation snippets must be present
@@ -238,11 +272,23 @@ rules:
       documentation snippets so that code, tests, and generated reports all
       preserve the rationale the spec asked for.
 
-  - code: SYU-trace-support-009
+  - code: SYU-trace-docscope-001
     genre: trace
     severity: error
-    title: Documentation assertions need a language that can verify them
-    summary: "`doc_contains` promises should only be made where the validator can inspect docs."
+    title: Wildcard traces cannot carry symbol-level doc assertions
+    summary: "`doc_contains` checks need a single symbol target instead of a wildcard file claim."
+    description: |
+      Wildcard ownership is useful when one specification item intentionally owns
+      every relevant symbol in a file. Documentation assertions are different:
+      they need one concrete symbol so the validator knows exactly which docs to
+      inspect. This rule keeps doc-level checks precise instead of letting them
+      ride on an ambiguous wildcard mapping.
+
+  - code: SYU-trace-docsupport-001
+    genre: trace
+    severity: error
+    title: Documentation assertions require rich symbol inspection
+    summary: "`doc_contains` promises should only be made where the validator can inspect symbol docs."
     description: |
       A repository should not declare documentation constraints that the current
       adapter cannot verify. Otherwise the spec would appear stricter than the
@@ -250,19 +296,42 @@ rules:
       doc-level checks to stay within languages with meaningful documentation
       inspection support.
 
-  - code: SYU-coverage-scan-001
+  - code: SYU-coverage-walk-001
     genre: coverage
     severity: error
-    title: Coverage inventory must be inspectable
-    summary: Opt-in trace coverage cannot be enforced unless `syu` can scan the workspace.
+    title: Coverage inventory paths must be walkable
+    summary: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
     description: |
-      The strict trace coverage rule only means something when `syu` can read and
-      parse the files it is supposed to inventory. If source or test files cannot
-      be scanned, the safest behavior is to fail loudly instead of pretending the
-      workspace is fully covered. This rule protects the credibility of the
-      100-percent coverage claim.
+      The strict trace coverage rule only means something when `syu` can walk the
+      repository paths that are supposed to contain owned Rust source and test
+      files. If directory discovery fails, the inventory itself is incomplete and
+      any 100-percent coverage conclusion would be misleading. This rule surfaces
+      repository layout problems before coverage claims become untrustworthy.
 
-  - code: SYU-coverage-public-002
+  - code: SYU-coverage-read-001
+    genre: coverage
+    severity: error
+    title: Coverage inventory files must be readable
+    summary: Unreadable Rust sources prevent honest trace coverage verification.
+    description: |
+      Trace coverage can only be enforced when `syu` can read the Rust source and
+      test files it is supposed to inventory. If a file is unreadable, the safest
+      behavior is to fail loudly instead of pretending the workspace was fully
+      scanned. This rule protects the credibility of strict coverage mode.
+
+  - code: SYU-coverage-parse-001
+    genre: coverage
+    severity: error
+    title: Coverage inventory sources must parse successfully
+    summary: Broken Rust syntax prevents reliable coverage inventory.
+    description: |
+      Strict trace coverage relies on understanding the Rust items that appear in
+      the workspace. When a source file does not parse, `syu` cannot build a
+      trustworthy inventory of public APIs or tests. This rule keeps coverage
+      results explicit by surfacing syntax failures instead of hiding them behind
+      incomplete scans.
+
+  - code: SYU-coverage-public-001
     genre: coverage
     severity: error
     title: Public API symbols must belong to at least one feature
@@ -274,7 +343,7 @@ rules:
       or which behavior owns it. This rule encourages deliberate API growth by
       forcing public surface area to stay attached to an explicit feature.
 
-  - code: SYU-coverage-test-003
+  - code: SYU-coverage-test-001
     genre: coverage
     severity: error
     title: Tests must belong to at least one requirement

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -522,7 +522,7 @@ fn validate_delivery_status(
 
     if normalized == DeliveryStatus::Planned && !config.validate.allow_planned {
         issues.push(Issue::error(
-            "SYU-delivery-status-002",
+            "SYU-delivery-planned-001",
             format!("{kind} {id}"),
             Some("status".to_string()),
             format!("{kind} `{id}` is marked `planned`, but `syu.yaml` forbids planned items."),
@@ -544,7 +544,7 @@ fn validate_unique_ids<'a>(
     for id in ids {
         if !seen.insert(id.to_string()) {
             issues.push(Issue::error(
-                "SYU-workspace-duplicate-003",
+                "SYU-workspace-duplicate-001",
                 format!("{kind} {id}"),
                 None,
                 format!("Duplicate {kind} id `{id}` was found in the specification set."),
@@ -578,7 +578,7 @@ fn validate_philosophy(
 
     if philosophy.linked_policies.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("philosophy {}", philosophy.id),
             None,
             "Philosophy does not link to any policies.".to_string(),
@@ -598,7 +598,7 @@ fn validate_philosophy(
                     .any(|item| item == &philosophy.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("philosophy {}", philosophy.id),
                         Some(policy_id.clone()),
                         format!(
@@ -639,7 +639,7 @@ fn validate_policy(
 
     if policy.linked_philosophies.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("policy {}", policy.id),
             None,
             "Policy does not link to any philosophies.".to_string(),
@@ -652,7 +652,7 @@ fn validate_policy(
 
     if policy.linked_requirements.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("policy {}", policy.id),
             None,
             "Policy does not link to any requirements.".to_string(),
@@ -672,7 +672,7 @@ fn validate_policy(
                     .any(|item| item == &policy.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("policy {}", policy.id),
                         Some(philosophy_id.clone()),
                         format!(
@@ -708,7 +708,7 @@ fn validate_policy(
                     .any(|item| item == &policy.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("policy {}", policy.id),
                         Some(requirement_id.clone()),
                         format!(
@@ -765,7 +765,7 @@ fn validate_requirement(
 
     if requirement.linked_policies.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("requirement {}", requirement.id),
             None,
             "Requirement does not link to any policies.".to_string(),
@@ -778,7 +778,7 @@ fn validate_requirement(
 
     if requirement.linked_features.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("requirement {}", requirement.id),
             None,
             "Requirement does not link to any features.".to_string(),
@@ -798,7 +798,7 @@ fn validate_requirement(
                     .any(|item| item == &requirement.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("requirement {}", requirement.id),
                         Some(policy_id.clone()),
                         format!(
@@ -834,7 +834,7 @@ fn validate_requirement(
                     .any(|item| item == &requirement.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("requirement {}", requirement.id),
                         Some(feature_id.clone()),
                         format!(
@@ -891,7 +891,7 @@ fn validate_feature(
 
     if feature.linked_requirements.is_empty() {
         issues.push(Issue::warning(
-            "SYU-graph-links-003",
+            "SYU-graph-links-001",
             format!("feature {}", feature.id),
             None,
             "Feature does not link to any requirements.".to_string(),
@@ -911,7 +911,7 @@ fn validate_feature(
                     .any(|item| item == &feature.id)
                 {
                     issues.push(Issue::error(
-                        "SYU-graph-reciprocal-002",
+                        "SYU-graph-reciprocal-001",
                         format!("feature {}", feature.id),
                         Some(requirement_id.clone()),
                         format!(
@@ -965,7 +965,7 @@ fn validate_trace_map(
         Some(DeliveryStatus::Planned) => {
             if !references_by_language.is_empty() {
                 issues.push(Issue::error(
-                    "SYU-delivery-planned-003",
+                    "SYU-delivery-planned-002",
                     subject,
                     Some("status".to_string()),
                     format!(
@@ -986,7 +986,7 @@ fn validate_trace_map(
         Some(DeliveryStatus::Implemented) => {
             if references_by_language.is_empty() {
                 issues.push(Issue::error(
-                    "SYU-delivery-implemented-004",
+                    "SYU-delivery-implemented-001",
                     subject,
                     Some("status".to_string()),
                     format!(
@@ -1006,7 +1006,7 @@ fn validate_trace_map(
         }
         None if references_by_language.is_empty() => {
             issues.push(Issue::warning(
-                "SYU-delivery-missing-005",
+                "SYU-delivery-missing-001",
                 subject,
                 None,
                 format!(
@@ -1097,7 +1097,7 @@ fn report_orphaned_definition(
     }
 
     issues.push(Issue::error(
-        "SYU-graph-orphaned-004",
+        "SYU-graph-orphaned-001",
         format!("{kind} {id}"),
         None,
         format!(
@@ -1136,7 +1136,7 @@ fn verify_trace_reference(
 
     if reference.file.as_os_str().is_empty() {
         issues.push(Issue::error(
-            "SYU-trace-file-002",
+            "SYU-trace-file-001",
             subject.clone(),
             Some(format_reference_location(language, reference)),
             format!(
@@ -1174,7 +1174,7 @@ fn verify_trace_reference(
     let mut success = true;
     if !adapter.supports_path(&path) {
         issues.push(Issue::error(
-            "SYU-trace-extension-004",
+            "SYU-trace-extension-001",
             subject.clone(),
             Some(format_reference_location(language, reference)),
             format!(
@@ -1195,7 +1195,7 @@ fn verify_trace_reference(
         Ok(contents) => contents,
         Err(error) => {
             issues.push(Issue::error(
-                "SYU-trace-unreadable-003",
+                "SYU-trace-unreadable-001",
                 subject,
                 Some(format_reference_location(language, reference)),
                 format!(
@@ -1214,7 +1214,7 @@ fn verify_trace_reference(
 
     if !contents.contains(owner_id) {
         issues.push(Issue::error(
-            "SYU-trace-id-005",
+            "SYU-trace-id-001",
             subject.clone(),
             Some(format_reference_location(language, reference)),
             format!(
@@ -1233,7 +1233,7 @@ fn verify_trace_reference(
 
     if reference.symbols.is_empty() {
         issues.push(Issue::error(
-            "SYU-trace-symbol-006",
+            "SYU-trace-symbol-001",
             subject.clone(),
             Some(format_reference_location(language, reference)),
             format!(
@@ -1252,7 +1252,7 @@ fn verify_trace_reference(
     if has_wildcard {
         if !reference.doc_contains.is_empty() {
             issues.push(Issue::error(
-                "SYU-trace-support-009",
+                "SYU-trace-docscope-001",
                 subject.clone(),
                 Some(format_reference_location(language, reference)),
                 format!(
@@ -1272,7 +1272,7 @@ fn verify_trace_reference(
     for symbol in &reference.symbols {
         if symbol.trim().is_empty() {
             issues.push(Issue::error(
-                "SYU-trace-symbol-006",
+                "SYU-trace-symbol-002",
                 subject.clone(),
                 Some(format_reference_location(language, reference)),
                 format!(
@@ -1293,7 +1293,7 @@ fn verify_trace_reference(
                 Ok(result) => result,
                 Err(error) => {
                     issues.push(Issue::error(
-                        "SYU-trace-inspection-007",
+                        "SYU-trace-inspection-001",
                         subject.clone(),
                         Some(format_reference_location(language, reference)),
                         format!(
@@ -1316,7 +1316,7 @@ fn verify_trace_reference(
         let symbol_exists = inspection.is_some() || adapter.symbol_exists(&contents, symbol);
         if !symbol_exists {
             issues.push(Issue::error(
-                "SYU-trace-symbol-006",
+                "SYU-trace-symbol-003",
                 subject.clone(),
                 Some(format_reference_location(language, reference)),
                 format!(
@@ -1342,7 +1342,7 @@ fn verify_trace_reference(
 
                         if !inspection.docs.contains(snippet) {
                             issues.push(Issue::error(
-                                "SYU-trace-doc-008",
+                                "SYU-trace-doc-001",
                                 subject.clone(),
                                 Some(format_reference_location(language, reference)),
                                 format!(
@@ -1359,7 +1359,7 @@ fn verify_trace_reference(
                 }
                 None => {
                     issues.push(Issue::error(
-                        "SYU-trace-support-009",
+                        "SYU-trace-docsupport-001",
                         subject.clone(),
                         Some(format_reference_location(language, reference)),
                         format!(
@@ -1385,7 +1385,7 @@ fn format_reference_location(language: &str, reference: &TraceReference) -> Stri
 fn validate_non_empty_field(kind: &str, field_name: &str, value: &str, issues: &mut Vec<Issue>) {
     if value.trim().is_empty() {
         issues.push(Issue::error(
-            "SYU-workspace-blank-002",
+            "SYU-workspace-blank-001",
             kind.to_string(),
             Some(field_name.to_string()),
             format!("Field `{field_name}` must not be blank."),
@@ -1565,7 +1565,7 @@ mod tests {
         let mut issues = Vec::new();
         validate_unique_ids("feature", ["FEAT-1", "FEAT-1"].into_iter(), &mut issues);
         assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].code, "SYU-workspace-duplicate-003");
+        assert_eq!(issues[0].code, "SYU-workspace-duplicate-001");
     }
 
     #[test]
@@ -1573,7 +1573,7 @@ mod tests {
         let mut issues = Vec::new();
         validate_non_empty_field("feature", "title", "   ", &mut issues);
         assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].code, "SYU-workspace-blank-002");
+        assert_eq!(issues[0].code, "SYU-workspace-blank-001");
         assert_eq!(issues[0].location.as_deref(), Some("title"));
     }
 
@@ -1589,7 +1589,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-workspace-blank-002")
+                .any(|issue| issue.code == "SYU-workspace-blank-001")
         );
         assert!(
             issues
@@ -1606,7 +1606,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-graph-links-003")
+                .any(|issue| issue.code == "SYU-graph-links-001")
         );
     }
 
@@ -1626,7 +1626,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-graph-reciprocal-002")
+                .any(|issue| issue.code == "SYU-graph-reciprocal-001")
         );
     }
 
@@ -1651,12 +1651,12 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-workspace-blank-002")
+                .any(|issue| issue.code == "SYU-workspace-blank-001")
         );
         assert!(
             issues
                 .iter()
-                .filter(|issue| issue.code == "SYU-graph-reciprocal-002")
+                .filter(|issue| issue.code == "SYU-graph-reciprocal-001")
                 .count()
                 >= 2
         );
@@ -1670,7 +1670,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .filter(|issue| issue.code == "SYU-graph-links-003")
+                .filter(|issue| issue.code == "SYU-graph-links-001")
                 .count()
                 >= 2
         );
@@ -1715,17 +1715,17 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-workspace-blank-002")
+                .any(|issue| issue.code == "SYU-workspace-blank-001")
         );
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-graph-links-003")
+                .any(|issue| issue.code == "SYU-graph-links-001")
         );
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-delivery-missing-005")
+                .any(|issue| issue.code == "SYU-delivery-missing-001")
         );
         assert_eq!(trace_count.declared, 0);
     }
@@ -1757,14 +1757,14 @@ mod tests {
         );
 
         assert!(issues.iter().any(|issue| {
-            issue.code == "SYU-graph-reciprocal-002" && issue.location.as_deref() == Some("POL-1")
+            issue.code == "SYU-graph-reciprocal-001" && issue.location.as_deref() == Some("POL-1")
         }));
         assert!(issues.iter().any(|issue| {
             issue.code == "SYU-graph-reference-001"
                 && issue.location.as_deref() == Some("POL-MISSING")
         }));
         assert!(issues.iter().any(|issue| {
-            issue.code == "SYU-graph-reciprocal-002" && issue.location.as_deref() == Some("FEAT-1")
+            issue.code == "SYU-graph-reciprocal-001" && issue.location.as_deref() == Some("FEAT-1")
         }));
         assert!(issues.iter().any(|issue| {
             issue.code == "SYU-graph-reference-001"
@@ -1791,17 +1791,17 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-workspace-blank-002")
+                .any(|issue| issue.code == "SYU-workspace-blank-001")
         );
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-graph-links-003")
+                .any(|issue| issue.code == "SYU-graph-links-001")
         );
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-delivery-implemented-004")
+                .any(|issue| issue.code == "SYU-delivery-implemented-001")
         );
         assert_eq!(trace_count.validated, 0);
     }
@@ -1834,7 +1834,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-delivery-planned-003")
+                .any(|issue| issue.code == "SYU-delivery-planned-002")
         );
         assert_eq!(trace_count.declared, 0);
     }
@@ -1923,7 +1923,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-delivery-status-002")
+                .any(|issue| issue.code == "SYU-delivery-planned-001")
         );
     }
 
@@ -1948,7 +1948,7 @@ mod tests {
         );
 
         assert!(issues.iter().any(|issue| {
-            issue.code == "SYU-graph-reciprocal-002" && issue.location.as_deref() == Some("REQ-1")
+            issue.code == "SYU-graph-reciprocal-001" && issue.location.as_deref() == Some("REQ-1")
         }));
         assert!(issues.iter().any(|issue| {
             issue.code == "SYU-graph-reference-001"
@@ -1993,7 +1993,7 @@ mod tests {
             &reference,
             &mut issues,
         ));
-        assert_eq!(issues[0].code, "SYU-trace-file-002");
+        assert_eq!(issues[0].code, "SYU-trace-file-001");
     }
 
     #[test]
@@ -2041,13 +2041,13 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-extension-004")
+                .any(|issue| issue.code == "SYU-trace-extension-001")
         );
-        assert!(issues.iter().any(|issue| issue.code == "SYU-trace-id-005"));
+        assert!(issues.iter().any(|issue| issue.code == "SYU-trace-id-001"));
         assert!(
             issues
                 .iter()
-                .filter(|issue| issue.code == "SYU-trace-symbol-006")
+                .filter(|issue| issue.code == "SYU-trace-symbol-002")
                 .count()
                 >= 1
         );
@@ -2077,7 +2077,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-symbol-006")
+                .any(|issue| issue.code == "SYU-trace-symbol-003")
         );
     }
 
@@ -2105,7 +2105,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-symbol-006")
+                .any(|issue| issue.code == "SYU-trace-symbol-001")
         );
     }
 
@@ -2166,7 +2166,7 @@ mod tests {
         assert!(
             python_issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-inspection-007")
+                .any(|issue| issue.code == "SYU-trace-inspection-001")
         );
 
         let rust_path = tempdir.path().join("trace.rs");
@@ -2188,7 +2188,7 @@ mod tests {
         assert_eq!(
             rust_issues
                 .iter()
-                .filter(|issue| issue.code == "SYU-trace-doc-008")
+                .filter(|issue| issue.code == "SYU-trace-doc-001")
                 .count(),
             1
         );
@@ -2213,7 +2213,7 @@ mod tests {
         assert!(
             shell_issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-support-009")
+                .any(|issue| issue.code == "SYU-trace-docsupport-001")
         );
 
         let wildcard_path = tempdir.path().join("wildcard.rs");
@@ -2236,7 +2236,7 @@ mod tests {
         assert!(
             wildcard_issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-support-009")
+                .any(|issue| issue.code == "SYU-trace-docscope-001")
         );
     }
 
@@ -2620,7 +2620,7 @@ mod tests {
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.code == "SYU-trace-unreadable-003")
+                .any(|issue| issue.code == "SYU-trace-unreadable-001")
         );
     }
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -55,7 +55,7 @@ pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Is
                 if !feature_coverage.covers(&target.file, &target.symbol) =>
             {
                 issues.push(Issue::error(
-                    "SYU-coverage-public-002",
+                    "SYU-coverage-public-001",
                     format!("public symbol {}", target.symbol),
                     Some(format!("{}::{}", target.file.display(), target.symbol)),
                     format!(
@@ -74,7 +74,7 @@ pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Is
                 if !requirement_coverage.covers(&target.file, &target.symbol) =>
             {
                 issues.push(Issue::error(
-                    "SYU-coverage-test-003",
+                    "SYU-coverage-test-001",
                     format!("test {}", target.symbol),
                     Some(format!("{}::{}", target.file.display(), target.symbol)),
                     format!(
@@ -161,7 +161,7 @@ fn discover_rust_targets(root: &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>
     for path in files {
         let contents = fs::read_to_string(&path).map_err(|error| {
             Box::new(Issue::error(
-                "SYU-coverage-scan-001",
+                "SYU-coverage-read-001",
                 "trace coverage inventory",
                 Some(path.display().to_string()),
                 format!("Failed to read `{}` while building trace coverage inventory: {error}", path.display()),
@@ -171,7 +171,7 @@ fn discover_rust_targets(root: &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>
 
         let file = syn::parse_file(&contents).map_err(|error| {
             Box::new(Issue::error(
-                "SYU-coverage-scan-001",
+                "SYU-coverage-parse-001",
                 "trace coverage inventory",
                 Some(path.display().to_string()),
                 format!("Failed to parse `{}` while building trace coverage inventory: {error}", path.display()),
@@ -317,7 +317,7 @@ fn rust_files_under(root: &Path) -> Result<Vec<PathBuf>, Box<Issue>> {
     let mut files = Vec::new();
     collect_rust_files_recursive(root, &mut files).map_err(|error| {
         Box::new(Issue::error(
-            "SYU-coverage-scan-001",
+            "SYU-coverage-walk-001",
             "trace coverage inventory",
             Some(root.display().to_string()),
             format!("Failed to walk `{}` while building trace coverage inventory: {error}", root.display()),
@@ -596,7 +596,7 @@ mod tests {
         let file_root = tempdir.path().join("not-a-dir.rs");
         fs::write(&file_root, "pub fn nope() {}\n").expect("file");
         let issue = rust_files_under(&file_root).expect_err("file roots should fail");
-        assert_eq!(issue.code, "SYU-coverage-scan-001");
+        assert_eq!(issue.code, "SYU-coverage-walk-001");
     }
 
     #[test]
@@ -606,7 +606,7 @@ mod tests {
         fs::write(tempdir.path().join("src/broken.rs"), "pub fn broken( {}\n").expect("broken");
 
         let issue = discover_rust_targets(tempdir.path()).expect_err("broken rust should fail");
-        assert_eq!(issue.code, "SYU-coverage-scan-001");
+        assert_eq!(issue.code, "SYU-coverage-parse-001");
     }
 
     #[cfg(unix)]
@@ -645,7 +645,7 @@ mod tests {
         fs::set_permissions(&unreadable, restore).expect("restore");
 
         assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].code, "SYU-coverage-scan-001");
+        assert_eq!(issues[0].code, "SYU-coverage-read-001");
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -208,7 +208,7 @@ mod tests {
             trace_summary: TraceSummary::default(),
             issues: vec![
                 Issue {
-                    code: "SYU-workspace-duplicate-003".to_string(),
+                    code: "SYU-workspace-duplicate-001".to_string(),
                     severity: Severity::Error,
                     subject: "feature|subject".to_string(),
                     location: Some("yaml:file.yml".to_string()),
@@ -225,7 +225,7 @@ mod tests {
             ],
             referenced_rules: crate::rules::referenced_rules(&[
                 Issue {
-                    code: "SYU-workspace-duplicate-003".to_string(),
+                    code: "SYU-workspace-duplicate-001".to_string(),
                     severity: Severity::Error,
                     subject: "feature|subject".to_string(),
                     location: Some("yaml:file.yml".to_string()),
@@ -246,7 +246,7 @@ mod tests {
         assert!(report.contains("Result: **FAIL**"));
         assert!(report.contains("error"));
         assert!(report.contains("warning"));
-        assert!(report.contains("SYU-workspace-duplicate-003"));
+        assert!(report.contains("SYU-workspace-duplicate-001"));
         assert!(report.contains("feature\\|subject"));
         assert!(report.contains("message\\|with pipe"));
         assert!(report.contains("## Referenced rules"));

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -139,12 +139,12 @@ mod tests {
         assert!(
             rules
                 .iter()
-                .any(|rule| rule.code == "SYU-graph-orphaned-004")
+                .any(|rule| rule.code == "SYU-graph-orphaned-001")
         );
         assert!(
             rules
                 .iter()
-                .any(|rule| rule.code == "SYU-coverage-public-002")
+                .any(|rule| rule.code == "SYU-coverage-public-001")
         );
     }
 
@@ -152,14 +152,14 @@ mod tests {
     fn referenced_rules_follow_issue_codes_without_duplicates() {
         let issues = vec![
             Issue::error(
-                "SYU-workspace-duplicate-003",
+                "SYU-workspace-duplicate-001",
                 "subject",
                 None,
                 "message",
                 None,
             ),
             Issue::warning(
-                "SYU-workspace-duplicate-003",
+                "SYU-workspace-duplicate-001",
                 "subject",
                 None,
                 "message",
@@ -171,7 +171,7 @@ mod tests {
 
         let rules = referenced_rules(&issues);
         assert_eq!(rules.len(), 2);
-        assert_eq!(rules[0].code, "SYU-workspace-duplicate-003");
+        assert_eq!(rules[0].code, "SYU-workspace-duplicate-001");
         assert_eq!(rules[1].code, "SYU-graph-reference-001");
     }
 

--- a/tests/orphan_validation.rs
+++ b/tests/orphan_validation.rs
@@ -68,7 +68,7 @@ fn validate_rejects_orphaned_definitions_by_default() {
 
     assert!(!output.status.success(), "orphaned definitions should fail");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("SYU-graph-orphaned-004"));
+    assert!(stdout.contains("SYU-graph-orphaned-001"));
     assert!(stdout.contains("Definitions must not be isolated from the layered graph"));
 }
 

--- a/tests/status_validation.rs
+++ b/tests/status_validation.rs
@@ -112,7 +112,7 @@ fn validate_rejects_implemented_entries_without_traces() {
 
     assert!(!output.status.success(), "implemented entries should fail");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("SYU-delivery-implemented-004"));
+    assert!(stdout.contains("SYU-delivery-implemented-001"));
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn validate_rejects_planned_entries_with_traces() {
         "planned entries with traces should fail"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("SYU-delivery-planned-003"));
+    assert!(stdout.contains("SYU-delivery-planned-002"));
 }
 
 #[test]
@@ -151,5 +151,5 @@ fn validate_rejects_planned_entries_when_config_disallows_them() {
 
     assert!(!output.status.success(), "planned entries should fail");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("SYU-delivery-status-002"));
+    assert!(stdout.contains("SYU-delivery-planned-001"));
 }

--- a/tests/trace_coverage_validation.rs
+++ b/tests/trace_coverage_validation.rs
@@ -93,8 +93,8 @@ fn validate_reports_untracked_public_symbols_and_tests() {
 
     assert!(!output.status.success(), "coverage gaps should fail");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("SYU-coverage-public-002"));
-    assert!(stdout.contains("SYU-coverage-test-003"));
+    assert!(stdout.contains("SYU-coverage-public-001"));
+    assert!(stdout.contains("SYU-coverage-test-001"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- refine validation rule IDs so content-scoped families use clearer, narrower codes
- split broad trace and coverage diagnostics into distinct rule codes and update emitted diagnostics/tests
- regenerate site-spec docs so the built-in rule catalog and CLI docs stay aligned

## Validation
- python3 scripts/generate-site-docs.py
- cargo test
- scripts/ci/quality-gates.sh
- cargo run -- validate <temporary workspace exercising SYU-trace-docscope-001 and SYU-trace-docsupport-001>

Closes #21