### PR TITLE
chore: ignore local helper worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 .tooling
 .DS_Store
+# FEAT-CONTRIB-002: keep contributor-local helper worktrees out of routine status output
+/.worktrees/
 website/.docusaurus
 website/build
 website/node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ releaseable at all times.
 5. Merge with squash once CI is green and review conversations are resolved.
 6. Delete the branch after merge.
 
+Local helper worktrees under `.worktrees/` are treated as contributor-local
+state and ignored by the repository so `git status` stays focused on the main
+checkout.
+
 ## Local checks
 
 Run the shared repository gates before opening or updating a pull request:

--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -39,7 +39,7 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
           - polyglot_example_validates
 - **id**: FEAT-CONTRIB-002
   - **title**: Contributor workflow templates
-  - **summary**: Guide GitHub Flow contributions with repository-native docs and forms.
+  - **summary**: Guide GitHub Flow contributions with repository-native docs, forms, and low-noise status defaults.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-013
@@ -49,6 +49,7 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
         - **symbols**:
           - FEAT-CONTRIB-002
           - GitHub Flow
+          - .worktrees/
           - scripts/ci/quality-gates.sh
       - **file**: .github/pull_request_template.md
         - **symbols**:
@@ -116,7 +117,7 @@ features:
 
   - id: FEAT-CONTRIB-002
     title: Contributor workflow templates
-    summary: Guide GitHub Flow contributions with repository-native docs and forms.
+    summary: Guide GitHub Flow contributions with repository-native docs, forms, and low-noise status defaults.
     status: implemented
     linked_requirements:
       - REQ-CORE-013
@@ -126,6 +127,7 @@ features:
           symbols:
             - FEAT-CONTRIB-002
             - GitHub Flow
+            - .worktrees/
             - scripts/ci/quality-gates.sh
         - file: .github/pull_request_template.md
           symbols:

--- a/docs/generated/site-spec/requirements/core/repository.md
+++ b/docs/generated/site-spec/requirements/core/repository.md
@@ -144,9 +144,11 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
     - |
       The repository MUST document its GitHub Flow process, keep `main` as the
       only long-lived branch, ship pull-request and issue templates that guide
-      high-signal contributions, and explain the local verification steps that
-      contributors should run before opening a pull request. Installing
-      pre-commit hooks SHOULD be a one-command experience.
+      high-signal contributions, keep contributor-local helper artifacts out of
+      normal status output through repository ignore rules, and explain the
+      local verification steps that contributors should run before opening a
+      pull request. Installing pre-commit hooks SHOULD be a one-command
+      experience.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -305,9 +307,11 @@ requirements:
     description: |
       The repository MUST document its GitHub Flow process, keep `main` as the
       only long-lived branch, ship pull-request and issue templates that guide
-      high-signal contributions, and explain the local verification steps that
-      contributors should run before opening a pull request. Installing
-      pre-commit hooks SHOULD be a one-command experience.
+      high-signal contributions, keep contributor-local helper artifacts out of
+      normal status output through repository ignore rules, and explain the
+      local verification steps that contributors should run before opening a
+      pull request. Installing pre-commit hooks SHOULD be a one-command
+      experience.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -25,7 +25,7 @@ features:
 
   - id: FEAT-CONTRIB-002
     title: Contributor workflow templates
-    summary: Guide GitHub Flow contributions with repository-native docs and forms.
+    summary: Guide GitHub Flow contributions with repository-native docs, forms, and low-noise status defaults.
     status: implemented
     linked_requirements:
       - REQ-CORE-013
@@ -35,6 +35,7 @@ features:
           symbols:
             - FEAT-CONTRIB-002
             - GitHub Flow
+            - .worktrees/
             - scripts/ci/quality-gates.sh
         - file: .github/pull_request_template.md
           symbols:

--- a/docs/syu/requirements/core/repository.yaml
+++ b/docs/syu/requirements/core/repository.yaml
@@ -121,9 +121,11 @@ requirements:
     description: |
       The repository MUST document its GitHub Flow process, keep `main` as the
       only long-lived branch, ship pull-request and issue templates that guide
-      high-signal contributions, and explain the local verification steps that
-      contributors should run before opening a pull request. Installing
-      pre-commit hooks SHOULD be a one-command experience.
+      high-signal contributions, keep contributor-local helper artifacts out of
+      normal status output through repository ignore rules, and explain the
+      local verification steps that contributors should run before opening a
+      pull request. Installing pre-commit hooks SHOULD be a one-command
+      experience.
     priority: medium
     status: implemented
     linked_policies:

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -300,10 +300,12 @@ fn repository_declares_contribution_workflow_assets() {
     let bug_report = read_file(".github/ISSUE_TEMPLATE/bug_report.yml");
     let feature_request = read_file(".github/ISSUE_TEMPLATE/feature_request.yml");
     let issue_config = read_file(".github/ISSUE_TEMPLATE/config.yml");
+    let gitignore = read_file(".gitignore");
 
     assert!(contributing.contains("FEAT-CONTRIB-002"));
     assert!(contributing.contains("GitHub Flow"));
     assert!(contributing.contains("main"));
+    assert!(contributing.contains(".worktrees/"));
     assert!(contributing.contains("scripts/ci/quality-gates.sh"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("GitHub Pages"));
@@ -324,6 +326,9 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(issue_config.contains("FEAT-CONTRIB-002"));
     assert!(issue_config.contains("blank_issues_enabled: false"));
     assert!(issue_config.contains("contact_links"));
+
+    assert!(gitignore.contains("FEAT-CONTRIB-002"));
+    assert!(gitignore.contains(".worktrees/"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Ignore contributor-local `.worktrees/` helper checkouts so `git status` stays focused on the main working tree, and document/spec-test that workflow expectation.

## Linked issue or specification

- Issue: #30
- Requirement / feature IDs: REQ-CORE-013, FEAT-CONTRIB-002

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [x] `scripts/ci/coverage.sh summary`
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed
