### PR TITLE
chore: release v0.0.1-alpha.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,8 +30,8 @@ body:
     id: version
     attributes:
       label: syu version
-      description: "Example: `0.0.1-alpha.6` or `v0.0.1-alpha.4`"
-      placeholder: 0.0.1-alpha.6
+      description: "Example: `0.0.1-alpha.7` or `v0.0.1-alpha.4`"
+      placeholder: 0.0.1-alpha.7
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syu"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "syu-core"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syu"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 edition = "2024"
 description = "Specification-driven development helper CLI"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu
 Install a specific prerelease:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.6 bash
+curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.7 bash
 ```
 
 ## Quick start
@@ -169,7 +169,7 @@ It keeps the source UI in `app/`, checks in the generated production bundle in
 `syu` looks for `syu.yaml` in the workspace root:
 
 ```yaml
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syu-app",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syu-app",
-      "version": "0.0.1-alpha.6",
+      "version": "0.0.1-alpha.7",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syu-app",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/wasm/Cargo.toml
+++ b/app/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syu-app-wasm"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 edition = "2024"
 description = "WebAssembly bridge for the syu browser app"
 license = "MIT"

--- a/crates/syu-core/Cargo.toml
+++ b/crates/syu-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syu-core"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 edition = "2024"
 description = "Browser-safe syu models for the local app UI"
 license = "MIT"

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -9,7 +9,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ### Version
 
-- 0.0.1-alpha.6
+- 0.0.1-alpha.7
 
 ### Updated
 
@@ -43,7 +43,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 ## Source YAML
 
 ```yaml
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 updated: "2026-03"
 
 files:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -18,7 +18,7 @@ change also needs narrative explanation or new examples.
 ## Minimal configuration
 
 ```yaml
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 updated: "2026-03"
 
 files:

--- a/examples/polyglot/docs/syu/features/features.yaml
+++ b/examples/polyglot/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 files:
   - kind: polyglot
     file: languages/polyglot.yaml

--- a/examples/polyglot/syu.yaml
+++ b/examples/polyglot/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/examples/python-only/docs/syu/features/features.yaml
+++ b/examples/python-only/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 files:
   - kind: python
     file: languages/python.yaml

--- a/examples/python-only/syu.yaml
+++ b/examples/python-only/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/examples/rust-only/docs/syu/features/features.yaml
+++ b/examples/rust-only/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 files:
   - kind: rust
     file: languages/rust.yaml

--- a/examples/rust-only/syu.yaml
+++ b/examples/rust-only/syu.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/syu.yaml
+++ b/syu.yaml
@@ -1,5 +1,5 @@
 # FEAT-CHECK-001
-version: 0.0.1-alpha.6
+version: 0.0.1-alpha.7
 spec:
   root: docs/syu
 validate:

--- a/tests/fixtures/workspaces/failing/docs/syu/features/features.yaml
+++ b/tests/fixtures/workspaces/failing/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 updated: "2026-03"
 
 files:

--- a/tests/fixtures/workspaces/passing/docs/syu/features/features.yaml
+++ b/tests/fixtures/workspaces/passing/docs/syu/features/features.yaml
@@ -1,4 +1,4 @@
-version: "0.0.1-alpha.6"
+version: "0.0.1-alpha.7"
 updated: "2026-03"
 
 files:


### PR DESCRIPTION
Manual alpha release bump for the next prerelease.

release-please is currently skipping because workflow permissions cannot create PRs automatically, so this PR performs the equivalent version bump for `v0.0.1-alpha.7` across the Rust crates, app manifests, self-hosted examples/fixtures, and generated feature docs.

Local validation:
- `cargo run -- --version`
- `cd app && npm run check && npm run test:e2e`
- `scripts/ci/quality-gates.sh`
- `scripts/ci/coverage.sh summary`
- `cd website && npm install --no-package-lock && npm run build`
