### PR TITLE
feat: add syu list and syu show

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ syu init .
 syu validate .
 syu validate . --fix
 syu browse .
+syu list requirement
+syu show REQ-CORE-015
 syu app .
 syu report . --output reports/syu.md
 ```
@@ -129,6 +131,24 @@ errors interactively:
 ```bash
 syu
 syu browse .
+```
+
+### `syu list`
+
+List one layer without entering the interactive browser:
+
+```bash
+syu list philosophy
+syu list feature path/to/workspace --format json
+```
+
+### `syu show`
+
+Show one definition by ID:
+
+```bash
+syu show REQ-CORE-015
+syu show FEAT-BROWSE-001 path/to/workspace --format json
 ```
 
 ### `syu app`

--- a/docs/generated/site-spec/features/cli/show-list.md
+++ b/docs/generated/site-spec/features/cli/show-list.md
@@ -1,0 +1,73 @@
+---
+title: "Lookup CLI / Show List"
+description: "Generated reference for docs/syu/features/cli/show-list.yaml"
+---
+
+> Generated from `docs/syu/features/cli/show-list.yaml`.
+
+## Parsed content
+
+### Category
+
+- Lookup CLI
+
+### Version
+
+- 1
+
+### Features
+
+- **id**: FEAT-LIST-001
+  - **title**: Non-interactive definition listing
+  - **summary**: List philosophies, policies, requirements, or features in one command without entering interactive browse mode.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-018
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/list.rs
+        - **symbols**:
+          - run_list_command
+- **id**: FEAT-SHOW-001
+  - **title**: Non-interactive definition detail lookup
+  - **summary**: Show one philosophy, policy, requirement, or feature by ID in one command.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-018
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/show.rs
+        - **symbols**:
+          - run_show_command
+
+## Source YAML
+
+```yaml
+category: Lookup CLI
+version: 1
+
+features:
+  - id: FEAT-LIST-001
+    title: Non-interactive definition listing
+    summary: List philosophies, policies, requirements, or features in one command without entering interactive browse mode.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/list.rs
+          symbols:
+            - run_list_command
+
+  - id: FEAT-SHOW-001
+    title: Non-interactive definition detail lookup
+    summary: Show one philosophy, policy, requirement, or feature by ID in one command.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/show.rs
+          symbols:
+            - run_show_command
+```

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -21,6 +21,8 @@ description: "Generated reference for docs/syu/features/features.yaml"
   - **file**: browser/app.yaml
 - **kind**: browse
   - **file**: cli/browse.yaml
+- **kind**: show-list
+  - **file**: cli/show-list.yaml
 - **kind**: check
   - **file**: cli/check.yaml
 - **kind**: init
@@ -51,6 +53,8 @@ files:
     file: browser/app.yaml
   - kind: browse
     file: cli/browse.yaml
+  - kind: show-list
+    file: cli/show-list.yaml
   - kind: check
     file: cli/check.yaml
   - kind: init

--- a/docs/generated/site-spec/index.md
+++ b/docs/generated/site-spec/index.md
@@ -17,6 +17,7 @@ This section is generated from the YAML source under `docs/syu/`.
 - [Validate Command / Check](/docs/generated/site-spec/features/cli/check)
 - [Init Command / Init](/docs/generated/site-spec/features/cli/init)
 - [Report Command / Report](/docs/generated/site-spec/features/cli/report)
+- [Lookup CLI / Show List](/docs/generated/site-spec/features/cli/show-list)
 - [Documentation / Docs](/docs/generated/site-spec/features/documentation/docs)
 - [Agent Skills / Skills](/docs/generated/site-spec/features/documentation/skills)
 - [Features](/docs/generated/site-spec/features)

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -37,6 +37,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-001
     - REQ-CORE-009
     - REQ-CORE-015
+    - REQ-CORE-018
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -55,6 +56,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-010
     - REQ-CORE-015
     - REQ-CORE-017
+    - REQ-CORE-018
 - **id**: POL-003
   - **title**: Traceability should prove ownership from specification to code and tests
   - **summary**: Declared traces should map to real files, real symbols, and optional full-file ownership.
@@ -88,6 +90,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-012
     - REQ-CORE-015
     - REQ-CORE-017
+    - REQ-CORE-018
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -166,6 +169,7 @@ policies:
       - REQ-CORE-001
       - REQ-CORE-009
       - REQ-CORE-015
+      - REQ-CORE-018
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -184,6 +188,7 @@ policies:
       - REQ-CORE-010
       - REQ-CORE-015
       - REQ-CORE-017
+      - REQ-CORE-018
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -217,6 +222,7 @@ policies:
       - REQ-CORE-012
       - REQ-CORE-015
       - REQ-CORE-017
+      - REQ-CORE-018
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -111,6 +111,36 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: app/tests/browser-app.spec.ts
         - **symbols**:
           - *
+- **id**: REQ-CORE-018
+  - **title**: Provide non-interactive list and show CLI commands
+  - **description**:
+    - |
+      The CLI MUST provide one-command lookup flows that let users list
+      philosophies, policies, requirements, or features and show the details
+      for a known item by ID without entering interactive browse mode. These
+      commands SHOULD keep working when validation issues exist so long as the
+      workspace itself can still load, and SHOULD offer JSON output for
+      automation.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-002
+    - POL-004
+  - **linked_features**:
+    - FEAT-LIST-001
+    - FEAT-SHOW-001
+  - **tests**:
+    - **rust**:
+      - **file**: tests/list_command.rs
+        - **symbols**:
+          - *
+      - **file**: tests/show_command.rs
+        - **symbols**:
+          - *
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatches_lookup_subcommands_without_rewriting_them
 
 ## Source YAML
 
@@ -209,4 +239,33 @@ requirements:
         - file: app/tests/browser-app.spec.ts
           symbols:
             - '*'
+  - id: REQ-CORE-018
+    title: Provide non-interactive list and show CLI commands
+    description: |
+      The CLI MUST provide one-command lookup flows that let users list
+      philosophies, policies, requirements, or features and show the details
+      for a known item by ID without entering interactive browse mode. These
+      commands SHOULD keep working when validation issues exist so long as the
+      workspace itself can still load, and SHOULD offer JSON output for
+      automation.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-LIST-001
+      - FEAT-SHOW-001
+    tests:
+      rust:
+        - file: tests/list_command.rs
+          symbols:
+            - '*'
+        - file: tests/show_command.rs
+          symbols:
+            - '*'
+        - file: src/lib.rs
+          symbols:
+            - dispatches_lookup_subcommands_without_rewriting_them
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -76,6 +76,8 @@ implementations:
 ```bash
 syu validate .
 syu browse .
+syu list feature
+syu show REQ-CORE-015
 syu app .
 ```
 
@@ -84,6 +86,8 @@ Use JSON when integrating with automation:
 ```bash
 syu validate . --format json
 syu validate . --severity error --genre trace
+syu list requirement --format json
+syu show FEAT-BROWSE-001 --format json
 ```
 
 Filters stay view-oriented: they narrow the visible diagnostics while preserving

--- a/docs/syu/features/cli/show-list.yaml
+++ b/docs/syu/features/cli/show-list.yaml
@@ -1,0 +1,27 @@
+category: Lookup CLI
+version: 1
+
+features:
+  - id: FEAT-LIST-001
+    title: Non-interactive definition listing
+    summary: List philosophies, policies, requirements, or features in one command without entering interactive browse mode.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/list.rs
+          symbols:
+            - run_list_command
+
+  - id: FEAT-SHOW-001
+    title: Non-interactive definition detail lookup
+    summary: Show one philosophy, policy, requirement, or feature by ID in one command.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/show.rs
+          symbols:
+            - run_show_command

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -6,6 +6,8 @@ files:
     file: browser/app.yaml
   - kind: browse
     file: cli/browse.yaml
+  - kind: show-list
+    file: cli/show-list.yaml
   - kind: check
     file: cli/check.yaml
   - kind: init

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -18,6 +18,7 @@ policies:
       - REQ-CORE-001
       - REQ-CORE-009
       - REQ-CORE-015
+      - REQ-CORE-018
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -36,6 +37,7 @@ policies:
       - REQ-CORE-010
       - REQ-CORE-015
       - REQ-CORE-017
+      - REQ-CORE-018
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -69,6 +71,7 @@ policies:
       - REQ-CORE-012
       - REQ-CORE-015
       - REQ-CORE-017
+      - REQ-CORE-018
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -92,3 +92,32 @@ requirements:
         - file: app/tests/browser-app.spec.ts
           symbols:
             - '*'
+  - id: REQ-CORE-018
+    title: Provide non-interactive list and show CLI commands
+    description: |
+      The CLI MUST provide one-command lookup flows that let users list
+      philosophies, policies, requirements, or features and show the details
+      for a known item by ID without entering interactive browse mode. These
+      commands SHOULD keep working when validation issues exist so long as the
+      workspace itself can still load, and SHOULD offer JSON output for
+      automation.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-LIST-001
+      - FEAT-SHOW-001
+    tests:
+      rust:
+        - file: tests/list_command.rs
+          symbols:
+            - '*'
+        - file: tests/show_command.rs
+          symbols:
+            - '*'
+        - file: src/lib.rs
+          symbols:
+            - dispatches_lookup_subcommands_without_rewriting_them

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub enum Commands {
         about = "Browse philosophies, policies, features, requirements, and validation errors"
     )]
     Browse(BrowseArgs),
+    #[command(about = "List philosophies, policies, requirements, or features")]
+    List(ListArgs),
+    #[command(about = "Show one philosophy, policy, requirement, or feature by ID")]
+    Show(ShowArgs),
     #[command(about = "Start a local browser app for exploring the current workspace")]
     App(AppArgs),
     #[command(
@@ -50,6 +54,58 @@ impl Default for BrowseArgs {
             workspace: PathBuf::from("."),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LookupKind {
+    #[value(alias = "philosophies")]
+    Philosophy,
+    #[value(alias = "policies")]
+    Policy,
+    #[value(alias = "requirements")]
+    Requirement,
+    #[value(alias = "features")]
+    Feature,
+}
+
+impl LookupKind {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Philosophy => "philosophy",
+            Self::Policy => "policy",
+            Self::Requirement => "requirement",
+            Self::Feature => "feature",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ListArgs {
+    #[arg(help = "Layer kind to list")]
+    #[arg(value_enum)]
+    pub kind: LookupKind,
+
+    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Output format for listed items")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ShowArgs {
+    #[arg(help = "Definition ID to show (for example PHIL-001 or REQ-CORE-001)")]
+    pub id: String,
+
+    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Output format for the selected item")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -170,10 +226,14 @@ impl ValidationGenreFilter {
 
 #[cfg(test)]
 mod tests {
-    use super::{ValidationGenreFilter, ValidationSeverityFilter};
+    use super::{LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
 
     #[test]
-    fn validation_filter_enums_expose_expected_labels() {
+    fn cli_enums_expose_expected_labels() {
+        assert_eq!(LookupKind::Philosophy.label(), "philosophy");
+        assert_eq!(LookupKind::Policy.label(), "policy");
+        assert_eq!(LookupKind::Requirement.label(), "requirement");
+        assert_eq!(LookupKind::Feature.label(), "feature");
         assert_eq!(ValidationSeverityFilter::Error.as_str(), "error");
         assert_eq!(ValidationSeverityFilter::Warning.as_str(), "warning");
         assert_eq!(ValidationGenreFilter::Workspace.as_str(), "workspace");

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -6,12 +6,14 @@ use std::io::{self, Write};
 use anyhow::Result;
 
 use crate::{
-    cli::BrowseArgs,
+    cli::{BrowseArgs, LookupKind as EntityKind},
     command::check::collect_check_result,
     model::{CheckResult, Feature, Philosophy, Policy, Requirement},
     rules::rule_by_code,
     workspace::{Workspace, load_workspace},
 };
+
+use super::lookup::WorkspaceLookup;
 
 #[derive(Debug, Clone, Copy)]
 enum TopLevelSection {
@@ -29,14 +31,6 @@ enum View {
     Detail(EntityRef),
     Errors,
     ErrorDetail(usize),
-}
-
-#[derive(Debug, Clone, Copy)]
-enum EntityKind {
-    Philosophy,
-    Policy,
-    Feature,
-    Requirement,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +52,10 @@ struct BrowseState {
 }
 
 impl BrowseState {
+    fn lookup(&self) -> Option<WorkspaceLookup<'_>> {
+        self.workspace.as_ref().map(WorkspaceLookup::new)
+    }
+
     fn run(&self) -> Result<i32> {
         let mut view = View::Menu;
 
@@ -373,95 +371,31 @@ impl BrowseState {
     }
 
     fn entity_entries(&self, kind: EntityKind) -> Vec<(String, String)> {
-        match kind {
-            EntityKind::Philosophy => self
-                .workspace
-                .as_ref()
-                .map(|workspace| {
-                    workspace
-                        .philosophies
-                        .iter()
-                        .map(|item| (item.id.clone(), item.title.clone()))
-                        .collect()
-                })
-                .unwrap_or_default(),
-            EntityKind::Policy => self
-                .workspace
-                .as_ref()
-                .map(|workspace| {
-                    workspace
-                        .policies
-                        .iter()
-                        .map(|item| (item.id.clone(), item.title.clone()))
-                        .collect()
-                })
-                .unwrap_or_default(),
-            EntityKind::Feature => self
-                .workspace
-                .as_ref()
-                .map(|workspace| {
-                    workspace
-                        .features
-                        .iter()
-                        .map(|item| (item.id.clone(), item.title.clone()))
-                        .collect()
-                })
-                .unwrap_or_default(),
-            EntityKind::Requirement => self
-                .workspace
-                .as_ref()
-                .map(|workspace| {
-                    workspace
-                        .requirements
-                        .iter()
-                        .map(|item| (item.id.clone(), item.title.clone()))
-                        .collect()
-                })
-                .unwrap_or_default(),
-        }
+        self.lookup()
+            .map(|lookup| {
+                lookup
+                    .entries(kind)
+                    .into_iter()
+                    .map(|item| (item.id, item.title))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     fn philosophy(&self, id: &str) -> Option<&Philosophy> {
-        self.workspace
-            .as_ref()?
-            .philosophies
-            .iter()
-            .find(|item| item.id == id)
+        self.lookup()?.philosophy(id)
     }
 
     fn policy(&self, id: &str) -> Option<&Policy> {
-        self.workspace
-            .as_ref()?
-            .policies
-            .iter()
-            .find(|item| item.id == id)
+        self.lookup()?.policy(id)
     }
 
     fn requirement(&self, id: &str) -> Option<&Requirement> {
-        self.workspace
-            .as_ref()?
-            .requirements
-            .iter()
-            .find(|item| item.id == id)
+        self.lookup()?.requirement(id)
     }
 
     fn feature(&self, id: &str) -> Option<&Feature> {
-        self.workspace
-            .as_ref()?
-            .features
-            .iter()
-            .find(|item| item.id == id)
-    }
-}
-
-impl EntityKind {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Philosophy => "philosophy",
-            Self::Policy => "policy",
-            Self::Feature => "feature",
-            Self::Requirement => "requirement",
-        }
+        self.lookup()?.feature(id)
     }
 }
 

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -1,0 +1,43 @@
+// FEAT-LIST-001
+// REQ-CORE-018
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::{
+    cli::{ListArgs, OutputFormat},
+    workspace::load_workspace,
+};
+
+use super::lookup::{EntitySummary, WorkspaceLookup};
+
+#[derive(Debug, Serialize)]
+struct JsonListOutput {
+    kind: &'static str,
+    items: Vec<EntitySummary>,
+}
+
+pub fn run_list_command(args: &ListArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let items = WorkspaceLookup::new(&workspace).entries(args.kind);
+
+    match args.format {
+        OutputFormat::Text => print_text_list(&items),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&JsonListOutput {
+                kind: args.kind.label(),
+                items,
+            })
+            .expect("serializing list output to JSON should succeed")
+        ),
+    }
+
+    Ok(0)
+}
+
+fn print_text_list(items: &[EntitySummary]) {
+    for item in items {
+        println!("{}\t{}", item.id, item.title);
+    }
+}

--- a/src/command/lookup.rs
+++ b/src/command/lookup.rs
@@ -1,0 +1,123 @@
+// REQ-CORE-018
+
+use serde::Serialize;
+
+use crate::{
+    cli::LookupKind,
+    model::{Feature, Philosophy, Policy, Requirement},
+    workspace::Workspace,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct EntitySummary {
+    pub id: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WorkspaceEntity<'a> {
+    Philosophy(&'a Philosophy),
+    Policy(&'a Policy),
+    Requirement(&'a Requirement),
+    Feature(&'a Feature),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WorkspaceLookup<'a> {
+    workspace: &'a Workspace,
+}
+
+impl<'a> WorkspaceLookup<'a> {
+    pub(crate) fn new(workspace: &'a Workspace) -> Self {
+        Self { workspace }
+    }
+
+    pub(crate) fn entries(self, kind: LookupKind) -> Vec<EntitySummary> {
+        match kind {
+            LookupKind::Philosophy => self
+                .workspace
+                .philosophies
+                .iter()
+                .map(|item| EntitySummary {
+                    id: item.id.clone(),
+                    title: item.title.clone(),
+                })
+                .collect(),
+            LookupKind::Policy => self
+                .workspace
+                .policies
+                .iter()
+                .map(|item| EntitySummary {
+                    id: item.id.clone(),
+                    title: item.title.clone(),
+                })
+                .collect(),
+            LookupKind::Requirement => self
+                .workspace
+                .requirements
+                .iter()
+                .map(|item| EntitySummary {
+                    id: item.id.clone(),
+                    title: item.title.clone(),
+                })
+                .collect(),
+            LookupKind::Feature => self
+                .workspace
+                .features
+                .iter()
+                .map(|item| EntitySummary {
+                    id: item.id.clone(),
+                    title: item.title.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn title_for(self, kind: LookupKind, id: &str) -> Option<&'a str> {
+        match kind {
+            LookupKind::Philosophy => self.philosophy(id).map(|item| item.title.as_str()),
+            LookupKind::Policy => self.policy(id).map(|item| item.title.as_str()),
+            LookupKind::Requirement => self.requirement(id).map(|item| item.title.as_str()),
+            LookupKind::Feature => self.feature(id).map(|item| item.title.as_str()),
+        }
+    }
+
+    pub(crate) fn philosophy(self, id: &str) -> Option<&'a Philosophy> {
+        self.workspace
+            .philosophies
+            .iter()
+            .find(|item| item.id == id)
+    }
+
+    pub(crate) fn policy(self, id: &str) -> Option<&'a Policy> {
+        self.workspace.policies.iter().find(|item| item.id == id)
+    }
+
+    pub(crate) fn requirement(self, id: &str) -> Option<&'a Requirement> {
+        self.workspace
+            .requirements
+            .iter()
+            .find(|item| item.id == id)
+    }
+
+    pub(crate) fn feature(self, id: &str) -> Option<&'a Feature> {
+        self.workspace.features.iter().find(|item| item.id == id)
+    }
+
+    pub(crate) fn find(self, id: &str) -> Option<WorkspaceEntity<'a>> {
+        if id.starts_with("PHIL-") {
+            return self.philosophy(id).map(WorkspaceEntity::Philosophy);
+        }
+        if id.starts_with("POL-") {
+            return self.policy(id).map(WorkspaceEntity::Policy);
+        }
+        if id.starts_with("REQ-") {
+            return self.requirement(id).map(WorkspaceEntity::Requirement);
+        }
+        if id.starts_with("FEAT-") {
+            return self.feature(id).map(WorkspaceEntity::Feature);
+        }
+
+        None
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,4 +4,7 @@ pub mod app;
 pub mod browse;
 pub mod check;
 pub mod init;
+pub mod list;
+mod lookup;
 pub mod report;
+pub mod show;

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -1,0 +1,224 @@
+// FEAT-SHOW-001
+// REQ-CORE-018
+
+use std::{collections::BTreeMap, fmt::Write};
+
+use anyhow::{Result, bail};
+use serde::Serialize;
+
+use crate::{
+    cli::{OutputFormat, ShowArgs},
+    model::{Feature, Philosophy, Policy, Requirement, TraceReference},
+    workspace::load_workspace,
+};
+
+use super::lookup::{WorkspaceEntity, WorkspaceLookup};
+
+#[derive(Debug, Serialize)]
+struct JsonShowOutput<'a, T> {
+    kind: &'a str,
+    item: &'a T,
+}
+
+pub fn run_show_command(args: &ShowArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let lookup = WorkspaceLookup::new(&workspace);
+    let Some(entity) = lookup.find(&args.id) else {
+        bail!(
+            "definition `{}` was not found in `{}`",
+            args.id,
+            workspace.root.display()
+        );
+    };
+
+    match args.format {
+        OutputFormat::Text => print!("{}", render_entity_text(lookup, entity)),
+        OutputFormat::Json => print_entity_json(entity),
+    }
+
+    Ok(0)
+}
+
+fn print_entity_json(entity: WorkspaceEntity<'_>) {
+    match entity {
+        WorkspaceEntity::Philosophy(item) => print_json_output("philosophy", item),
+        WorkspaceEntity::Policy(item) => print_json_output("policy", item),
+        WorkspaceEntity::Requirement(item) => print_json_output("requirement", item),
+        WorkspaceEntity::Feature(item) => print_json_output("feature", item),
+    }
+}
+
+fn print_json_output<T: Serialize>(kind: &str, item: &T) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&JsonShowOutput { kind, item })
+            .expect("serializing show output to JSON should succeed")
+    );
+}
+
+fn render_entity_text(lookup: WorkspaceLookup<'_>, entity: WorkspaceEntity<'_>) -> String {
+    let mut output = String::new();
+
+    match entity {
+        WorkspaceEntity::Philosophy(item) => render_philosophy(&mut output, lookup, item),
+        WorkspaceEntity::Policy(item) => render_policy(&mut output, lookup, item),
+        WorkspaceEntity::Requirement(item) => render_requirement(&mut output, lookup, item),
+        WorkspaceEntity::Feature(item) => render_feature(&mut output, lookup, item),
+    }
+
+    output
+}
+
+fn render_philosophy(output: &mut String, lookup: WorkspaceLookup<'_>, item: &Philosophy) {
+    write_common_header(output, "philosophy", &item.id, &item.title);
+    writeln!(
+        output,
+        "Product design principle: {}",
+        collapse_whitespace(&item.product_design_principle)
+    )
+    .expect("writing to String must succeed");
+    writeln!(
+        output,
+        "Coding guideline: {}",
+        collapse_whitespace(&item.coding_guideline)
+    )
+    .expect("writing to String must succeed");
+    write_links(
+        output,
+        "Linked policies",
+        lookup,
+        crate::cli::LookupKind::Policy,
+        &item.linked_policies,
+    );
+}
+
+fn render_policy(output: &mut String, lookup: WorkspaceLookup<'_>, item: &Policy) {
+    write_common_header(output, "policy", &item.id, &item.title);
+    writeln!(output, "Summary: {}", collapse_whitespace(&item.summary))
+        .expect("writing to String must succeed");
+    writeln!(
+        output,
+        "Description: {}",
+        collapse_whitespace(&item.description)
+    )
+    .expect("writing to String must succeed");
+    write_links(
+        output,
+        "Linked philosophies",
+        lookup,
+        crate::cli::LookupKind::Philosophy,
+        &item.linked_philosophies,
+    );
+    write_links(
+        output,
+        "Linked requirements",
+        lookup,
+        crate::cli::LookupKind::Requirement,
+        &item.linked_requirements,
+    );
+}
+
+fn render_requirement(output: &mut String, lookup: WorkspaceLookup<'_>, item: &Requirement) {
+    write_common_header(output, "requirement", &item.id, &item.title);
+    writeln!(output, "Priority: {}", item.priority).expect("writing to String must succeed");
+    writeln!(output, "Status: {}", item.status).expect("writing to String must succeed");
+    writeln!(
+        output,
+        "Description: {}",
+        collapse_whitespace(&item.description)
+    )
+    .expect("writing to String must succeed");
+    write_links(
+        output,
+        "Linked policies",
+        lookup,
+        crate::cli::LookupKind::Policy,
+        &item.linked_policies,
+    );
+    write_links(
+        output,
+        "Linked features",
+        lookup,
+        crate::cli::LookupKind::Feature,
+        &item.linked_features,
+    );
+    write_trace_map(output, "Declared tests", &item.tests);
+}
+
+fn render_feature(output: &mut String, lookup: WorkspaceLookup<'_>, item: &Feature) {
+    write_common_header(output, "feature", &item.id, &item.title);
+    writeln!(output, "Status: {}", item.status).expect("writing to String must succeed");
+    writeln!(output, "Summary: {}", collapse_whitespace(&item.summary))
+        .expect("writing to String must succeed");
+    write_links(
+        output,
+        "Linked requirements",
+        lookup,
+        crate::cli::LookupKind::Requirement,
+        &item.linked_requirements,
+    );
+    write_trace_map(output, "Declared implementations", &item.implementations);
+}
+
+fn write_common_header(output: &mut String, kind: &str, id: &str, title: &str) {
+    writeln!(output, "Kind: {kind}").expect("writing to String must succeed");
+    writeln!(output, "ID: {id}").expect("writing to String must succeed");
+    writeln!(output, "Title: {title}").expect("writing to String must succeed");
+}
+
+fn write_links(
+    output: &mut String,
+    heading: &str,
+    lookup: WorkspaceLookup<'_>,
+    kind: crate::cli::LookupKind,
+    ids: &[String],
+) {
+    writeln!(output, "{heading}:").expect("writing to String must succeed");
+    if ids.is_empty() {
+        writeln!(output, "- none").expect("writing to String must succeed");
+        return;
+    }
+
+    for id in ids {
+        let title = lookup.title_for(kind, id).unwrap_or("missing");
+        writeln!(output, "- {id}\t{title}").expect("writing to String must succeed");
+    }
+}
+
+fn write_trace_map(
+    output: &mut String,
+    heading: &str,
+    references: &BTreeMap<String, Vec<TraceReference>>,
+) {
+    writeln!(output, "{heading}:").expect("writing to String must succeed");
+    if references.is_empty() {
+        writeln!(output, "- none").expect("writing to String must succeed");
+        return;
+    }
+
+    for (language, items) in references {
+        writeln!(output, "- {language}:").expect("writing to String must succeed");
+        for item in items {
+            writeln!(output, "  - file: {}", item.file.display())
+                .expect("writing to String must succeed");
+            writeln!(
+                output,
+                "    symbols: {}",
+                if item.symbols.is_empty() {
+                    "-".to_string()
+                } else {
+                    item.symbols.join(", ")
+                }
+            )
+            .expect("writing to String must succeed");
+            if !item.doc_contains.is_empty() {
+                writeln!(output, "    doc_contains: {}", item.doc_contains.join(", "))
+                    .expect("writing to String must succeed");
+            }
+        }
+    }
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use std::io::IsTerminal;
 
 enum Dispatch {
     Browse(cli::BrowseArgs),
+    List(cli::ListArgs),
+    Show(cli::ShowArgs),
     App(cli::AppArgs),
     PrintHelp,
     Validate(cli::ValidateArgs),
@@ -28,6 +30,8 @@ enum Dispatch {
 fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) -> Dispatch {
     match cli.command {
         Some(cli::Commands::Browse(args)) => Dispatch::Browse(args),
+        Some(cli::Commands::List(args)) => Dispatch::List(args),
+        Some(cli::Commands::Show(args)) => Dispatch::Show(args),
         Some(cli::Commands::App(args)) => Dispatch::App(args),
         None if stdin_is_terminal && stdout_is_terminal => {
             Dispatch::Browse(cli::BrowseArgs::default())
@@ -42,6 +46,8 @@ fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) ->
 fn run_dispatch(dispatch: Dispatch) -> Result<i32> {
     match dispatch {
         Dispatch::Browse(args) => command::browse::run_browse_command(&args),
+        Dispatch::List(args) => command::list::run_list_command(&args),
+        Dispatch::Show(args) => command::show::run_show_command(&args),
         Dispatch::App(args) => command::app::run_app_command(&args),
         Dispatch::PrintHelp => {
             let mut command = cli::Cli::command();
@@ -68,7 +74,7 @@ pub fn run() -> Result<i32> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::cli::{AppArgs, Cli, Commands};
+    use crate::cli::{AppArgs, Cli, Commands, ListArgs, LookupKind, OutputFormat, ShowArgs};
 
     // REQ-CORE-015
     #[test]
@@ -100,6 +106,48 @@ mod tests {
             action,
             super::Dispatch::App(crate::cli::AppArgs { workspace, port, .. })
                 if workspace == Path::new("workspace") && port == Some(4173)
+        ));
+    }
+
+    #[test]
+    // REQ-CORE-018
+    fn dispatches_lookup_subcommands_without_rewriting_them() {
+        let list = super::dispatch(
+            Cli {
+                command: Some(Commands::List(ListArgs {
+                    kind: LookupKind::Requirement,
+                    workspace: PathBuf::from("workspace"),
+                    format: OutputFormat::Json,
+                })),
+            },
+            true,
+            true,
+        );
+        assert!(matches!(
+            list,
+            super::Dispatch::List(crate::cli::ListArgs { kind, workspace, format })
+                if kind == LookupKind::Requirement
+                    && workspace == Path::new("workspace")
+                    && format == OutputFormat::Json
+        ));
+
+        let show = super::dispatch(
+            Cli {
+                command: Some(Commands::Show(ShowArgs {
+                    id: "REQ-CORE-018".to_string(),
+                    workspace: PathBuf::from("workspace"),
+                    format: OutputFormat::Text,
+                })),
+            },
+            true,
+            true,
+        );
+        assert!(matches!(
+            show,
+            super::Dispatch::Show(crate::cli::ShowArgs { id, workspace, format })
+                if id == "REQ-CORE-018"
+                    && workspace == Path::new("workspace")
+                    && format == OutputFormat::Text
         ));
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,7 +15,7 @@ pub struct PhilosophyDocument {
     pub philosophies: Vec<Philosophy>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Philosophy {
     pub id: String,
@@ -35,7 +35,7 @@ pub struct PolicyDocument {
     pub policies: Vec<Policy>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Policy {
     pub id: String,
@@ -56,7 +56,7 @@ pub struct RequirementDocument {
     pub requirements: Vec<Requirement>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Requirement {
     pub id: String,
@@ -95,7 +95,7 @@ pub struct FeatureDocument {
     pub features: Vec<Feature>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Feature {
     pub id: String,
@@ -108,7 +108,7 @@ pub struct Feature {
     pub implementations: BTreeMap<String, Vec<TraceReference>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TraceReference {
     pub file: PathBuf,

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -38,6 +38,8 @@ fn bare_syu_prints_help_when_not_attached_to_a_terminal() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Usage:"));
     assert!(stdout.contains("browse"));
+    assert!(stdout.contains("list"));
+    assert!(stdout.contains("show"));
     assert!(stdout.contains("validate"));
 }
 

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -1,0 +1,76 @@
+use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
+use std::{path::PathBuf, process::Command};
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/workspaces")
+        .join(name)
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_lists_philosophies_in_text_format() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg("philosophy")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("PHIL-TRACE-001\tTrace everything"));
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_supports_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg("feature")
+        .arg(fixture_path("passing"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(json["kind"], "feature");
+    assert_eq!(
+        json["items"]
+            .as_array()
+            .expect("items should be an array")
+            .len(),
+        3
+    );
+    assert_eq!(json["items"][0]["id"], "FEAT-TRACE-001");
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_accepts_plural_lookup_aliases() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg("requirements")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success(), "plural alias should be accepted");
+    assert!(String::from_utf8_lossy(&output.stdout).contains("REQ-TRACE-003"));
+}

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -201,6 +201,8 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu validate"));
     assert!(readme.contains("syu browse"));
+    assert!(readme.contains("syu list"));
+    assert!(readme.contains("syu show"));
     assert!(readme.contains("syu app"));
     assert!(readme.contains("examples/polyglot"));
     assert!(readme.contains("CONTRIBUTING.md"));
@@ -222,6 +224,8 @@ fn repository_declares_documentation_guides() {
     assert!(concepts.contains("Specification Reference"));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
+    assert!(getting_started.contains("syu list feature"));
+    assert!(getting_started.contains("syu show REQ-CORE-015"));
     assert!(getting_started.contains("syu app ."));
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
@@ -242,6 +246,7 @@ fn repository_declares_documentation_guides() {
     assert!(generated_config_spec.contains("docs/syu/config/spec.yaml"));
     assert!(generated_config_validate.contains("validate.default_fix"));
     assert!(generated_config_runtimes.contains("docs/syu/config/runtimes.yaml"));
+    assert!(generated_site_index.contains("/docs/generated/site-spec/features/cli/show-list"));
     assert!(generated_site_index.contains("/docs/generated/site-spec/features/validation"));
     assert!(generated_validation.contains("docs/syu/features/validation/validation.yaml"));
     assert!(generated_validation.contains("SYU-graph-reference-001"));

--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -1,0 +1,278 @@
+use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
+use std::{fs, path::PathBuf, process::Command};
+use tempfile::tempdir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/workspaces")
+        .join(name)
+}
+
+fn write_show_fixture_workspace() -> tempfile::TempDir {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let docs_root = tempdir.path().join("docs/syu");
+    fs::create_dir_all(docs_root.join("philosophy")).expect("philosophy dir");
+    fs::create_dir_all(docs_root.join("policies")).expect("policies dir");
+    fs::create_dir_all(docs_root.join("requirements")).expect("requirements dir");
+    fs::create_dir_all(docs_root.join("features")).expect("features dir");
+
+    fs::write(
+        docs_root.join("philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-001\n    title: Solo philosophy\n    product_design_principle: Keep lookups explicit.\n    coding_guideline: Prefer one-command inspection.\n    linked_policies: []\n",
+    )
+    .expect("philosophy file");
+    fs::write(
+        docs_root.join("policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-001\n    title: Solo policy\n    summary: Empty links are okay.\n    description: Show should still render details.\n    linked_philosophies: []\n    linked_requirements: []\n",
+    )
+    .expect("policy file");
+    fs::write(
+        docs_root.join("requirements/core.yaml"),
+        "category: Core\nprefix: REQ\nrequirements:\n  - id: REQ-001\n    title: Doc-only requirement\n    description: Uses doc_contains without symbols.\n    priority: medium\n    status: implemented\n    linked_policies: []\n    linked_features: []\n    tests:\n      rust:\n        - file: src/doc_only.rs\n          doc_contains:\n            - REQ-001\n",
+    )
+    .expect("requirement file");
+    fs::write(
+        docs_root.join("features/features.yaml"),
+        "version: \"1\"\nfiles:\n  - kind: solo\n    file: solo.yaml\n",
+    )
+    .expect("feature registry");
+    fs::write(
+        docs_root.join("features/solo.yaml"),
+        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-001\n    title: Empty feature\n    summary: Leaves implementations empty.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n",
+    )
+    .expect("feature file");
+
+    tempdir
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_renders_philosophy_details_in_text_format() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("PHIL-TRACE-001")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind: philosophy"));
+    assert!(stdout.contains("Linked policies:"));
+    assert!(stdout.contains("POL-TRACE-001\tRequirements need executable evidence"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_renders_policy_details_in_text_format() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("POL-TRACE-001")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind: policy"));
+    assert!(stdout.contains("Linked philosophies:"));
+    assert!(stdout.contains("PHIL-TRACE-001\tTrace everything"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_renders_requirement_details_in_text_format() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("REQ-TRACE-001")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind: requirement"));
+    assert!(stdout.contains("ID: REQ-TRACE-001"));
+    assert!(stdout.contains("Linked features:"));
+    assert!(stdout.contains("FEAT-TRACE-001\tRust implementation trace"));
+    assert!(stdout.contains("Declared tests:"));
+    assert!(stdout.contains("src/rust_trace_tests.rs"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_renders_feature_details_in_text_format() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("FEAT-TRACE-001")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind: feature"));
+    assert!(stdout.contains("Linked requirements:"));
+    assert!(stdout.contains("REQ-TRACE-001\tRust requirement trace"));
+    assert!(stdout.contains("Declared implementations:"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_supports_json_output_for_each_kind() {
+    for (id, kind) in [
+        ("PHIL-TRACE-001", "philosophy"),
+        ("POL-TRACE-001", "policy"),
+        ("REQ-TRACE-001", "requirement"),
+        ("FEAT-TRACE-002", "feature"),
+    ] {
+        let output = Command::cargo_bin("syu")
+            .expect("binary should build")
+            .arg("show")
+            .arg(id)
+            .arg(fixture_path("passing"))
+            .arg("--format")
+            .arg("json")
+            .output()
+            .expect("command should run");
+
+        assert!(
+            output.status.success(),
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let json: Value =
+            serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+        assert_eq!(json["kind"], kind);
+        assert_eq!(json["item"]["id"], id);
+    }
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_supports_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("FEAT-TRACE-002")
+        .arg(fixture_path("passing"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(json["kind"], "feature");
+    assert_eq!(json["item"]["id"], "FEAT-TRACE-002");
+    assert_eq!(json["item"]["linked_requirements"][0], "REQ-TRACE-002");
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_reads_items_from_workspaces_with_validation_errors() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("REQ-FAIL-001")
+        .arg(fixture_path("failing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "validation issues should not block lookups"
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("ID: REQ-FAIL-001"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_handles_empty_links_and_doc_only_traces() {
+    let tempdir = write_show_fixture_workspace();
+
+    let philosophy = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("PHIL-001")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+    assert!(philosophy.status.success());
+    let philosophy_stdout = String::from_utf8_lossy(&philosophy.stdout);
+    assert!(philosophy_stdout.contains("Linked policies:"));
+    assert!(philosophy_stdout.contains("- none"));
+
+    let feature = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("FEAT-001")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+    assert!(feature.status.success());
+    let feature_stdout = String::from_utf8_lossy(&feature.stdout);
+    assert!(feature_stdout.contains("Declared implementations:"));
+    assert!(feature_stdout.contains("- none"));
+
+    let requirement = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("REQ-001")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+    assert!(requirement.status.success());
+    let requirement_stdout = String::from_utf8_lossy(&requirement.stdout);
+    assert!(requirement_stdout.contains("symbols: -"));
+    assert!(requirement_stdout.contains("doc_contains: REQ-001"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_errors_when_the_id_is_missing() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("REQ-MISSING-999")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("was not found"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_errors_for_ids_without_supported_prefixes() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("MISSING")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("was not found"));
+}


### PR DESCRIPTION
## Summary
- add non-interactive syu list and syu show commands for one-shot workspace lookups
- document the new commands in the README, getting started guide, and generated site spec
- add CLI/manual/integration coverage and self-hosting spec updates for the new requirement

## Testing
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary
- pre-commit run --all-files --hook-stage pre-commit
- pre-commit run --all-files --hook-stage pre-push

Closes #59
