### PR TITLE
fix: support gitignore trace validation

### DIFF
--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -72,6 +72,11 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
           - FEAT-CONTRIB-002
           - blank_issues_enabled
           - contact_links
+    - **gitignore**:
+      - **file**: .gitignore
+        - **symbols**:
+          - FEAT-CONTRIB-002
+          - /.worktrees/
 - **id**: FEAT-CONTRIB-003
   - **title**: One-command pre-commit setup
   - **summary**: Install pre-commit and activate local hooks without asking contributors to assemble the commands themselves.
@@ -150,6 +155,11 @@ features:
             - FEAT-CONTRIB-002
             - blank_issues_enabled
             - contact_links
+      gitignore:
+        - file: .gitignore
+          symbols:
+            - FEAT-CONTRIB-002
+            - /.worktrees/
 
   - id: FEAT-CONTRIB-003
     title: One-command pre-commit setup

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -58,6 +58,11 @@ features:
             - FEAT-CONTRIB-002
             - blank_issues_enabled
             - contact_links
+      gitignore:
+        - file: .gitignore
+          symbols:
+            - FEAT-CONTRIB-002
+            - /.worktrees/
 
   - id: FEAT-CONTRIB-003
     title: One-command pre-commit setup

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -1125,10 +1125,10 @@ fn verify_trace_reference(
             subject,
             Some(format_reference_location(language, reference)),
             format!(
-                "Language `{language}` is not supported. Built-in adapters currently cover Rust, Python, TypeScript, Shell, YAML, JSON, and Markdown."
+                "Language `{language}` is not supported. Built-in adapters currently cover Rust, Python, TypeScript, Shell, YAML, JSON, Markdown, and Gitignore."
             ),
             Some(format!(
-                "Use a supported language alias such as `rust`, `python`, `typescript`, `shell`, `yaml`, `json`, or `markdown` for `{owner_id}`."
+                "Use a supported language alias such as `rust`, `python`, `typescript`, `shell`, `yaml`, `json`, `markdown`, or `gitignore` for `{owner_id}`."
             )),
         ));
         return false;
@@ -2127,6 +2127,30 @@ mod tests {
             "FEAT-1",
             TraceRole::FeatureImplementation,
             "shell",
+            &reference,
+            &mut issues,
+        ));
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn verify_trace_reference_accepts_valid_gitignore_files() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let path = tempdir.path().join(".gitignore");
+        fs::write(&path, "# FEAT-CONTRIB-002\n/.worktrees/\n").expect("file should exist");
+
+        let reference = TraceReference {
+            file: PathBuf::from(".gitignore"),
+            symbols: vec!["FEAT-CONTRIB-002".to_string(), "/.worktrees/".to_string()],
+            doc_contains: Vec::new(),
+        };
+        let mut issues = Vec::new();
+        assert!(verify_trace_reference(
+            tempdir.path(),
+            &SyuConfig::default(),
+            "FEAT-CONTRIB-002",
+            TraceRole::FeatureImplementation,
+            "gitignore",
             &reference,
             &mut issues,
         ));

--- a/src/language.rs
+++ b/src/language.rs
@@ -54,6 +54,9 @@ struct JsonAdapter;
 #[derive(Debug)]
 struct MarkdownAdapter;
 
+#[derive(Debug)]
+struct GitignoreAdapter;
+
 static RUST_ADAPTER: RustAdapter = RustAdapter;
 static PYTHON_ADAPTER: PythonAdapter = PythonAdapter;
 static TYPESCRIPT_ADAPTER: TypeScriptAdapter = TypeScriptAdapter;
@@ -61,6 +64,7 @@ static SHELL_ADAPTER: ShellAdapter = ShellAdapter;
 static YAML_ADAPTER: YamlAdapter = YamlAdapter;
 static JSON_ADAPTER: JsonAdapter = JsonAdapter;
 static MARKDOWN_ADAPTER: MarkdownAdapter = MarkdownAdapter;
+static GITIGNORE_ADAPTER: GitignoreAdapter = GitignoreAdapter;
 
 impl LanguageAdapter for RustAdapter {
     fn canonical_name(&self) -> &'static str {
@@ -222,6 +226,32 @@ impl LanguageAdapter for MarkdownAdapter {
     }
 }
 
+impl LanguageAdapter for GitignoreAdapter {
+    fn canonical_name(&self) -> &'static str {
+        "gitignore"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["gitignore", "ignore"]
+    }
+
+    fn extensions(&self) -> &'static [&'static str] {
+        &["gitignore"]
+    }
+
+    fn patterns(&self, symbol: &str) -> Vec<String> {
+        let escaped = regex::escape(symbol);
+        vec![format!(r"(?m)\b{escaped}\b")]
+    }
+
+    fn supports_path(&self, path: &Path) -> bool {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.eq_ignore_ascii_case(".gitignore"))
+            .unwrap_or(false)
+    }
+}
+
 // FEAT-CHECK-001
 pub fn adapter_for_language(language: &str) -> Option<&'static dyn LanguageAdapter> {
     let normalized = language.trim().to_ascii_lowercase().replace('_', "-");
@@ -234,6 +264,7 @@ pub fn adapter_for_language(language: &str) -> Option<&'static dyn LanguageAdapt
         &YAML_ADAPTER as &dyn LanguageAdapter,
         &JSON_ADAPTER as &dyn LanguageAdapter,
         &MARKDOWN_ADAPTER as &dyn LanguageAdapter,
+        &GITIGNORE_ADAPTER as &dyn LanguageAdapter,
     ]
     .into_iter()
     .find(|adapter| adapter.aliases().iter().any(|alias| *alias == normalized))
@@ -282,6 +313,10 @@ mod tests {
             adapter_for_language("md").map(LanguageAdapter::canonical_name),
             Some("markdown")
         );
+        assert_eq!(
+            adapter_for_language("ignore").map(LanguageAdapter::canonical_name),
+            Some("gitignore")
+        );
         assert!(adapter_for_language("unknown").is_none());
     }
 
@@ -292,6 +327,7 @@ mod tests {
         let yaml = adapter_for_language("yaml").expect("yaml adapter should exist");
         let json = adapter_for_language("json").expect("json adapter should exist");
         let markdown = adapter_for_language("markdown").expect("markdown adapter should exist");
+        let gitignore = adapter_for_language("gitignore").expect("gitignore adapter should exist");
 
         assert!(rust.supports_path(Path::new("src/lib.rs")));
         assert!(!rust.supports_path(Path::new("src/lib.py")));
@@ -299,7 +335,11 @@ mod tests {
         assert!(yaml.supports_path(Path::new(".github/workflows/ci.yml")));
         assert!(json.supports_path(Path::new("release-please-config.json")));
         assert!(markdown.supports_path(Path::new("README.md")));
+        assert!(gitignore.supports_path(Path::new(".gitignore")));
+        assert!(gitignore.supports_path(Path::new("app/.gitignore")));
+        assert_eq!(gitignore.extensions(), &["gitignore"]);
         assert!(!yaml.supports_path(Path::new("README.md")));
+        assert!(!gitignore.supports_path(Path::new("README.md")));
     }
 
     #[test]
@@ -312,6 +352,7 @@ mod tests {
         let yaml = adapter_for_language("yaml").expect("yaml adapter should exist");
         let json = adapter_for_language("json").expect("json adapter should exist");
         let markdown = adapter_for_language("markdown").expect("markdown adapter should exist");
+        let gitignore = adapter_for_language("gitignore").expect("gitignore adapter should exist");
 
         assert!(rust.symbol_exists("pub fn hello_world() {}", "hello_world"));
         assert!(python.symbol_exists("def test_trace():\n    return True\n", "test_trace"));
@@ -324,6 +365,9 @@ mod tests {
         assert!(json.symbol_exists("{\"package\":\"syu\"}", "package"));
         assert!(json.symbol_exists("{\"package-name\":\"syu\"}", "package-name"));
         assert!(markdown.symbol_exists("# syu\n\nSee `docs/guide/concepts.md`\n", "concepts"));
+        assert!(gitignore.symbol_exists("# FEAT-CONTRIB-002\n/.worktrees/\n", "FEAT-CONTRIB-002"));
+        assert!(gitignore.symbol_exists("# FEAT-CONTRIB-002\n/.worktrees/\n", "/.worktrees/"));
+        assert!(gitignore.symbol_exists("worktree_helper\n", "worktree_helper"));
     }
 
     #[test]

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -328,7 +328,7 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(issue_config.contains("contact_links"));
 
     assert!(gitignore.contains("FEAT-CONTRIB-002"));
-    assert!(gitignore.contains(".worktrees/"));
+    assert!(gitignore.contains("/.worktrees/"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `gitignore` adapter support so implementation traces can target `.gitignore`
- trace `FEAT-CONTRIB-002` directly to `.gitignore` and tighten the rooted `/.worktrees/` assertion
- extend validation tests so the new adapter remains fully covered

## Testing
- `cargo run -- validate .`
- `scripts/ci/quality-gates.sh`
- `scripts/ci/coverage.sh summary </dev/null`

Follow-up to #31.
