### PR TITLE
feat: detect duplicate spec references

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,13 @@ and `validate.require_symbol_trace_coverage` in its root `syu.yaml`.
 - philosophy ↔ policy links must exist and be reciprocal
 - policy ↔ requirement links must exist and be reciprocal
 - requirement ↔ feature links must exist and be reciprocal
+- duplicate linked IDs inside one relationship list are rejected
 - requirements and features must use `status: planned` or `status: implemented`
 - `planned` items must not declare tests or implementations yet
 - `implemented` items must declare valid tests or implementations
 - requirement test mappings must point to existing files and symbols
 - feature implementation mappings must point to existing files and symbols
+- duplicate trace mappings inside one language list are rejected
 - traced files must mention the owning requirement / feature ID
 - optional `doc_contains` snippets must be present in the traced symbol's
   documentation

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -97,6 +97,18 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
       constrain behavior, or be justified by higher-level intent. This rule
       exists to keep every layer part of one connected explanation instead of
       allowing decorative or abandoned nodes to accumulate.
+- **code**: SYU-graph-duplicate-001
+  - **genre**: graph
+  - **severity**: error
+  - **title**: Relationship lists must not repeat the same linked ID
+  - **summary**: Repeating the same adjacent-layer reference does not create new traceability.
+  - **description**:
+    - |
+      Link lists explain why one definition relates to another. When the same
+      target ID appears more than once inside one list, the graph becomes
+      noisier without becoming more informative. This rule keeps adjacent-layer
+      relationships crisp and reviewable by requiring each linked ID to appear
+      at most once per list.
 - **code**: SYU-delivery-invalid-001
   - **genre**: delivery
   - **severity**: error
@@ -260,6 +272,18 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
       no longer identifies real evidence and may be drifting behind refactors or
       stale documentation. This rule keeps symbol traces anchored to actual code
       and tests.
+- **code**: SYU-trace-duplicate-001
+  - **genre**: trace
+  - **severity**: error
+  - **title**: Trace lists must not repeat the same mapping
+  - **summary**: Duplicated trace records inflate evidence without adding new repository facts.
+  - **description**:
+    - |
+      A trace list should enumerate distinct pieces of repository evidence.
+      Repeating the exact same file, symbol, and documentation mapping inside
+      one language list makes the specification look more complete than it is
+      and makes review harder. This rule keeps trace evidence explicit by
+      requiring each mapping to appear only once per list.
 - **code**: SYU-trace-inspection-001
   - **genre**: trace
   - **severity**: error
@@ -458,6 +482,18 @@ rules:
       exists to keep every layer part of one connected explanation instead of
       allowing decorative or abandoned nodes to accumulate.
 
+  - code: SYU-graph-duplicate-001
+    genre: graph
+    severity: error
+    title: Relationship lists must not repeat the same linked ID
+    summary: Repeating the same adjacent-layer reference does not create new traceability.
+    description: |
+      Link lists explain why one definition relates to another. When the same
+      target ID appears more than once inside one list, the graph becomes
+      noisier without becoming more informative. This rule keeps adjacent-layer
+      relationships crisp and reviewable by requiring each linked ID to appear
+      at most once per list.
+
   - code: SYU-delivery-invalid-001
     genre: delivery
     severity: error
@@ -620,6 +656,18 @@ rules:
       no longer identifies real evidence and may be drifting behind refactors or
       stale documentation. This rule keeps symbol traces anchored to actual code
       and tests.
+
+  - code: SYU-trace-duplicate-001
+    genre: trace
+    severity: error
+    title: Trace lists must not repeat the same mapping
+    summary: Duplicated trace records inflate evidence without adding new repository facts.
+    description: |
+      A trace list should enumerate distinct pieces of repository evidence.
+      Repeating the exact same file, symbol, and documentation mapping inside
+      one language list makes the specification look more complete than it is
+      and makes review harder. This rule keeps trace evidence explicit by
+      requiring each mapping to appear only once per list.
 
   - code: SYU-trace-inspection-001
     genre: trace

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -24,6 +24,7 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
       references, verify reciprocal links across the adjacent-layer graph,
+      reject duplicate adjacent-layer IDs inside a single relationship list,
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
@@ -46,6 +47,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/validate_filter_command.rs
         - **symbols**:
           - *
+      - **file**: tests/duplicate_validation.rs
+        - **symbols**:
+          - validate_reports_duplicate_relationship_entries
       - **file**: tests/status_validation.rs
         - **symbols**:
           - *
@@ -76,7 +80,8 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       today: Rust, Python, and TypeScript. A declared trace is valid only when
       the file exists, the symbol exists, the file explicitly mentions the
       owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also support wildcard file ownership and an
+      documentation. Validation MUST also reject duplicate trace mappings inside
+      a single language list, support wildcard file ownership, and provide an
       optional mode that requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement.
   - **priority**: high
@@ -95,6 +100,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/trace_coverage_validation.rs
         - **symbols**:
           - *
+      - **file**: tests/duplicate_validation.rs
+        - **symbols**:
+          - validate_reports_duplicate_trace_entries
       - **file**: src/coverage.rs
         - **symbols**:
           - *
@@ -174,6 +182,7 @@ requirements:
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
       references, verify reciprocal links across the adjacent-layer graph,
+      reject duplicate adjacent-layer IDs inside a single relationship list,
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
@@ -196,6 +205,9 @@ requirements:
         - file: tests/validate_filter_command.rs
           symbols:
             - '*'
+        - file: tests/duplicate_validation.rs
+          symbols:
+            - validate_reports_duplicate_relationship_entries
         - file: tests/status_validation.rs
           symbols:
             - '*'
@@ -225,7 +237,8 @@ requirements:
       today: Rust, Python, and TypeScript. A declared trace is valid only when
       the file exists, the symbol exists, the file explicitly mentions the
       owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also support wildcard file ownership and an
+      documentation. Validation MUST also reject duplicate trace mappings inside
+      a single language list, support wildcard file ownership, and provide an
       optional mode that requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement.
     priority: high
@@ -244,6 +257,9 @@ requirements:
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'
+        - file: tests/duplicate_validation.rs
+          symbols:
+            - validate_reports_duplicate_trace_entries
         - file: src/coverage.rs
           symbols:
             - '*'

--- a/docs/syu/features/validation/validation.yaml
+++ b/docs/syu/features/validation/validation.yaml
@@ -86,6 +86,18 @@ rules:
       exists to keep every layer part of one connected explanation instead of
       allowing decorative or abandoned nodes to accumulate.
 
+  - code: SYU-graph-duplicate-001
+    genre: graph
+    severity: error
+    title: Relationship lists must not repeat the same linked ID
+    summary: Repeating the same adjacent-layer reference does not create new traceability.
+    description: |
+      Link lists explain why one definition relates to another. When the same
+      target ID appears more than once inside one list, the graph becomes
+      noisier without becoming more informative. This rule keeps adjacent-layer
+      relationships crisp and reviewable by requiring each linked ID to appear
+      at most once per list.
+
   - code: SYU-delivery-invalid-001
     genre: delivery
     severity: error
@@ -248,6 +260,18 @@ rules:
       no longer identifies real evidence and may be drifting behind refactors or
       stale documentation. This rule keeps symbol traces anchored to actual code
       and tests.
+
+  - code: SYU-trace-duplicate-001
+    genre: trace
+    severity: error
+    title: Trace lists must not repeat the same mapping
+    summary: Duplicated trace records inflate evidence without adding new repository facts.
+    description: |
+      A trace list should enumerate distinct pieces of repository evidence.
+      Repeating the exact same file, symbol, and documentation mapping inside
+      one language list makes the specification look more complete than it is
+      and makes review harder. This rule keeps trace evidence explicit by
+      requiring each mapping to appear only once per list.
 
   - code: SYU-trace-inspection-001
     genre: trace

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -7,6 +7,7 @@ requirements:
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
       references, verify reciprocal links across the adjacent-layer graph,
+      reject duplicate adjacent-layer IDs inside a single relationship list,
       report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, and
       surface rule codes with human-readable titles and explanations in
@@ -29,6 +30,9 @@ requirements:
         - file: tests/validate_filter_command.rs
           symbols:
             - '*'
+        - file: tests/duplicate_validation.rs
+          symbols:
+            - validate_reports_duplicate_relationship_entries
         - file: tests/status_validation.rs
           symbols:
             - '*'
@@ -58,7 +62,8 @@ requirements:
       today: Rust, Python, and TypeScript. A declared trace is valid only when
       the file exists, the symbol exists, the file explicitly mentions the
       owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also support wildcard file ownership and an
+      documentation. Validation MUST also reject duplicate trace mappings inside
+      a single language list, support wildcard file ownership, and provide an
       optional mode that requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement.
     priority: high
@@ -77,6 +82,9 @@ requirements:
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'
+        - file: tests/duplicate_validation.rs
+          symbols:
+            - validate_reports_duplicate_trace_entries
         - file: src/coverage.rs
           symbols:
             - '*'

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -740,6 +740,93 @@ fn validate_unique_ids<'a>(
     }
 }
 
+fn validate_duplicate_links(
+    owner_kind: &str,
+    owner_id: &str,
+    relation_name: &str,
+    target_kind: &str,
+    values: &[String],
+    issues: &mut Vec<Issue>,
+) {
+    let mut seen = HashSet::new();
+
+    for value in values {
+        if seen.insert(value.as_str()) {
+            continue;
+        }
+
+        issues.push(Issue::error(
+            "SYU-graph-duplicate-001",
+            format!("{owner_kind} {owner_id}"),
+            Some(relation_name.to_string()),
+            format!(
+                "{owner_kind} `{owner_id}` repeats linked {target_kind} `{value}` in `{relation_name}`."
+            ),
+            Some(format!(
+                "Remove the duplicate `{value}` entry from `{relation_name}` in {owner_kind} `{owner_id}`."
+            )),
+        ));
+    }
+}
+
+fn validate_duplicate_trace_references(
+    owner_id: &str,
+    role: TraceRole,
+    language: &str,
+    references: &[TraceReference],
+    issues: &mut Vec<Issue>,
+) {
+    let mut seen = HashSet::new();
+    let subject = format!("{} {}", role.subject_kind(), owner_id);
+
+    for reference in references {
+        let key = (
+            reference.file.clone(),
+            reference.symbols.clone(),
+            reference.doc_contains.clone(),
+        );
+        if seen.insert(key) {
+            continue;
+        }
+
+        issues.push(Issue::error(
+            "SYU-trace-duplicate-001",
+            subject.clone(),
+            Some(format_reference_location(language, reference)),
+            format!(
+                "{} `{owner_id}` repeats the same `{language}` {} entry: {}.",
+                role.subject_kind(),
+                role.relation_name(),
+                describe_trace_reference(reference),
+            ),
+            Some(format!(
+                "Remove the duplicate `{language}` {} entry from `{owner_id}`.",
+                role.relation_name()
+            )),
+        ));
+    }
+}
+
+fn describe_trace_reference(reference: &TraceReference) -> String {
+    let symbols = reference
+        .symbols
+        .iter()
+        .map(|symbol| format!("`{symbol}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let doc_contains = reference
+        .doc_contains
+        .iter()
+        .map(|snippet| format!("`{snippet}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "file=`{}` symbols=[{symbols}] doc_contains=[{doc_contains}]",
+        reference.file.display()
+    )
+}
+
 fn validate_philosophy(
     philosophy: &Philosophy,
     policies_by_id: &HashMap<&str, &Policy>,
@@ -757,6 +844,14 @@ fn validate_philosophy(
         "philosophy",
         "coding_guideline",
         &philosophy.coding_guideline,
+        issues,
+    );
+    validate_duplicate_links(
+        "philosophy",
+        &philosophy.id,
+        "linked_policies",
+        "policy",
+        &philosophy.linked_policies,
         issues,
     );
 
@@ -820,6 +915,22 @@ fn validate_policy(
     validate_non_empty_field("policy", "title", &policy.title, issues);
     validate_non_empty_field("policy", "summary", &policy.summary, issues);
     validate_non_empty_field("policy", "description", &policy.description, issues);
+    validate_duplicate_links(
+        "policy",
+        &policy.id,
+        "linked_philosophies",
+        "philosophy",
+        &policy.linked_philosophies,
+        issues,
+    );
+    validate_duplicate_links(
+        "policy",
+        &policy.id,
+        "linked_requirements",
+        "requirement",
+        &policy.linked_requirements,
+        issues,
+    );
 
     if policy.linked_philosophies.is_empty() {
         issues.push(Issue::warning(
@@ -944,6 +1055,22 @@ fn validate_requirement(
         &requirement.id,
         &requirement.status,
         config,
+        issues,
+    );
+    validate_duplicate_links(
+        "requirement",
+        &requirement.id,
+        "linked_policies",
+        "policy",
+        &requirement.linked_policies,
+        issues,
+    );
+    validate_duplicate_links(
+        "requirement",
+        &requirement.id,
+        "linked_features",
+        "feature",
+        &requirement.linked_features,
         issues,
     );
 
@@ -1072,6 +1199,14 @@ fn validate_feature(
     validate_non_empty_field("feature", "summary", &feature.summary, issues);
     validate_non_empty_field("feature", "status", &feature.status, issues);
     let status = validate_delivery_status("feature", &feature.id, &feature.status, config, issues);
+    validate_duplicate_links(
+        "feature",
+        &feature.id,
+        "linked_requirements",
+        "requirement",
+        &feature.linked_requirements,
+        issues,
+    );
 
     if feature.linked_requirements.is_empty() {
         issues.push(Issue::warning(
@@ -1145,6 +1280,16 @@ fn validate_trace_map(
     trace_count: &mut TraceCount,
 ) {
     let subject = format!("{} {}", target.role.subject_kind(), target.owner_id);
+    for (language, references) in references_by_language {
+        validate_duplicate_trace_references(
+            target.owner_id,
+            target.role,
+            language,
+            references,
+            issues,
+        );
+    }
+
     match target.status {
         Some(DeliveryStatus::Planned) => {
             if !references_by_language.is_empty() {
@@ -1603,9 +1748,11 @@ mod tests {
 
     use super::{
         FilteredIssueView, IssueFilters, TraceRole, apply_autofix, apply_autofix_for_reference,
-        collect_check_result, filter_check_result, format_reference_location, render_text_report,
-        run_check_command, validate_feature, validate_non_empty_field, validate_philosophy,
-        validate_policy, validate_requirement, validate_unique_ids, verify_trace_reference,
+        collect_check_result, describe_trace_reference, filter_check_result,
+        format_reference_location, render_text_report, run_check_command, validate_duplicate_links,
+        validate_duplicate_trace_references, validate_feature, validate_non_empty_field,
+        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
+        verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -1829,6 +1976,52 @@ mod tests {
         validate_unique_ids("feature", ["FEAT-1", "FEAT-1"].into_iter(), &mut issues);
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].code, "SYU-workspace-duplicate-001");
+    }
+
+    #[test]
+    fn validate_duplicate_links_reports_repeated_relationships() {
+        let mut issues = Vec::new();
+        validate_duplicate_links(
+            "requirement",
+            "REQ-1",
+            "linked_features",
+            "feature",
+            &["FEAT-1".to_string(), "FEAT-1".to_string()],
+            &mut issues,
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].code, "SYU-graph-duplicate-001");
+        assert_eq!(issues[0].location.as_deref(), Some("linked_features"));
+        assert!(issues[0].message.contains("linked feature `FEAT-1`"));
+    }
+
+    #[test]
+    fn validate_duplicate_trace_references_reports_exact_entries() {
+        let mut issues = Vec::new();
+        let duplicate = TraceReference {
+            file: PathBuf::from("src/lib.rs"),
+            symbols: vec!["trace_symbol".to_string()],
+            doc_contains: vec!["REQ-1".to_string()],
+        };
+
+        validate_duplicate_trace_references(
+            "REQ-1",
+            TraceRole::RequirementTest,
+            "rust",
+            &[duplicate.clone(), duplicate.clone()],
+            &mut issues,
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].code, "SYU-trace-duplicate-001");
+        assert_eq!(issues[0].location.as_deref(), Some("rust:src/lib.rs"));
+        assert!(issues[0].message.contains("file=`src/lib.rs`"));
+        assert!(issues[0].message.contains("symbols=[`trace_symbol`]"));
+        assert_eq!(
+            describe_trace_reference(&duplicate),
+            "file=`src/lib.rs` symbols=[`trace_symbol`] doc_contains=[`REQ-1`]"
+        );
     }
 
     #[test]

--- a/tests/duplicate_validation.rs
+++ b/tests/duplicate_validation.rs
@@ -1,0 +1,141 @@
+// REQ-CORE-001
+// REQ-CORE-002
+
+use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
+use std::{fs, path::Path, process::Command};
+use tempfile::tempdir;
+
+fn write_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_symbol_trace_coverage: false\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep linked intent explicit\n    product_design_principle: Duplicate graph edges should stay visible.\n    coding_guideline: Keep adjacent links unique per list.\n    linked_policies:\n      - POL-001\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Keep trace evidence distinct\n    summary: Repeated links or trace records should be rejected.\n    description: This fixture duplicates both graph links and trace mappings.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Requirement traces should stay unique\n    description: Duplicate requirement links and tests should fail validation.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n      - POL-001\n    linked_features:\n      - FEAT-001\n      - FEAT-001\n    tests:\n      rust:\n        - file: tests/duplicate_trace.rs\n          symbols:\n            - requirement_trace\n          doc_contains:\n            - duplicate requirement trace\n        - file: tests/duplicate_trace.rs\n          symbols:\n            - requirement_trace\n          doc_contains:\n            - duplicate requirement trace\n",
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Feature traces should stay unique\n    summary: Duplicate implementation records should fail validation.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n      - REQ-001\n    implementations:\n      rust:\n        - file: src/duplicate_trace.rs\n          symbols:\n            - feature_impl\n          doc_contains:\n            - duplicate feature trace\n        - file: src/duplicate_trace.rs\n          symbols:\n            - feature_impl\n          doc_contains:\n            - duplicate feature trace\n",
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("tests/duplicate_trace.rs"),
+        "/// REQ-001\n/// duplicate requirement trace\n#[test]\nfn requirement_trace() {}\n",
+    )
+    .expect("tests");
+
+    fs::write(
+        root.join("src/duplicate_trace.rs"),
+        "/// FEAT-001\n/// duplicate feature trace\npub fn feature_impl() {}\n",
+    )
+    .expect("source");
+}
+
+#[test]
+fn validate_reports_duplicate_relationship_entries() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "duplicate relationships should fail"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-graph-duplicate-001"));
+    assert!(stdout.contains("philosophy `PHIL-001` repeats linked policy `POL-001`"));
+    assert!(stdout.contains("policy `POL-001` repeats linked requirement `REQ-001`"));
+    assert!(stdout.contains("requirement `REQ-001` repeats linked feature `FEAT-001`"));
+    assert!(stdout.contains("feature `FEAT-001` repeats linked requirement `REQ-001`"));
+}
+
+#[test]
+fn validate_reports_duplicate_trace_entries() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("validate should run");
+
+    assert!(!output.status.success(), "duplicate traces should fail");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    let issues = json["issues"]
+        .as_array()
+        .expect("issues should be represented as an array");
+    let trace_duplicates = issues
+        .iter()
+        .filter(|issue| issue["code"] == "SYU-trace-duplicate-001")
+        .collect::<Vec<_>>();
+
+    assert_eq!(trace_duplicates.len(), 2);
+    assert!(trace_duplicates.iter().any(|issue| {
+        issue["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("file=`tests/duplicate_trace.rs`"))
+    }));
+    assert!(trace_duplicates.iter().any(|issue| {
+        issue["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("file=`src/duplicate_trace.rs`"))
+    }));
+
+    let rules = json["referenced_rules"]
+        .as_array()
+        .expect("referenced rules should be represented as an array");
+    assert!(
+        rules
+            .iter()
+            .any(|rule| rule["code"] == "SYU-trace-duplicate-001")
+    );
+}


### PR DESCRIPTION
## Summary
- reject duplicate adjacent-layer IDs inside individual relationship lists
- reject duplicate trace records inside tests and implementations language lists
- update self-hosted rules, requirements, docs, and regression coverage

## Testing
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary

Closes #34