### PR TITLE
feat: add validate output filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,15 @@ Validate definitions and traceability:
 ```bash
 syu validate .
 syu validate . --format json
+syu validate . --severity error --genre trace
+syu validate . --rule SYU-trace-file-002
 syu validate . --fix
 syu validate . --no-fix
 ```
 
 `check` remains available as a compatibility alias for `validate`.
+Use `--severity`, `--genre`, and `--rule` to narrow the rendered issue list
+without changing the underlying validation result or exit code.
 
 ### `syu browse`
 

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -27,8 +27,10 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
-      validation output. `check` MAY remain as a compatibility alias, but
-      `validate` is the canonical command name.
+      validation output. It MUST also support optional filtered views by
+      severity, rule genre, and exact rule code for both text and JSON output
+      without changing the underlying validation result. `check` MAY remain as
+      a compatibility alias, but `validate` is the canonical command name.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -41,6 +43,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/check_command.rs
         - **symbols**:
           - *
+      - **file**: tests/validate_filter_command.rs
+        - **symbols**:
+          - *
       - **file**: tests/status_validation.rs
         - **symbols**:
           - *
@@ -48,6 +53,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - *
       - **file**: src/command/check.rs
+        - **symbols**:
+          - *
+      - **file**: src/cli.rs
         - **symbols**:
           - *
       - **file**: src/model.rs
@@ -169,8 +177,10 @@ requirements:
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
-      validation output. `check` MAY remain as a compatibility alias, but
-      `validate` is the canonical command name.
+      validation output. It MUST also support optional filtered views by
+      severity, rule genre, and exact rule code for both text and JSON output
+      without changing the underlying validation result. `check` MAY remain as
+      a compatibility alias, but `validate` is the canonical command name.
     priority: high
     status: implemented
     linked_policies:
@@ -183,6 +193,9 @@ requirements:
         - file: tests/check_command.rs
           symbols:
             - '*'
+        - file: tests/validate_filter_command.rs
+          symbols:
+            - '*'
         - file: tests/status_validation.rs
           symbols:
             - '*'
@@ -190,6 +203,9 @@ requirements:
           symbols:
             - '*'
         - file: src/command/check.rs
+          symbols:
+            - '*'
+        - file: src/cli.rs
           symbols:
             - '*'
         - file: src/model.rs

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -83,7 +83,11 @@ Use JSON when integrating with automation:
 
 ```bash
 syu validate . --format json
+syu validate . --severity error --genre trace
 ```
+
+Filters stay view-oriented: they narrow the visible diagnostics while preserving
+the full validation result and exit code.
 
 ## 5. Apply safe autofixes
 

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -10,8 +10,10 @@ requirements:
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
-      validation output. `check` MAY remain as a compatibility alias, but
-      `validate` is the canonical command name.
+      validation output. It MUST also support optional filtered views by
+      severity, rule genre, and exact rule code for both text and JSON output
+      without changing the underlying validation result. `check` MAY remain as
+      a compatibility alias, but `validate` is the canonical command name.
     priority: high
     status: implemented
     linked_policies:
@@ -24,6 +26,9 @@ requirements:
         - file: tests/check_command.rs
           symbols:
             - '*'
+        - file: tests/validate_filter_command.rs
+          symbols:
+            - '*'
         - file: tests/status_validation.rs
           symbols:
             - '*'
@@ -31,6 +36,9 @@ requirements:
           symbols:
             - '*'
         - file: src/command/check.rs
+          symbols:
+            - '*'
+        - file: src/cli.rs
           symbols:
             - '*'
         - file: src/model.rs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 // FEAT-BROWSE-001
+// REQ-CORE-001
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
@@ -75,6 +76,18 @@ pub struct ValidateArgs {
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
 
+    #[arg(help = "Filter visible diagnostics by severity (repeat or use commas)")]
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub severity: Vec<ValidationSeverityFilter>,
+
+    #[arg(help = "Filter visible diagnostics by rule genre (repeat or use commas)")]
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub genre: Vec<ValidationGenreFilter>,
+
+    #[arg(help = "Filter visible diagnostics by exact rule code (repeat or use commas)")]
+    #[arg(long, value_delimiter = ',')]
+    pub rule: Vec<String>,
+
     #[arg(help = "Apply conservative documentation autofixes")]
     #[arg(long, action = ArgAction::SetTrue)]
     pub fix: bool,
@@ -116,4 +129,56 @@ pub struct InitArgs {
 pub enum OutputFormat {
     Text,
     Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum ValidationSeverityFilter {
+    Error,
+    Warning,
+}
+
+impl ValidationSeverityFilter {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum ValidationGenreFilter {
+    Workspace,
+    Graph,
+    Delivery,
+    Trace,
+    Coverage,
+}
+
+impl ValidationGenreFilter {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Graph => "graph",
+            Self::Delivery => "delivery",
+            Self::Trace => "trace",
+            Self::Coverage => "coverage",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ValidationGenreFilter, ValidationSeverityFilter};
+
+    #[test]
+    fn validation_filter_enums_expose_expected_labels() {
+        assert_eq!(ValidationSeverityFilter::Error.as_str(), "error");
+        assert_eq!(ValidationSeverityFilter::Warning.as_str(), "warning");
+        assert_eq!(ValidationGenreFilter::Workspace.as_str(), "workspace");
+        assert_eq!(ValidationGenreFilter::Graph.as_str(), "graph");
+        assert_eq!(ValidationGenreFilter::Delivery.as_str(), "delivery");
+        assert_eq!(ValidationGenreFilter::Trace.as_str(), "trace");
+        assert_eq!(ValidationGenreFilter::Coverage.as_str(), "coverage");
+    }
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -9,18 +9,19 @@ use std::{
 };
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::{
-    cli::{CheckArgs, OutputFormat},
+    cli::{CheckArgs, OutputFormat, ValidationGenreFilter, ValidationSeverityFilter},
     config::SyuConfig,
     coverage::validate_symbol_trace_coverage,
     inspect::{apply_symbol_doc_fix, inspect_symbol, supports_rich_inspection},
     language::adapter_for_language,
     model::{
-        CheckResult, DefinitionCounts, Feature, Issue, Philosophy, Policy, Requirement, TraceCount,
-        TraceReference, TraceSummary,
+        CheckResult, DefinitionCounts, Feature, Issue, Philosophy, Policy, Requirement, Severity,
+        TraceCount, TraceReference, TraceSummary,
     },
-    rules::{attach_referenced_rules, rule_by_code},
+    rules::{attach_referenced_rules, referenced_rules, rule_by_code, rule_genre},
     workspace::{Workspace, load_workspace},
 };
 
@@ -49,6 +50,34 @@ struct AutofixSummary {
     symbol_updates: usize,
 }
 
+#[derive(Debug, Clone, Default)]
+struct IssueFilters {
+    severities: BTreeSet<ValidationSeverityFilter>,
+    genres: BTreeSet<ValidationGenreFilter>,
+    rules: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FilteredIssueView {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    severities: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    genres: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rules: Vec<String>,
+    displayed_issue_count: usize,
+    total_issue_count: usize,
+    hidden_issue_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonCheckOutput<'a> {
+    #[serde(flatten)]
+    result: &'a CheckResult,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filtered_view: Option<&'a FilteredIssueView>,
+}
+
 impl TraceRole {
     fn label(self) -> &'static str {
         match self {
@@ -69,6 +98,82 @@ impl TraceRole {
             Self::RequirementTest => "tests",
             Self::FeatureImplementation => "implementations",
         }
+    }
+}
+
+impl IssueFilters {
+    fn from_args(args: &CheckArgs) -> Self {
+        Self {
+            severities: args.severity.iter().copied().collect(),
+            genres: args.genre.iter().copied().collect(),
+            rules: args
+                .rule
+                .iter()
+                .map(|rule| rule.trim())
+                .filter(|rule| !rule.is_empty())
+                .map(ToOwned::to_owned)
+                .collect(),
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        !self.severities.is_empty() || !self.genres.is_empty() || !self.rules.is_empty()
+    }
+
+    fn matches(&self, issue: &Issue) -> bool {
+        (self.severities.is_empty()
+            || self
+                .severities
+                .iter()
+                .any(|candidate| candidate.as_str() == severity_label(&issue.severity)))
+            && (self.rules.is_empty() || self.rules.contains(&issue.code))
+            && (self.genres.is_empty()
+                || rule_genre(&issue.code).is_some_and(|genre| {
+                    self.genres
+                        .iter()
+                        .any(|candidate| candidate.as_str() == genre)
+                }))
+    }
+}
+
+impl FilteredIssueView {
+    fn from_filters(
+        filters: &IssueFilters,
+        displayed_issue_count: usize,
+        total_issue_count: usize,
+    ) -> Self {
+        Self {
+            severities: filters
+                .severities
+                .iter()
+                .map(|severity| severity.as_str().to_string())
+                .collect(),
+            genres: filters
+                .genres
+                .iter()
+                .map(|genre| genre.as_str().to_string())
+                .collect(),
+            rules: filters.rules.iter().cloned().collect(),
+            displayed_issue_count,
+            total_issue_count,
+            hidden_issue_count: total_issue_count.saturating_sub(displayed_issue_count),
+        }
+    }
+
+    fn describe_filters(&self) -> String {
+        let mut parts = Vec::new();
+
+        if !self.severities.is_empty() {
+            parts.push(format!("severity={}", self.severities.join(",")));
+        }
+        if !self.genres.is_empty() {
+            parts.push(format!("genre={}", self.genres.join(",")));
+        }
+        if !self.rules.is_empty() {
+            parts.push(format!("rule={}", self.rules.join(",")));
+        }
+
+        parts.join(" ")
     }
 }
 
@@ -94,6 +199,9 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             None,
         ),
     };
+    let overall_success = result.is_success();
+    let filters = IssueFilters::from_args(args);
+    let (result, filtered_view) = filter_check_result(result, &filters);
 
     match args.format {
         OutputFormat::Text => {
@@ -106,18 +214,25 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
                     summary.updated_files.len()
                 );
             }
-            print!("{}", render_text_report(&result));
+            print!(
+                "{}",
+                render_text_report(overall_success, &result, filtered_view.as_ref())
+            );
         }
         OutputFormat::Json => {
+            let output = JsonCheckOutput {
+                result: &result,
+                filtered_view: filtered_view.as_ref(),
+            };
             println!(
                 "{}",
-                serde_json::to_string_pretty(&result)
-                    .expect("serializing CheckResult to JSON should succeed")
+                serde_json::to_string_pretty(&output)
+                    .expect("serializing validate output to JSON should succeed")
             );
         }
     }
 
-    Ok(if result.is_success() { 0 } else { 1 })
+    Ok(if overall_success { 0 } else { 1 })
 }
 
 // FEAT-CHECK-001
@@ -247,6 +362,51 @@ fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
         issues,
         referenced_rules: Vec::new(),
     })
+}
+
+fn severity_label(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    }
+}
+
+fn filter_check_result(
+    result: CheckResult,
+    filters: &IssueFilters,
+) -> (CheckResult, Option<FilteredIssueView>) {
+    if !filters.is_active() {
+        return (result, None);
+    }
+
+    let CheckResult {
+        workspace_root,
+        definition_counts,
+        trace_summary,
+        issues: existing_issues,
+        referenced_rules: _,
+    } = result;
+
+    let total_issue_count = existing_issues.len();
+    let issues: Vec<_> = existing_issues
+        .into_iter()
+        .filter(|issue| filters.matches(issue))
+        .collect();
+    let displayed_issue_count = issues.len();
+    let filtered_view =
+        FilteredIssueView::from_filters(filters, displayed_issue_count, total_issue_count);
+    let referenced_rules = referenced_rules(&issues);
+
+    (
+        CheckResult {
+            workspace_root,
+            definition_counts,
+            trace_summary,
+            issues,
+            referenced_rules,
+        },
+        Some(filtered_view),
+    )
 }
 
 fn effective_fix(args: &CheckArgs, config: &SyuConfig) -> bool {
@@ -382,15 +542,21 @@ fn apply_autofix_for_reference(
     Ok(())
 }
 
-fn render_text_report(result: &CheckResult) -> String {
+fn render_text_report(
+    overall_success: bool,
+    result: &CheckResult,
+    filtered_view: Option<&FilteredIssueView>,
+) -> String {
     let mut output = String::new();
-    let status = if result.is_success() {
-        "passed"
+    let status = if overall_success { "passed" } else { "failed" };
+    let filtered_suffix = if filtered_view.is_some() {
+        " (filtered view)"
     } else {
-        "failed"
+        ""
     };
 
-    writeln!(&mut output, "syu validate {status}").expect("writing to String must succeed");
+    writeln!(&mut output, "syu validate {status}{filtered_suffix}")
+        .expect("writing to String must succeed");
     writeln!(
         &mut output,
         "workspace: {}",
@@ -415,6 +581,17 @@ fn render_text_report(result: &CheckResult) -> String {
         result.trace_summary.feature_traces.declared
     )
     .expect("writing to String must succeed");
+
+    if let Some(filtered_view) = filtered_view {
+        writeln!(&mut output, "filters: {}", filtered_view.describe_filters())
+            .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "showing {} of {} issues after filtering",
+            filtered_view.displayed_issue_count, filtered_view.total_issue_count
+        )
+        .expect("writing to String must succeed");
+    }
 
     if !result.issues.is_empty() {
         writeln!(&mut output).expect("writing to String must succeed");
@@ -445,6 +622,13 @@ fn render_text_report(result: &CheckResult) -> String {
                 .expect("writing to String must succeed");
             }
         }
+    } else if let Some(filtered_view) = filtered_view
+        && filtered_view.total_issue_count > 0
+    {
+        writeln!(&mut output).expect("writing to String must succeed");
+        writeln!(&mut output, "issues:").expect("writing to String must succeed");
+        writeln!(&mut output, "- no issues matched the active filters.")
+            .expect("writing to String must succeed");
     }
 
     if !result.referenced_rules.is_empty() {
@@ -1399,7 +1583,7 @@ fn validate_non_empty_field(kind: &str, field_name: &str, value: &str, issues: &
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, BTreeSet, HashMap},
         fs,
         path::{Path, PathBuf},
     };
@@ -1410,16 +1594,18 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::{
+        cli::{ValidationGenreFilter, ValidationSeverityFilter},
         config::SyuConfig,
         model::{Feature, Issue, Philosophy, Policy, Requirement, TraceReference},
+        rules::referenced_rules,
         workspace::Workspace,
     };
 
     use super::{
-        TraceRole, apply_autofix, apply_autofix_for_reference, collect_check_result,
-        format_reference_location, render_text_report, run_check_command, validate_feature,
-        validate_non_empty_field, validate_philosophy, validate_policy, validate_requirement,
-        validate_unique_ids, verify_trace_reference,
+        FilteredIssueView, IssueFilters, TraceRole, apply_autofix, apply_autofix_for_reference,
+        collect_check_result, filter_check_result, format_reference_location, render_text_report,
+        run_check_command, validate_feature, validate_non_empty_field, validate_philosophy,
+        validate_policy, validate_requirement, validate_unique_ids, verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -1479,6 +1665,9 @@ mod tests {
         let code = run_check_command(&crate::cli::CheckArgs {
             workspace: PathBuf::from("/definitely/missing-syu-workspace"),
             format: crate::cli::OutputFormat::Json,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
             fix: false,
             no_fix: false,
         })
@@ -1536,6 +1725,9 @@ mod tests {
         let error = run_check_command(&crate::cli::CheckArgs {
             workspace,
             format: crate::cli::OutputFormat::Text,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
             fix: true,
             no_fix: false,
         })
@@ -1554,10 +1746,81 @@ mod tests {
             referenced_rules: Vec::new(),
         };
 
-        let report = render_text_report(&result);
+        let report = render_text_report(true, &result, None);
         assert!(report.contains("syu validate passed"));
         assert!(report.contains("issues:"));
         assert!(report.contains("[Warning] warn subject: message"));
+    }
+
+    #[test]
+    fn filter_check_result_scopes_visible_issues() {
+        let issues = vec![
+            Issue::warning("SYU-graph-links-001", "subject", None, "message", None),
+            Issue::error("SYU-trace-file-001", "subject", None, "message", None),
+        ];
+        let result = crate::model::CheckResult {
+            workspace_root: PathBuf::from("."),
+            definition_counts: Default::default(),
+            trace_summary: Default::default(),
+            referenced_rules: referenced_rules(&issues),
+            issues,
+        };
+        let filters = IssueFilters {
+            severities: [ValidationSeverityFilter::Warning].into_iter().collect(),
+            genres: [ValidationGenreFilter::Graph].into_iter().collect(),
+            rules: BTreeSet::new(),
+        };
+
+        let (filtered, filtered_view) = filter_check_result(result, &filters);
+
+        assert_eq!(filtered.issues.len(), 1);
+        assert_eq!(filtered.issues[0].code, "SYU-graph-links-001");
+        assert_eq!(filtered.referenced_rules.len(), 1);
+        assert_eq!(filtered.referenced_rules[0].code, "SYU-graph-links-001");
+        let filtered_view = filtered_view.expect("filters should produce filtered metadata");
+        assert_eq!(filtered_view.displayed_issue_count, 1);
+        assert_eq!(filtered_view.total_issue_count, 2);
+        assert_eq!(filtered_view.hidden_issue_count, 1);
+    }
+
+    #[test]
+    fn render_text_report_explains_filtered_views_without_matches() {
+        let result = crate::model::CheckResult {
+            workspace_root: PathBuf::from("."),
+            definition_counts: Default::default(),
+            trace_summary: Default::default(),
+            referenced_rules: Vec::new(),
+            issues: Vec::new(),
+        };
+        let filtered_view = FilteredIssueView {
+            severities: vec!["warning".to_string()],
+            genres: Vec::new(),
+            rules: Vec::new(),
+            displayed_issue_count: 0,
+            total_issue_count: 2,
+            hidden_issue_count: 2,
+        };
+
+        let report = render_text_report(false, &result, Some(&filtered_view));
+
+        assert!(report.contains("syu validate failed (filtered view)"));
+        assert!(report.contains("filters: severity=warning"));
+        assert!(report.contains("showing 0 of 2 issues after filtering"));
+        assert!(report.contains("no issues matched the active filters."));
+    }
+
+    #[test]
+    fn filtered_issue_view_describes_genre_filters() {
+        let filtered_view = FilteredIssueView {
+            severities: Vec::new(),
+            genres: vec!["trace".to_string()],
+            rules: Vec::new(),
+            displayed_issue_count: 1,
+            total_issue_count: 1,
+            hidden_issue_count: 0,
+        };
+
+        assert_eq!(filtered_view.describe_filters(), "genre=trace");
     }
 
     #[test]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -50,6 +50,10 @@ pub fn rule_by_code(code: &str) -> Option<&'static ReferencedRule> {
     RULES_BY_CODE.get(code)
 }
 
+pub fn rule_genre(code: &str) -> Option<&'static str> {
+    rule_by_code(code).map(|rule| rule.genre.as_str())
+}
+
 pub fn attach_referenced_rules(mut result: CheckResult) -> CheckResult {
     result.referenced_rules = referenced_rules(&result.issues);
     result
@@ -125,7 +129,8 @@ mod tests {
     use crate::model::{CheckResult, DefinitionCounts, Issue, TraceSummary};
 
     use super::{
-        all_rules, attach_referenced_rules, is_structured_rule_code, referenced_rules, rule_by_code,
+        all_rules, attach_referenced_rules, is_structured_rule_code, referenced_rules,
+        rule_by_code, rule_genre,
     };
 
     #[test]
@@ -199,6 +204,12 @@ mod tests {
     #[test]
     fn rule_lookup_returns_none_for_unknown_codes() {
         assert!(rule_by_code("warn").is_none());
+    }
+
+    #[test]
+    fn rule_genre_follows_built_in_catalog() {
+        assert_eq!(rule_genre("SYU-graph-reference-001"), Some("graph"));
+        assert_eq!(rule_genre("warn"), None);
     }
 
     #[test]

--- a/tests/validate_filter_command.rs
+++ b/tests/validate_filter_command.rs
@@ -1,0 +1,152 @@
+// REQ-CORE-001
+
+use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
+use std::{fs, path::Path, process::Command};
+use tempfile::tempdir;
+
+fn write_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: false\n  require_symbol_trace_coverage: false\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-WARN-001\n    title: Keep weakly linked ideas visible\n    product_design_principle: Warnings should stay reviewable.\n    coding_guideline: Keep optional gaps explicit.\n    linked_policies: []\n  - id: PHIL-OK-001\n    title: Keep traceability connected\n    product_design_principle: Connected items should stay explicit.\n    coding_guideline: Prefer reciprocal links.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Connected work should point to real evidence\n    summary: Keep validation output filterable without hiding repository drift.\n    description: This fixture keeps one valid chain plus one warning-only philosophy.\n    linked_philosophies:\n      - PHIL-OK-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Requirement traces should point to real files\n    description: This fixture intentionally points to a missing test file.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      rust:\n        - file: tests/missing_trace.rs\n          symbols:\n            - missing_trace\n",
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Feature traces should stay valid\n    summary: The feature trace passes so the requirement trace failure stands out.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      rust:\n        - file: src/feature.rs\n          symbols:\n            - feature_impl\n",
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("src/feature.rs"),
+        "/// FEAT-001\npub fn feature_impl() {}\n",
+    )
+    .expect("source");
+}
+
+#[test]
+fn validate_filters_text_output_by_severity() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--severity")
+        .arg("warning")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "filtered warnings should still reflect hidden errors"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("syu validate failed (filtered view)"));
+    assert!(stdout.contains("filters: severity=warning"));
+    assert!(stdout.contains("showing 1 of 2 issues after filtering"));
+    assert!(stdout.contains("SYU-graph-links-001"));
+    assert!(!stdout.contains("SYU-trace-file-002"));
+}
+
+#[test]
+fn validate_filters_json_output_by_genre() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--format")
+        .arg("json")
+        .arg("--genre")
+        .arg("trace")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "trace-only filtered output should still reflect hidden warnings or errors"
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(json["filtered_view"]["genres"][0], "trace");
+    assert_eq!(json["filtered_view"]["displayed_issue_count"], 1);
+    assert_eq!(json["filtered_view"]["total_issue_count"], 2);
+    assert_eq!(json["filtered_view"]["hidden_issue_count"], 1);
+
+    let issues = json["issues"]
+        .as_array()
+        .expect("issues should be represented as an array");
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0]["code"], "SYU-trace-file-002");
+
+    let rules = json["referenced_rules"]
+        .as_array()
+        .expect("referenced rules should be represented as an array");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0]["genre"], "trace");
+}
+
+#[test]
+fn validate_reports_when_rule_filters_hide_every_issue() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--rule")
+        .arg("SYU-coverage-public-001")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "hidden errors should still produce a failing exit code"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("filters: rule=SYU-coverage-public-001"));
+    assert!(stdout.contains("showing 0 of 2 issues after filtering"));
+    assert!(stdout.contains("no issues matched the active filters."));
+}


### PR DESCRIPTION
## Summary
- add severity, genre, and exact rule-code filters to `syu validate`
- keep filtered text and JSON output explicit without changing the overall exit code
- update self-hosted validation spec, generated docs, and regression tests

## Testing
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary

Closes #33