### PR TITLE
feat: make reciprocal links configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ spec:
 validate:
   default_fix: false
   allow_planned: true
+  require_non_orphaned_items: true
+  require_reciprocal_links: true
+  require_symbol_trace_coverage: false
 runtimes:
   python:
     command: auto
@@ -193,14 +196,16 @@ Key behaviors:
 - `validate.default_fix` enables conservative autofix by default
 - `validate.allow_planned` controls whether `planned` requirements and features are allowed at all
 - `validate.require_non_orphaned_items` turns isolated layered definitions into validation errors
+- `validate.require_reciprocal_links` keeps adjacent-layer backlinks mandatory by default while still allowing phased migration when disabled
 - `validate.require_symbol_trace_coverage` opt-in checks that public Rust symbols belong to features and tests belong to requirements
 - `runtimes.*.command` can be set to `auto` or an explicit executable name/path
 
 The self-hosted repository keeps a structured reference for supported config
 fields under [`docs/syu/config/`](docs/syu/config).
 
-The `syu` repository itself enables both `validate.require_non_orphaned_items`
-and `validate.require_symbol_trace_coverage` in its root `syu.yaml`.
+The `syu` repository itself enables `validate.require_non_orphaned_items`,
+`validate.require_reciprocal_links`, and
+`validate.require_symbol_trace_coverage` in its root `syu.yaml`.
 
 ## Traceability rules
 

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -53,6 +53,16 @@ description: "Generated reference for docs/syu/config/validate.yaml"
     - |
       This keeps the adjacent-layer graph deliberate by requiring every item to
       stay connected to at least one neighboring layer.
+- **key**: validate.require_reciprocal_links
+  - **type**: boolean
+  - **default**: True
+  - **summary**: Requires adjacent-layer links to be confirmed from both sides.
+  - **description**:
+    - |
+      This keeps navigation explainable by making philosophy, policy,
+      requirement, and feature relationships agree in both directions.
+      Repositories doing a gradual migration can temporarily set it to `false`
+      while still keeping broken-reference validation enabled.
 - **key**: validate.require_symbol_trace_coverage
   - **type**: boolean
   - **default**: False
@@ -97,6 +107,15 @@ items:
     description: |
       This keeps the adjacent-layer graph deliberate by requiring every item to
       stay connected to at least one neighboring layer.
+  - key: validate.require_reciprocal_links
+    type: boolean
+    default: true
+    summary: Requires adjacent-layer links to be confirmed from both sides.
+    description: |
+      This keeps navigation explainable by making philosophy, policy,
+      requirement, and feature relationships agree in both directions.
+      Repositories doing a gradual migration can temporarily set it to `false`
+      while still keeping broken-reference validation enabled.
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false

--- a/docs/generated/site-spec/features/cli/check.md
+++ b/docs/generated/site-spec/features/cli/check.md
@@ -60,6 +60,7 @@ description: "Generated reference for docs/syu/features/cli/check.yaml"
         - **symbols**:
           - FEAT-CHECK-001
           - require_non_orphaned_items
+          - require_reciprocal_links
           - require_symbol_trace_coverage
       - **file**: docs/syu/features/validation/validation.yaml
         - **symbols**:
@@ -117,6 +118,7 @@ features:
           symbols:
             - FEAT-CHECK-001
             - require_non_orphaned_items
+            - require_reciprocal_links
             - require_symbol_trace_coverage
         - file: docs/syu/features/validation/validation.yaml
           symbols:

--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -52,6 +52,7 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
           - validate.default_fix
           - validate.allow_planned
           - validate.require_non_orphaned_items
+          - validate.require_reciprocal_links
           - validate.require_symbol_trace_coverage
           - runtimes.python.command
 - **id**: FEAT-DOCS-002
@@ -124,6 +125,7 @@ features:
             - validate.default_fix
             - validate.allow_planned
             - validate.require_non_orphaned_items
+            - validate.require_reciprocal_links
             - validate.require_symbol_trace_coverage
             - runtimes.python.command
 

--- a/docs/generated/site-spec/requirements/core/repository.md
+++ b/docs/generated/site-spec/requirements/core/repository.md
@@ -25,7 +25,8 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
       linting, tests, workflow linting, pre-commit / pre-push hooks, and
       self-validation so `syu`'s own promises stay continuously checkable. The
       repository MUST also check in a root `syu.yaml` that enables non-orphaned
-      validation and strict symbol/test ownership for self-hosting.
+      validation, reciprocal-link validation, and strict symbol/test ownership
+      for self-hosting.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -194,7 +195,8 @@ requirements:
       linting, tests, workflow linting, pre-commit / pre-push hooks, and
       self-validation so `syu`'s own promises stay continuously checkable. The
       repository MUST also check in a root `syu.yaml` that enables non-orphaned
-      validation and strict symbol/test ownership for self-hosting.
+      validation, reciprocal-link validation, and strict symbol/test ownership
+      for self-hosting.
     priority: high
     status: implemented
     linked_policies:

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -23,16 +23,18 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
     - |
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
-      references, verify reciprocal links across the adjacent-layer graph,
-      reject duplicate adjacent-layer IDs inside a single relationship list,
-      report isolated definitions by default, enforce `planned` /
+      references, verify reciprocal links across the adjacent-layer graph by
+      default, reject duplicate adjacent-layer IDs inside a single relationship
+      list, report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, warn
       when linked requirements and features drift apart semantically on delivery
       state, and surface rule codes with human-readable titles and explanations
       in validation output. It MUST also support optional filtered views by
       severity, rule genre, and exact rule code for both text and JSON output
-      without changing the underlying validation result. `check` MAY remain as
-      a compatibility alias, but `validate` is the canonical command name.
+      without changing the underlying validation result, and `syu.yaml` MUST be
+      able to disable reciprocal-link enforcement without disabling missing-
+      reference validation. `check` MAY remain as a compatibility alias, but
+      `validate` is the canonical command name.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -55,6 +57,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - *
       - **file**: tests/orphan_validation.rs
+        - **symbols**:
+          - *
+      - **file**: tests/reciprocal_validation.rs
         - **symbols**:
           - *
       - **file**: src/command/check.rs
@@ -185,16 +190,18 @@ requirements:
     description: |
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
-      references, verify reciprocal links across the adjacent-layer graph,
-      reject duplicate adjacent-layer IDs inside a single relationship list,
-      report isolated definitions by default, enforce `planned` /
+      references, verify reciprocal links across the adjacent-layer graph by
+      default, reject duplicate adjacent-layer IDs inside a single relationship
+      list, report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, warn
       when linked requirements and features drift apart semantically on delivery
       state, and surface rule codes with human-readable titles and explanations
       in validation output. It MUST also support optional filtered views by
       severity, rule genre, and exact rule code for both text and JSON output
-      without changing the underlying validation result. `check` MAY remain as
-      a compatibility alias, but `validate` is the canonical command name.
+      without changing the underlying validation result, and `syu.yaml` MUST be
+      able to disable reciprocal-link enforcement without disabling missing-
+      reference validation. `check` MAY remain as a compatibility alias, but
+      `validate` is the canonical command name.
     priority: high
     status: implemented
     linked_policies:
@@ -217,6 +224,9 @@ requirements:
           symbols:
             - '*'
         - file: tests/orphan_validation.rs
+          symbols:
+            - '*'
+        - file: tests/reciprocal_validation.rs
           symbols:
             - '*'
         - file: src/command/check.rs

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -25,6 +25,7 @@ validate:
   default_fix: false
   allow_planned: true
   require_non_orphaned_items: true
+  require_reciprocal_links: true
   require_symbol_trace_coverage: false
 runtimes:
   python:
@@ -73,6 +74,17 @@ When `true`, philosophy, policy, requirement, and feature entries must each
 connect to at least one adjacent layer. This is on by default because isolated
 definitions usually mean the specification has drifted away from the repository.
 
+### `validate.require_reciprocal_links`
+
+When `true`, adjacent-layer relationships must be confirmed from both sides.
+
+- `true`: `SYU-graph-reciprocal-001` remains an error
+- `false`: missing backlinks stop failing validation, but broken references still do
+
+Keep this enabled for steady-state self-hosting. Turning it off is mainly useful
+when a repository is migrating an existing spec graph and wants to phase in
+backlinks after the forward links are already trustworthy.
+
 ### `validate.require_symbol_trace_coverage`
 
 When `true`, `syu` scans Rust source and test files to confirm that every public
@@ -107,7 +119,8 @@ For autofix behavior, CLI flags override config:
 `validate.allow_planned` is configuration-only. There is no CLI flag to
 override it.
 
-`validate.require_non_orphaned_items` and
+`validate.require_non_orphaned_items`,
+`validate.require_reciprocal_links`, and
 `validate.require_symbol_trace_coverage` are also configuration-only.
 
 ## Wildcard file ownership
@@ -134,6 +147,8 @@ want strict ownership checks without enumerating every public symbol by hand.
   forbid backlog items
 - leave `validate.require_non_orphaned_items: true` unless you are doing a
   deliberate migration
+- leave `validate.require_reciprocal_links: true` unless you are phasing in
+  backlinks after stabilizing the forward graph
 - turn on `validate.require_symbol_trace_coverage: true` once the repository
   wants public APIs and tests to remain fully owned by the spec
 - treat runtime overrides as environment-specific, not project-specific, unless

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -29,6 +29,15 @@ items:
     description: |
       This keeps the adjacent-layer graph deliberate by requiring every item to
       stay connected to at least one neighboring layer.
+  - key: validate.require_reciprocal_links
+    type: boolean
+    default: true
+    summary: Requires adjacent-layer links to be confirmed from both sides.
+    description: |
+      This keeps navigation explainable by making philosophy, policy,
+      requirement, and feature relationships agree in both directions.
+      Repositories doing a gradual migration can temporarily set it to `false`
+      while still keeping broken-reference validation enabled.
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false

--- a/docs/syu/features/cli/check.yaml
+++ b/docs/syu/features/cli/check.yaml
@@ -45,6 +45,7 @@ features:
           symbols:
             - FEAT-CHECK-001
             - require_non_orphaned_items
+            - require_reciprocal_links
             - require_symbol_trace_coverage
         - file: docs/syu/features/validation/validation.yaml
           symbols:

--- a/docs/syu/features/documentation/docs.yaml
+++ b/docs/syu/features/documentation/docs.yaml
@@ -37,6 +37,7 @@ features:
             - validate.default_fix
             - validate.allow_planned
             - validate.require_non_orphaned_items
+            - validate.require_reciprocal_links
             - validate.require_symbol_trace_coverage
             - runtimes.python.command
 

--- a/docs/syu/requirements/core/repository.yaml
+++ b/docs/syu/requirements/core/repository.yaml
@@ -8,7 +8,8 @@ requirements:
       linting, tests, workflow linting, pre-commit / pre-push hooks, and
       self-validation so `syu`'s own promises stay continuously checkable. The
       repository MUST also check in a root `syu.yaml` that enables non-orphaned
-      validation and strict symbol/test ownership for self-hosting.
+      validation, reciprocal-link validation, and strict symbol/test ownership
+      for self-hosting.
     priority: high
     status: implemented
     linked_policies:

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -6,16 +6,18 @@ requirements:
     description: |
       The `validate` command MUST load philosophy, policy, requirement, and
       feature YAML definitions, validate required fields, reject broken
-      references, verify reciprocal links across the adjacent-layer graph,
-      reject duplicate adjacent-layer IDs inside a single relationship list,
-      report isolated definitions by default, enforce `planned` /
+      references, verify reciprocal links across the adjacent-layer graph by
+      default, reject duplicate adjacent-layer IDs inside a single relationship
+      list, report isolated definitions by default, enforce `planned` /
       `implemented` delivery-state rules for requirements and features, warn
       when linked requirements and features drift apart semantically on delivery
       state, and surface rule codes with human-readable titles and explanations
       in validation output. It MUST also support optional filtered views by
       severity, rule genre, and exact rule code for both text and JSON output
-      without changing the underlying validation result. `check` MAY remain as
-      a compatibility alias, but `validate` is the canonical command name.
+      without changing the underlying validation result, and `syu.yaml` MUST be
+      able to disable reciprocal-link enforcement without disabling missing-
+      reference validation. `check` MAY remain as a compatibility alias, but
+      `validate` is the canonical command name.
     priority: high
     status: implemented
     linked_policies:
@@ -38,6 +40,9 @@ requirements:
           symbols:
             - '*'
         - file: tests/orphan_validation.rs
+          symbols:
+            - '*'
+        - file: tests/reciprocal_validation.rs
           symbols:
             - '*'
         - file: src/command/check.rs

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -300,7 +300,7 @@ fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
         .collect();
 
     for philosophy in &workspace.philosophies {
-        validate_philosophy(philosophy, &policies_by_id, &mut issues);
+        validate_philosophy(philosophy, &policies_by_id, &workspace.config, &mut issues);
     }
 
     for policy in &workspace.policies {
@@ -308,6 +308,7 @@ fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
             policy,
             &philosophies_by_id,
             &requirements_by_id,
+            &workspace.config,
             &mut issues,
         );
     }
@@ -907,6 +908,7 @@ fn describe_trace_reference(reference: &TraceReference) -> String {
 fn validate_philosophy(
     philosophy: &Philosophy,
     policies_by_id: &HashMap<&str, &Policy>,
+    config: &SyuConfig,
     issues: &mut Vec<Issue>,
 ) {
     validate_non_empty_field("philosophy", "id", &philosophy.id, issues);
@@ -948,10 +950,11 @@ fn validate_philosophy(
     for policy_id in &philosophy.linked_policies {
         match policies_by_id.get(policy_id.as_str()) {
             Some(policy) => {
-                if !policy
-                    .linked_philosophies
-                    .iter()
-                    .any(|item| item == &philosophy.id)
+                if config.validate.require_reciprocal_links
+                    && !policy
+                        .linked_philosophies
+                        .iter()
+                        .any(|item| item == &philosophy.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -986,6 +989,7 @@ fn validate_policy(
     policy: &Policy,
     philosophies_by_id: &HashMap<&str, &Philosophy>,
     requirements_by_id: &HashMap<&str, &Requirement>,
+    config: &SyuConfig,
     issues: &mut Vec<Issue>,
 ) {
     validate_non_empty_field("policy", "id", &policy.id, issues);
@@ -1038,10 +1042,11 @@ fn validate_policy(
     for philosophy_id in &policy.linked_philosophies {
         match philosophies_by_id.get(philosophy_id.as_str()) {
             Some(philosophy) => {
-                if !philosophy
-                    .linked_policies
-                    .iter()
-                    .any(|item| item == &policy.id)
+                if config.validate.require_reciprocal_links
+                    && !philosophy
+                        .linked_policies
+                        .iter()
+                        .any(|item| item == &policy.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -1074,10 +1079,11 @@ fn validate_policy(
     for requirement_id in &policy.linked_requirements {
         match requirements_by_id.get(requirement_id.as_str()) {
             Some(requirement) => {
-                if !requirement
-                    .linked_policies
-                    .iter()
-                    .any(|item| item == &policy.id)
+                if config.validate.require_reciprocal_links
+                    && !requirement
+                        .linked_policies
+                        .iter()
+                        .any(|item| item == &policy.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -1180,10 +1186,11 @@ fn validate_requirement(
     for policy_id in &requirement.linked_policies {
         match policies_by_id.get(policy_id.as_str()) {
             Some(policy) => {
-                if !policy
-                    .linked_requirements
-                    .iter()
-                    .any(|item| item == &requirement.id)
+                if config.validate.require_reciprocal_links
+                    && !policy
+                        .linked_requirements
+                        .iter()
+                        .any(|item| item == &requirement.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -1216,10 +1223,11 @@ fn validate_requirement(
     for feature_id in &requirement.linked_features {
         match features_by_id.get(feature_id.as_str()) {
             Some(feature) => {
-                if !feature
-                    .linked_requirements
-                    .iter()
-                    .any(|item| item == &requirement.id)
+                if config.validate.require_reciprocal_links
+                    && !feature
+                        .linked_requirements
+                        .iter()
+                        .any(|item| item == &requirement.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -1321,10 +1329,11 @@ fn validate_feature(
     for requirement_id in &feature.linked_requirements {
         match requirements_by_id.get(requirement_id.as_str()) {
             Some(requirement) => {
-                if !requirement
-                    .linked_features
-                    .iter()
-                    .any(|item| item == &feature.id)
+                if config.validate.require_reciprocal_links
+                    && !requirement
+                        .linked_features
+                        .iter()
+                        .any(|item| item == &feature.id)
                 {
                     issues.push(Issue::error(
                         "SYU-graph-reciprocal-001",
@@ -2185,7 +2194,7 @@ mod tests {
         entry.linked_policies.push("POL-1".to_string());
 
         let mut issues = Vec::new();
-        validate_philosophy(&entry, &HashMap::new(), &mut issues);
+        validate_philosophy(&entry, &HashMap::new(), &SyuConfig::default(), &mut issues);
 
         assert!(
             issues
@@ -2203,7 +2212,7 @@ mod tests {
     fn validate_philosophy_warns_when_unlinked() {
         let entry = philosophy("PHIL-1");
         let mut issues = Vec::new();
-        validate_philosophy(&entry, &HashMap::new(), &mut issues);
+        validate_philosophy(&entry, &HashMap::new(), &SyuConfig::default(), &mut issues);
         assert!(
             issues
                 .iter()
@@ -2223,7 +2232,7 @@ mod tests {
         policy_map.insert("POL-1", &linked_policy);
 
         let mut issues = Vec::new();
-        validate_philosophy(&entry, &policy_map, &mut issues);
+        validate_philosophy(&entry, &policy_map, &SyuConfig::default(), &mut issues);
         assert!(
             issues
                 .iter()
@@ -2247,7 +2256,13 @@ mod tests {
         requirements.insert("REQ-1", &referenced_requirement);
 
         let mut issues = Vec::new();
-        validate_policy(&entry, &philosophies, &requirements, &mut issues);
+        validate_policy(
+            &entry,
+            &philosophies,
+            &requirements,
+            &SyuConfig::default(),
+            &mut issues,
+        );
 
         assert!(
             issues
@@ -2267,7 +2282,13 @@ mod tests {
     fn validate_policy_warns_when_unlinked() {
         let entry = policy("POL-1");
         let mut issues = Vec::new();
-        validate_policy(&entry, &HashMap::new(), &HashMap::new(), &mut issues);
+        validate_policy(
+            &entry,
+            &HashMap::new(),
+            &HashMap::new(),
+            &SyuConfig::default(),
+            &mut issues,
+        );
         assert!(
             issues
                 .iter()
@@ -2284,7 +2305,13 @@ mod tests {
         entry.linked_requirements.push("REQ-MISSING".to_string());
 
         let mut issues = Vec::new();
-        validate_policy(&entry, &HashMap::new(), &HashMap::new(), &mut issues);
+        validate_policy(
+            &entry,
+            &HashMap::new(),
+            &HashMap::new(),
+            &SyuConfig::default(),
+            &mut issues,
+        );
 
         assert!(issues.iter().any(|issue| {
             issue.code == "SYU-graph-reference-001"

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ pub struct ValidateConfig {
     pub allow_planned: bool,
     #[serde(default = "default_require_non_orphaned_items")]
     pub require_non_orphaned_items: bool,
+    #[serde(default = "default_require_reciprocal_links")]
+    pub require_reciprocal_links: bool,
     #[serde(default)]
     pub require_symbol_trace_coverage: bool,
 }
@@ -75,6 +77,7 @@ impl Default for ValidateConfig {
             default_fix: false,
             allow_planned: default_allow_planned(),
             require_non_orphaned_items: default_require_non_orphaned_items(),
+            require_reciprocal_links: default_require_reciprocal_links(),
             require_symbol_trace_coverage: false,
         }
     }
@@ -143,6 +146,10 @@ fn default_allow_planned() -> bool {
 }
 
 fn default_require_non_orphaned_items() -> bool {
+    true
+}
+
+fn default_require_reciprocal_links() -> bool {
     true
 }
 
@@ -223,6 +230,7 @@ mod tests {
         assert_eq!(loaded.config.runtimes.python.command, "auto");
         assert!(loaded.config.validate.allow_planned);
         assert!(loaded.config.validate.require_non_orphaned_items);
+        assert!(loaded.config.validate.require_reciprocal_links);
         assert!(!loaded.config.validate.require_symbol_trace_coverage);
     }
 
@@ -232,7 +240,7 @@ mod tests {
         fs::write(
             tempdir.path().join(CONFIG_FILE_NAME),
             format!(
-                "version: {version}\nspec:\n  root: spec/contracts\nvalidate:\n  default_fix: true\n  allow_planned: false\n  require_non_orphaned_items: false\n  require_symbol_trace_coverage: true\nruntimes:\n  python:\n    command: python3\n  node:\n    command: node\n",
+                "version: {version}\nspec:\n  root: spec/contracts\nvalidate:\n  default_fix: true\n  allow_planned: false\n  require_non_orphaned_items: false\n  require_reciprocal_links: false\n  require_symbol_trace_coverage: true\nruntimes:\n  python:\n    command: python3\n  node:\n    command: node\n",
                 version = current_cli_version()
             ),
         )
@@ -247,6 +255,7 @@ mod tests {
         assert!(loaded.config.validate.default_fix);
         assert!(!loaded.config.validate.allow_planned);
         assert!(!loaded.config.validate.require_non_orphaned_items);
+        assert!(!loaded.config.validate.require_reciprocal_links);
         assert!(loaded.config.validate.require_symbol_trace_coverage);
         assert_eq!(loaded.config.runtimes.python.command, "python3");
     }
@@ -258,6 +267,7 @@ mod tests {
         assert!(rendered.contains("default_fix: false"));
         assert!(rendered.contains("allow_planned: true"));
         assert!(rendered.contains("require_non_orphaned_items: true"));
+        assert!(rendered.contains("require_reciprocal_links: true"));
         assert!(rendered.contains("require_symbol_trace_coverage: false"));
         assert!(rendered.contains("command: auto"));
     }

--- a/syu.yaml
+++ b/syu.yaml
@@ -6,6 +6,7 @@ validate:
   default_fix: false
   allow_planned: false
   require_non_orphaned_items: true
+  require_reciprocal_links: true
   require_symbol_trace_coverage: true
 runtimes:
   python:

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -33,6 +33,7 @@ fn init_command_bootstraps_a_workspace_that_validate_accepts() {
         .expect("feature should exist");
 
     assert!(config.contains(env!("CARGO_PKG_VERSION")));
+    assert!(config.contains("require_reciprocal_links: true"));
     assert!(requirement.contains("status: planned"));
     assert!(feature.contains("status: planned"));
 

--- a/tests/reciprocal_validation.rs
+++ b/tests/reciprocal_validation.rs
@@ -1,0 +1,133 @@
+// REQ-CORE-001
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::{fs, path::Path, process::Command};
+use tempfile::tempdir;
+
+fn write_workspace(root: &Path, require_reciprocal_links: bool, broken_reference: bool) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_reciprocal_links: {require_reciprocal_links}\n  require_symbol_trace_coverage: false\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+            require_reciprocal_links = if require_reciprocal_links {
+                "true"
+            } else {
+                "false"
+            },
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep graph intent deliberate\n    product_design_principle: Forward links should stay reviewable.\n    coding_guideline: Tighten reciprocity after migration when needed.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    let linked_requirement = if broken_reference {
+        "REQ-MISSING"
+    } else {
+        "REQ-001"
+    };
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Let repositories phase in reciprocity\n    summary: Missing backlinks may be temporary during migration.\n    description: This fixture keeps reference validation active while reciprocal enforcement is configurable.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - {linked_requirement}\n",
+        ),
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Keep requirement links explicit\n    description: This fixture intentionally omits a backlink to the policy.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features:\n      - FEAT-001\n    tests: {}\n",
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Keep feature links explicit\n    summary: This fixture keeps feature reciprocity intact.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {}\n",
+    )
+    .expect("feature");
+}
+
+#[test]
+fn validate_rejects_missing_reciprocal_links_by_default() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path(), true, false);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("SYU-graph-reciprocal-001"));
+}
+
+#[test]
+fn validate_allows_missing_reciprocal_links_when_disabled_in_config() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path(), false, false);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("syu validate passed"));
+    assert!(!stdout.contains("SYU-graph-reciprocal-001"));
+}
+
+#[test]
+fn validate_still_reports_missing_references_when_reciprocal_links_disabled() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path(), false, true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-graph-reference-001"));
+    assert!(!stdout.contains("SYU-graph-reciprocal-001"));
+}

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -45,6 +45,7 @@ fn repository_declares_precommit_and_quality_gates() {
 
     assert!(repo_config.contains("FEAT-CHECK-001"));
     assert!(repo_config.contains("require_non_orphaned_items: true"));
+    assert!(repo_config.contains("require_reciprocal_links: true"));
     assert!(repo_config.contains("require_symbol_trace_coverage: true"));
 }
 


### PR DESCRIPTION
## Summary
- add `validate.require_reciprocal_links` to `syu.yaml` with a default of `true`
- skip `SYU-graph-reciprocal-001` when the config is disabled while keeping missing-reference validation active
- document the new config surface and add CLI/integration coverage for the migration workflow

## Testing
- cargo test --lib --test reciprocal_validation --test init_command --test orphan_validation
- ./target/debug/syu validate target/issue43-manual
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary </dev/null>

Closes #43