### PR TITLE
feat: warn on non-canonical trace paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ and `validate.require_symbol_trace_coverage` in its root `syu.yaml`.
 - `implemented` items must declare valid tests or implementations
 - requirement test mappings must point to existing files and symbols
 - feature implementation mappings must point to existing files and symbols
+- trace file paths should use canonical repository-relative spelling
 - duplicate trace mappings inside one language list are rejected
 - traced files must mention the owning requirement / feature ID
 - optional `doc_contains` snippets must be present in the traced symbol's

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -202,6 +202,18 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
       real evidence and starts pointing to an aspiration. This rule ensures that
       every declared trace remains grounded in a repository artifact that both
       reviewers and automation can actually inspect.
+- **code**: SYU-trace-file-003
+  - **genre**: trace
+  - **severity**: warning
+  - **title**: Trace file paths should use canonical repository-relative form
+  - **summary**: Portable path spelling keeps checked-in traces easier to review and reuse.
+  - **description**:
+    - |
+      Trace paths become harder to review when they rely on redundant `./` or
+      `..` segments, backslash separators, or other spellings that are not the
+      repository's canonical relative form. This rule warns on path notation
+      drift and suggests the normalized repository-relative path so the spec can
+      stay portable without silently rewriting checked-in YAML.
 - **code**: SYU-trace-unreadable-001
   - **genre**: trace
   - **severity**: error
@@ -586,6 +598,18 @@ rules:
       real evidence and starts pointing to an aspiration. This rule ensures that
       every declared trace remains grounded in a repository artifact that both
       reviewers and automation can actually inspect.
+
+  - code: SYU-trace-file-003
+    genre: trace
+    severity: warning
+    title: Trace file paths should use canonical repository-relative form
+    summary: Portable path spelling keeps checked-in traces easier to review and reuse.
+    description: |
+      Trace paths become harder to review when they rely on redundant `./` or
+      `..` segments, backslash separators, or other spellings that are not the
+      repository's canonical relative form. This rule warns on path notation
+      drift and suggests the normalized repository-relative path so the spec can
+      stay portable without silently rewriting checked-in YAML.
 
   - code: SYU-trace-unreadable-001
     genre: trace

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -78,12 +78,13 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
       today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the file explicitly mentions the
-      owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also reject duplicate trace mappings inside
-      a single language list, support wildcard file ownership, and provide an
-      optional mode that requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement.
+      the file exists, the symbol exists, the trace path uses canonical
+      repository-relative form, the file explicitly mentions the owning ID, and
+      any `doc_contains` snippets are present in the symbol documentation.
+      Validation MUST also reject duplicate trace mappings inside a single
+      language list, support wildcard file ownership, and provide an optional
+      mode that requires every public Rust symbol to belong to some feature and
+      every Rust test to belong to some requirement.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -97,6 +98,8 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - check_command_verifies_requirement_test_traceability_in_all_supported_languages
           - check_command_verifies_feature_implementation_traceability_in_all_supported_languages
+          - check_command_warns_for_non_canonical_relative_trace_paths
+          - check_command_warns_for_backslash_trace_paths
       - **file**: tests/trace_coverage_validation.rs
         - **symbols**:
           - *
@@ -235,12 +238,13 @@ requirements:
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
       today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the file explicitly mentions the
-      owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also reject duplicate trace mappings inside
-      a single language list, support wildcard file ownership, and provide an
-      optional mode that requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement.
+      the file exists, the symbol exists, the trace path uses canonical
+      repository-relative form, the file explicitly mentions the owning ID, and
+      any `doc_contains` snippets are present in the symbol documentation.
+      Validation MUST also reject duplicate trace mappings inside a single
+      language list, support wildcard file ownership, and provide an optional
+      mode that requires every public Rust symbol to belong to some feature and
+      every Rust test to belong to some requirement.
     priority: high
     status: implemented
     linked_policies:
@@ -254,6 +258,8 @@ requirements:
           symbols:
             - check_command_verifies_requirement_test_traceability_in_all_supported_languages
             - check_command_verifies_feature_implementation_traceability_in_all_supported_languages
+            - check_command_warns_for_non_canonical_relative_trace_paths
+            - check_command_warns_for_backslash_trace_paths
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'

--- a/docs/syu/features/validation/validation.yaml
+++ b/docs/syu/features/validation/validation.yaml
@@ -191,6 +191,18 @@ rules:
       every declared trace remains grounded in a repository artifact that both
       reviewers and automation can actually inspect.
 
+  - code: SYU-trace-file-003
+    genre: trace
+    severity: warning
+    title: Trace file paths should use canonical repository-relative form
+    summary: Portable path spelling keeps checked-in traces easier to review and reuse.
+    description: |
+      Trace paths become harder to review when they rely on redundant `./` or
+      `..` segments, backslash separators, or other spellings that are not the
+      repository's canonical relative form. This rule warns on path notation
+      drift and suggests the normalized repository-relative path so the spec can
+      stay portable without silently rewriting checked-in YAML.
+
   - code: SYU-trace-unreadable-001
     genre: trace
     severity: error

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -60,12 +60,13 @@ requirements:
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
       today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the file explicitly mentions the
-      owning ID, and any `doc_contains` snippets are present in the symbol
-      documentation. Validation MUST also reject duplicate trace mappings inside
-      a single language list, support wildcard file ownership, and provide an
-      optional mode that requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement.
+      the file exists, the symbol exists, the trace path uses canonical
+      repository-relative form, the file explicitly mentions the owning ID, and
+      any `doc_contains` snippets are present in the symbol documentation.
+      Validation MUST also reject duplicate trace mappings inside a single
+      language list, support wildcard file ownership, and provide an optional
+      mode that requires every public Rust symbol to belong to some feature and
+      every Rust test to belong to some requirement.
     priority: high
     status: implemented
     linked_policies:
@@ -79,6 +80,8 @@ requirements:
           symbols:
             - check_command_verifies_requirement_test_traceability_in_all_supported_languages
             - check_command_verifies_feature_implementation_traceability_in_all_supported_languages
+            - check_command_warns_for_non_canonical_relative_trace_paths
+            - check_command_warns_for_backslash_trace_paths
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Write,
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use anyhow::Result;
@@ -14,7 +14,7 @@ use serde::Serialize;
 use crate::{
     cli::{CheckArgs, OutputFormat, ValidationGenreFilter, ValidationSeverityFilter},
     config::SyuConfig,
-    coverage::validate_symbol_trace_coverage,
+    coverage::{normalize_relative_path, validate_symbol_trace_coverage},
     inspect::{apply_symbol_doc_fix, inspect_symbol, supports_rich_inspection},
     language::adapter_for_language,
     model::{
@@ -807,6 +807,22 @@ fn validate_duplicate_trace_references(
     }
 }
 
+fn preferred_trace_file_path(file: &Path) -> Option<PathBuf> {
+    let portable = file.to_string_lossy().replace('\\', "/");
+    let normalized = normalize_relative_path(Path::new(&portable));
+
+    if normalized.as_os_str().is_empty()
+        || normalized.is_absolute()
+        || normalized
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+
+    Some(normalized)
+}
+
 fn describe_trace_reference(reference: &TraceReference) -> String {
     let symbols = reference
         .symbols
@@ -1480,7 +1496,33 @@ fn verify_trace_reference(
         return false;
     }
 
-    let path = root.join(&reference.file);
+    let preferred_path = preferred_trace_file_path(&reference.file);
+    if let Some(preferred_path) = preferred_path
+        .as_ref()
+        .filter(|preferred_path| *preferred_path != &reference.file)
+    {
+        issues.push(Issue::warning(
+            "SYU-trace-file-003",
+            subject.clone(),
+            Some(format_reference_location(language, reference)),
+            format!(
+                "Declared {} file path `{}` is not written in canonical repository-relative form; prefer `{}`.",
+                role.label(),
+                reference.file.display(),
+                preferred_path.display()
+            ),
+            Some(format!(
+                "Change the `{language}` {} path for `{owner_id}` to `{}`.",
+                role.relation_name(),
+                preferred_path.display()
+            )),
+        ));
+    }
+
+    let display_path = preferred_path
+        .as_deref()
+        .unwrap_or(reference.file.as_path());
+    let path = root.join(display_path);
     if !path.is_file() {
         issues.push(Issue::error(
             "SYU-trace-file-002",
@@ -1489,11 +1531,11 @@ fn verify_trace_reference(
             format!(
                 "Declared {} file `{}` does not exist.",
                 role.label(),
-                reference.file.display()
+                display_path.display()
             ),
             Some(format!(
                 "Create `{}` or update `{owner_id}` to point to the correct {} file.",
-                reference.file.display(),
+                display_path.display(),
                 role.label()
             )),
         ));
@@ -1508,13 +1550,13 @@ fn verify_trace_reference(
             Some(format_reference_location(language, reference)),
             format!(
                 "File `{}` does not match the `{}` adapter extensions.",
-                reference.file.display(),
+                display_path.display(),
                 adapter.canonical_name()
             ),
             Some(format!(
                 "Use a `{}` file extension or change the declared language for `{}`.",
                 adapter.canonical_name(),
-                reference.file.display()
+                display_path.display()
             )),
         ));
         success = false;
@@ -1530,11 +1572,11 @@ fn verify_trace_reference(
                 format!(
                     "Declared {} file `{}` could not be read: {error}",
                     role.label(),
-                    reference.file.display()
+                    display_path.display()
                 ),
                 Some(format!(
                     "Ensure `{}` is readable before running `syu validate`.",
-                    reference.file.display()
+                    display_path.display()
                 )),
             ));
             return false;
@@ -1549,11 +1591,11 @@ fn verify_trace_reference(
             format!(
                 "Declared {} file `{}` does not mention `{owner_id}`.",
                 role.label(),
-                reference.file.display()
+                display_path.display()
             ),
             Some(format!(
                 "Add `{owner_id}` to `{}` so the {} remains explicitly traceable.",
-                reference.file.display(),
+                display_path.display(),
                 role.label()
             )),
         ));
@@ -1568,7 +1610,7 @@ fn verify_trace_reference(
             format!(
                 "Declared {} file `{}` does not list any symbols to verify.",
                 role.label(),
-                reference.file.display()
+                display_path.display()
             ),
             Some(format!(
                 "Add one or more symbols to the `{language}` mapping for `{owner_id}`."
@@ -1586,7 +1628,7 @@ fn verify_trace_reference(
                 Some(format_reference_location(language, reference)),
                 format!(
                     "Wildcard trace mappings in `{}` cannot use `doc_contains` because they do not point to a single symbol.",
-                    reference.file.display()
+                    display_path.display()
                 ),
                 Some(
                     "Remove `doc_contains` or replace `*` with explicit symbol names for documentation checks."
@@ -1607,7 +1649,7 @@ fn verify_trace_reference(
                 format!(
                     "Declared {} file `{}` contains an empty symbol entry.",
                     role.label(),
-                    reference.file.display()
+                    display_path.display()
                 ),
                 Some(format!(
                     "Remove blank symbol entries from the `{language}` mapping for `{owner_id}`."
@@ -1627,11 +1669,11 @@ fn verify_trace_reference(
                         Some(format_reference_location(language, reference)),
                         format!(
                             "Failed to inspect symbol `{symbol}` in `{}` with the `{language}` inspector: {error}",
-                            reference.file.display()
+                            display_path.display()
                         ),
                         Some(format!(
                             "Fix the parser/runtime configuration for `{language}` or update `{}` so `syu validate` can inspect it.",
-                            reference.file.display()
+                            display_path.display()
                         )),
                     ));
                     success = false;
@@ -1650,11 +1692,11 @@ fn verify_trace_reference(
                 Some(format_reference_location(language, reference)),
                 format!(
                     "Declared symbol `{symbol}` was not found in `{}`.",
-                    reference.file.display()
+                    display_path.display()
                 ),
                 Some(format!(
                     "Add symbol `{symbol}` to `{}` or update the YAML mapping for `{owner_id}`.",
-                    reference.file.display()
+                    display_path.display()
                 )),
             ));
             success = false;
@@ -1676,7 +1718,7 @@ fn verify_trace_reference(
                                 Some(format_reference_location(language, reference)),
                                 format!(
                                     "Documentation for symbol `{symbol}` in `{}` does not include `{snippet}`.",
-                                    reference.file.display()
+                                    display_path.display()
                                 ),
                                 Some(format!(
                                     "Add `{snippet}` to the documentation for `{symbol}` or run `syu validate --fix`."
@@ -1749,10 +1791,10 @@ mod tests {
     use super::{
         FilteredIssueView, IssueFilters, TraceRole, apply_autofix, apply_autofix_for_reference,
         collect_check_result, describe_trace_reference, filter_check_result,
-        format_reference_location, render_text_report, run_check_command, validate_duplicate_links,
-        validate_duplicate_trace_references, validate_feature, validate_non_empty_field,
-        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
-        verify_trace_reference,
+        format_reference_location, preferred_trace_file_path, render_text_report,
+        run_check_command, validate_duplicate_links, validate_duplicate_trace_references,
+        validate_feature, validate_non_empty_field, validate_philosophy, validate_policy,
+        validate_requirement, validate_unique_ids, verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -2470,6 +2512,76 @@ mod tests {
             &mut issues,
         ));
         assert_eq!(issues[0].code, "SYU-trace-file-002");
+    }
+
+    #[test]
+    fn verify_trace_reference_warns_for_non_canonical_relative_paths() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let source = tempdir.path().join("src");
+        fs::create_dir_all(&source).expect("src dir should exist");
+        fs::write(source.join("trace.rs"), "/// REQ-1\npub fn expected() {}\n")
+            .expect("trace file should exist");
+
+        let reference = TraceReference {
+            file: PathBuf::from("./src/../src/trace.rs"),
+            symbols: vec!["expected".to_string()],
+            doc_contains: Vec::new(),
+        };
+        let mut issues = Vec::new();
+        assert!(verify_trace_reference(
+            tempdir.path(),
+            &SyuConfig::default(),
+            "REQ-1",
+            TraceRole::RequirementTest,
+            "rust",
+            &reference,
+            &mut issues,
+        ));
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.code == "SYU-trace-file-003")
+        );
+        assert!(
+            issues
+                .iter()
+                .all(|issue| issue.code != "SYU-trace-file-002")
+        );
+    }
+
+    #[test]
+    fn verify_trace_reference_warns_for_backslash_path_spellings() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let source = tempdir.path().join("src");
+        fs::create_dir_all(&source).expect("src dir should exist");
+        fs::write(source.join("trace.rs"), "/// REQ-1\npub fn expected() {}\n")
+            .expect("trace file should exist");
+
+        let reference = TraceReference {
+            file: PathBuf::from(r"src\trace.rs"),
+            symbols: vec!["expected".to_string()],
+            doc_contains: Vec::new(),
+        };
+        let mut issues = Vec::new();
+        assert!(verify_trace_reference(
+            tempdir.path(),
+            &SyuConfig::default(),
+            "REQ-1",
+            TraceRole::RequirementTest,
+            "rust",
+            &reference,
+            &mut issues,
+        ));
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.code == "SYU-trace-file-003")
+        );
+    }
+
+    #[test]
+    fn preferred_trace_file_path_rejects_paths_that_escape_the_workspace() {
+        assert!(preferred_trace_file_path(Path::new("../trace.rs")).is_none());
     }
 
     #[test]

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -343,13 +343,15 @@ fn collect_rust_files_recursive(directory: &Path, files: &mut Vec<PathBuf>) -> s
     Ok(())
 }
 
-fn normalize_relative_path(path: &Path) -> PathBuf {
+pub(crate) fn normalize_relative_path(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
-                normalized.pop();
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
             }
             Component::Normal(segment) => normalized.push(segment),
             Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
@@ -657,6 +659,10 @@ mod tests {
         assert_eq!(
             normalize_relative_path(Path::new("/tmp/coverage.rs")),
             PathBuf::from("/tmp/coverage.rs")
+        );
+        assert_eq!(
+            normalize_relative_path(Path::new("../spec/trace.rs")),
+            PathBuf::from("../spec/trace.rs")
         );
     }
 }

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -1,10 +1,69 @@
 use assert_cmd::cargo::CommandCargoExt;
-use std::{path::PathBuf, process::Command};
+use std::{fs, path::Path, path::PathBuf, process::Command};
+use tempfile::tempdir;
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/workspaces")
         .join(name)
+}
+
+fn write_trace_path_workspace(root: &Path, trace_path: &str) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Clear repository paths\n    product_design_principle: Keep trace paths portable.\n    coding_guideline: Prefer canonical repository-relative file paths.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Keep traces portable\n    summary: Trace file paths should stay reviewable across environments.\n    description: Checked-in trace paths should use one portable repository-relative form.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Verify canonical trace paths\n    description: Requirement traces should stay portable across reviewers and CI.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      rust:\n        - file: {trace_path}\n          symbols:\n            - trace_symbol\n",
+        ),
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Verify canonical trace paths\n    summary: Feature implementations should keep portable trace paths.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      rust:\n        - file: src/trace.rs\n          symbols:\n            - trace_symbol\n",
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("src/trace.rs"),
+        "// REQ-001\n// FEAT-001\npub fn trace_symbol() {}\n",
+    )
+    .expect("trace source");
 }
 
 #[test]
@@ -109,4 +168,54 @@ fn check_alias_still_invokes_validate() {
 
     assert!(output.status.success());
     assert!(String::from_utf8_lossy(&output.stdout).contains("syu validate passed"));
+}
+
+#[test]
+// REQ-CORE-002
+fn check_command_warns_for_non_canonical_relative_trace_paths() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_trace_path_workspace(tempdir.path(), "./src/../src/trace.rs");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-trace-file-003"));
+    assert!(stdout.contains("src/trace.rs"));
+}
+
+#[test]
+// REQ-CORE-002
+fn check_command_warns_for_backslash_trace_paths() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_trace_path_workspace(tempdir.path(), "src\\\\trace.rs");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-trace-file-003"));
+    assert!(stdout.contains("src/trace.rs"));
 }


### PR DESCRIPTION
## Summary
- warn when trace file paths are not written in canonical repository-relative form
- normalize portable trace path spellings during verification so review-friendly warnings do not become false negatives
- document the new trace path rule and add unit plus CLI coverage for relative and backslash path cases

## Testing
- cargo run --quiet -- validate target/issue36-manual-py
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary

Closes #36