### PR TITLE
docs: publish release-hosted installer entrypoint

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -106,6 +106,11 @@ jobs:
             "${RELEASE_TAG}__${{ matrix.target }}" \
             "release-artifacts/${archive_name}"
 
+      - name: Include release installer
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: cp scripts/install-syu.sh release-artifacts/install-syu.sh
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -34,34 +34,35 @@ See the detailed guides:
 - [`docs/guide/configuration.md`](docs/guide/configuration.md)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
-## Install from GitHub Packages
+## Install from published releases
 
-`syu` publishes repository-scoped GHCR packages under `ghcr.io/ugoite/syu` and
-falls back to matching GitHub release assets if anonymous package pulls are not
-available yet.
+`syu` publishes a release-hosted installer entrypoint and repository-scoped
+GHCR packages under `ghcr.io/ugoite/syu`. Download the installer from the
+current CLI release; the script prefers the matching package artifact and falls
+back to GitHub release assets if anonymous package pulls are not available yet.
 
-Latest published package for your platform:
+Current installer entrypoint:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | bash
+curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | bash
 ```
 
 Pin a specific release track:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=alpha bash
+curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash
 ```
 
 Install to a custom directory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_INSTALL_DIR=$HOME/bin bash
+curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_INSTALL_DIR=$HOME/bin bash
 ```
 
 Install a specific prerelease:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.7 bash
+curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.7 bash
 ```
 
 ## Quick start

--- a/docs/generated/site-spec/features/repository/install.md
+++ b/docs/generated/site-spec/features/repository/install.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/repository/install.yaml"
 
 - **id**: FEAT-INSTALL-001
   - **title**: Release installer
-  - **summary**: Install the matching packaged binary with one shell command and a release-asset fallback.
+  - **summary**: Install the matching packaged binary from a release-hosted one-line entrypoint that prefers GHCR packages and falls back to GitHub release assets.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-008
@@ -46,7 +46,7 @@ version: 1
 features:
   - id: FEAT-INSTALL-001
     title: Release installer
-    summary: Install the matching packaged binary with one shell command and a release-asset fallback.
+    summary: Install the matching packaged binary from a release-hosted one-line entrypoint that prefers GHCR packages and falls back to GitHub release assets.
     status: implemented
     linked_requirements:
       - REQ-CORE-008

--- a/docs/generated/site-spec/requirements/core/repository.md
+++ b/docs/generated/site-spec/requirements/core/repository.md
@@ -63,8 +63,9 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
       PRs from `main`, keeps `main` releaseable under GitHub Flow, publishes
       GitHub release notes without a committed changelog file, generates alpha,
       beta, and stable release notes against the previous tag in the same track,
-      builds installable artifacts for supported platforms, and publishes
-      install packages to GitHub Packages / GHCR.
+      builds installable artifacts for supported platforms, publishes the
+      one-line installer as a GitHub release asset, and publishes install
+      packages to GitHub Packages / GHCR.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -80,11 +81,11 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
   - **title**: Provide a one-line installer for package artifacts
   - **description**:
     - |
-      The repository MUST ship an installer script that resolves the current
-      platform, prefers the matching package artifact from GitHub Packages /
-      GHCR, falls back to GitHub release assets when package download is not
-      available, defaults to `ugoite/syu`, and installs the binary into a
-      user-controlled location.
+      The repository MUST ship a release-hosted installer script that resolves
+      the current platform, prefers the matching package artifact from GitHub
+      Packages / GHCR, falls back to GitHub release assets when package
+      download is not available, defaults to `ugoite/syu`, and installs the
+      binary into a user-controlled location.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -230,8 +231,9 @@ requirements:
       PRs from `main`, keeps `main` releaseable under GitHub Flow, publishes
       GitHub release notes without a committed changelog file, generates alpha,
       beta, and stable release notes against the previous tag in the same track,
-      builds installable artifacts for supported platforms, and publishes
-      install packages to GitHub Packages / GHCR.
+      builds installable artifacts for supported platforms, publishes the
+      one-line installer as a GitHub release asset, and publishes install
+      packages to GitHub Packages / GHCR.
     priority: high
     status: implemented
     linked_policies:
@@ -246,11 +248,11 @@ requirements:
   - id: REQ-CORE-008
     title: Provide a one-line installer for package artifacts
     description: |
-      The repository MUST ship an installer script that resolves the current
-      platform, prefers the matching package artifact from GitHub Packages /
-      GHCR, falls back to GitHub release assets when package download is not
-      available, defaults to `ugoite/syu`, and installs the binary into a
-      user-controlled location.
+      The repository MUST ship a release-hosted installer script that resolves
+      the current platform, prefers the matching package artifact from GitHub
+      Packages / GHCR, falls back to GitHub release assets when package
+      download is not available, defaults to `ugoite/syu`, and installs the
+      binary into a user-controlled location.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/syu/features/repository/install.yaml
+++ b/docs/syu/features/repository/install.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-INSTALL-001
     title: Release installer
-    summary: Install the matching packaged binary with one shell command and a release-asset fallback.
+    summary: Install the matching packaged binary from a release-hosted one-line entrypoint that prefers GHCR packages and falls back to GitHub release assets.
     status: implemented
     linked_requirements:
       - REQ-CORE-008

--- a/docs/syu/requirements/core/repository.yaml
+++ b/docs/syu/requirements/core/repository.yaml
@@ -44,8 +44,9 @@ requirements:
       PRs from `main`, keeps `main` releaseable under GitHub Flow, publishes
       GitHub release notes without a committed changelog file, generates alpha,
       beta, and stable release notes against the previous tag in the same track,
-      builds installable artifacts for supported platforms, and publishes
-      install packages to GitHub Packages / GHCR.
+      builds installable artifacts for supported platforms, publishes the
+      one-line installer as a GitHub release asset, and publishes install
+      packages to GitHub Packages / GHCR.
     priority: high
     status: implemented
     linked_policies:
@@ -60,11 +61,11 @@ requirements:
   - id: REQ-CORE-008
     title: Provide a one-line installer for package artifacts
     description: |
-      The repository MUST ship an installer script that resolves the current
-      platform, prefers the matching package artifact from GitHub Packages /
-      GHCR, falls back to GitHub release assets when package download is not
-      available, defaults to `ugoite/syu`, and installs the binary into a
-      user-controlled location.
+      The repository MUST ship a release-hosted installer script that resolves
+      the current platform, prefers the matching package artifact from GitHub
+      Packages / GHCR, falls back to GitHub release assets when package
+      download is not available, defaults to `ugoite/syu`, and installs the
+      binary into a user-controlled location.
     priority: medium
     status: implemented
     linked_policies:

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -91,6 +91,7 @@ fn repository_declares_release_automation() {
     assert!(release_artifacts.contains("x86_64-pc-windows-msvc"));
     assert!(release_artifacts.contains("PACKAGE_REPOSITORY"));
     assert!(release_artifacts.contains("publish-package.sh"));
+    assert!(release_artifacts.contains("install-syu.sh"));
     assert!(release_artifacts.contains("release-notes:"));
     assert!(release_artifacts.contains("release-track-notes.sh"));
 
@@ -132,6 +133,7 @@ fn repository_declares_release_automation() {
 #[test]
 // REQ-CORE-008
 fn repository_declares_installer_contract() {
+    let current_version = env!("CARGO_PKG_VERSION");
     let installer = read_file("scripts/install-syu.sh");
     let installer_smoke = read_file("scripts/ci/installer-smoke.sh");
     let mock_registry = read_file("scripts/ci/mock_package_registry.py");
@@ -157,7 +159,11 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("install-syu.sh"));
     assert!(readme.contains("ugoite/syu"));
     assert!(readme.contains("SYU_VERSION"));
+    assert!(readme.contains(&format!(
+        "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
+    )));
     assert!(readme.contains("GitHub Packages"));
+    assert!(!readme.contains("raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- publish `scripts/install-syu.sh` as a GitHub release asset
- update README install docs to use the release-hosted installer URL
- align self-hosted spec text and repository quality assertions

## Testing
- `scripts/ci/quality-gates.sh`
- `scripts/ci/coverage.sh summary </dev/null>`

Closes #47