### PR TITLE
chore: extend dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,35 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: npm
+    directory: /website
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      docs-site-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /app
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:15"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      browser-app-npm:
+        patterns:
+          - "*"

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
 
 - **id**: FEAT-QUALITY-001
   - **title**: Repository quality automation
-  - **summary**: Keep self-validation, dependency hygiene, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
+  - **summary**: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, and the browser app, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-005
@@ -70,6 +70,8 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - FEAT-QUALITY-001
           - package-ecosystem
           - target-branch
+          - directory: /website
+          - directory: /app
 
 ## Source YAML
 
@@ -80,7 +82,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, dependency hygiene, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
+    summary: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, and the browser app, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -131,4 +133,6 @@ features:
             - FEAT-QUALITY-001
             - package-ecosystem
             - target-branch
+            - "directory: /website"
+            - "directory: /app"
 ```

--- a/docs/generated/site-spec/requirements/core/repository.md
+++ b/docs/generated/site-spec/requirements/core/repository.md
@@ -169,7 +169,8 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
     - |
       The repository MUST cache repeatable CI build state, keep GitHub Actions
       runs concise enough for pull-request-first development, and use Dependabot
-      to update Rust and GitHub Actions dependencies against `main`.
+      to update Rust, GitHub Actions, docs-site npm, and browser-app npm
+      dependencies against `main`.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -333,7 +334,8 @@ requirements:
     description: |
       The repository MUST cache repeatable CI build state, keep GitHub Actions
       runs concise enough for pull-request-first development, and use Dependabot
-      to update Rust and GitHub Actions dependencies against `main`.
+      to update Rust, GitHub Actions, docs-site npm, and browser-app npm
+      dependencies against `main`.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, dependency hygiene, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
+    summary: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, and the browser app, code scanning, and merge-queue-safe CI execution fast enough to run on every pull request.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -55,3 +55,5 @@ features:
             - FEAT-QUALITY-001
             - package-ecosystem
             - target-branch
+            - "directory: /website"
+            - "directory: /app"

--- a/docs/syu/requirements/core/repository.yaml
+++ b/docs/syu/requirements/core/repository.yaml
@@ -145,7 +145,8 @@ requirements:
     description: |
       The repository MUST cache repeatable CI build state, keep GitHub Actions
       runs concise enough for pull-request-first development, and use Dependabot
-      to update Rust and GitHub Actions dependencies against `main`.
+      to update Rust, GitHub Actions, docs-site npm, and browser-app npm
+      dependencies against `main`.
     priority: medium
     status: implemented
     linked_policies:

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -392,9 +392,14 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(dependabot.contains("FEAT-QUALITY-001"));
     assert!(dependabot.contains("package-ecosystem: cargo"));
     assert!(dependabot.contains("package-ecosystem: github-actions"));
+    assert!(dependabot.matches("package-ecosystem: npm").count() >= 2);
     assert!(dependabot.contains("target-branch: main"));
     assert!(dependabot.contains("rust-crates"));
     assert!(dependabot.contains("github-actions"));
+    assert!(dependabot.contains("directory: /website"));
+    assert!(dependabot.contains("directory: /app"));
+    assert!(dependabot.contains("docs-site-npm"));
+    assert!(dependabot.contains("browser-app-npm"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add npm Dependabot coverage for the checked-in docs site and browser app
- update the self-hosted repository requirement/feature text for dependency hygiene
- extend repository quality assertions to cover the new Dependabot entries

## Testing
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary
- pre-commit run --all-files --hook-stage pre-commit
- pre-commit run --all-files --hook-stage pre-push

Closes #60