### PR TITLE
fix: unblock syu app docs and browser-app CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "25"
           cache: npm
           cache-dependency-path: app/package-lock.json
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -114,6 +114,6 @@ The repository includes complete examples:
 
 - Read [syu concepts](./concepts.md) for the reasoning behind the four layers
 - Review [configuration](./configuration.md) before tightening validation in a real repository
-- Start [`syu app .`](../../README.md#syu-app) when you want a browser view of the same workspace
+- Start `syu app .` when you want a browser view of the same workspace
 - Browse the [Specification Reference](../generated/site-spec/index.md) to see how `syu` self-hosts its own contract
 - Open the [latest validation report](../generated/syu-report.md) to inspect the checked-in repository status


### PR DESCRIPTION
Follow-up to #25 and issue #20.

Fixes:
- remove the broken README-relative docs link so docs-site builds on CI
- run the browser-app CI job on Node 25 so `vp check` can load the checked TypeScript config files

Local validation:
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary
- cd app && vp check ... && playwright test
- cd website && python3 ../scripts/generate-site-docs.py && docusaurus build