### PR TITLE
feat: extend strict symbol trace coverage to TypeScript and JavaScript

### DIFF
--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -49,7 +49,7 @@ features:
           symbols:
             - merge_group
             - Analyze (rust)
-            - github/codeql-action/init@v3
+            - github/codeql-action/init@v4
         - file: .github/dependabot.yml
           symbols:
             - FEAT-QUALITY-001

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -71,8 +71,11 @@ requirements:
       any `doc_contains` snippets are present in the symbol documentation.
       Validation MUST also reject duplicate trace mappings inside a single
       language list, support wildcard file ownership, and provide an optional
-      mode that requires every public Rust symbol to belong to some feature and
-      every Rust test to belong to some requirement.
+      mode that requires every public symbol and every test symbol in repository
+      source and test roots to belong to some feature or requirement respectively,
+      across Rust (`pub` symbols and `#[test]` functions), Python (non-underscore-
+      prefixed symbols and `test_*` functions), and TypeScript/JavaScript (exported
+      symbols and `test*`-prefixed functions).
     priority: high
     status: implemented
     linked_policies:

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -10,6 +10,7 @@ use std::{
 use syn::{Attribute, ImplItem, Item, Visibility};
 
 use crate::{
+    inspect::inspect_typescript_file,
     model::{Feature, Issue, Requirement, TraceReference},
     workspace::Workspace,
 };
@@ -38,13 +39,21 @@ pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Is
         return;
     }
 
-    let targets = match discover_rust_targets(&workspace.root) {
+    let mut targets = match discover_rust_targets(&workspace.root) {
         Ok(targets) => targets,
         Err(issue) => {
             issues.push(*issue);
             return;
         }
     };
+
+    match discover_typescript_targets(&workspace.root) {
+        Ok(ts_targets) => targets.extend(ts_targets),
+        Err(issue) => {
+            issues.push(*issue);
+            return;
+        }
+    }
 
     let feature_coverage = collect_feature_coverage(&workspace.features);
     let requirement_coverage = collect_requirement_coverage(&workspace.requirements);
@@ -325,6 +334,133 @@ fn rust_files_under(root: &Path) -> Result<Vec<PathBuf>, Box<Issue>> {
         ))
     })?;
     Ok(files)
+}
+
+fn discover_typescript_targets(root: &Path) -> Result<Vec<CoverageTarget>, Box<Issue>> {
+    const TS_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
+
+    let src_dir = root.join("src");
+    let tests_dir = root.join("tests");
+
+    let mut src_files: Vec<PathBuf> = Vec::new();
+    let mut test_files: Vec<PathBuf> = Vec::new();
+
+    for ext in TS_EXTENSIONS {
+        src_files.extend(typescript_files_under(&src_dir, ext)?);
+        test_files.extend(typescript_files_under(&tests_dir, ext)?);
+    }
+
+    if src_files.is_empty() && test_files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut targets = Vec::new();
+
+    for path in &src_files {
+        let contents = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let symbols = match inspect_typescript_file(path, &contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned file should remain under the workspace root")
+            .to_path_buf();
+        for symbol in symbols {
+            if symbol.is_exported {
+                targets.push(CoverageTarget {
+                    file: relative.clone(),
+                    symbol: symbol.name,
+                    kind: CoverageTargetKind::PublicSymbol,
+                });
+            }
+        }
+    }
+
+    for path in &test_files {
+        let contents = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let symbols = match inspect_typescript_file(path, &contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned file should remain under the workspace root")
+            .to_path_buf();
+        for symbol in symbols {
+            if symbol.name.starts_with("test") || symbol.name.starts_with("Test") {
+                targets.push(CoverageTarget {
+                    file: relative.clone(),
+                    symbol: symbol.name,
+                    kind: CoverageTargetKind::TestSymbol,
+                });
+            }
+        }
+    }
+
+    targets.sort_by(|left, right| {
+        (
+            left.file.as_os_str(),
+            left.symbol.as_str(),
+            match left.kind {
+                CoverageTargetKind::PublicSymbol => 0,
+                CoverageTargetKind::TestSymbol => 1,
+            },
+        )
+            .cmp(&(
+                right.file.as_os_str(),
+                right.symbol.as_str(),
+                match right.kind {
+                    CoverageTargetKind::PublicSymbol => 0,
+                    CoverageTargetKind::TestSymbol => 1,
+                },
+            ))
+    });
+    targets.dedup();
+
+    Ok(targets)
+}
+
+fn typescript_files_under(root: &Path, extension: &str) -> Result<Vec<PathBuf>, Box<Issue>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_typescript_files_recursive(root, extension, &mut files).map_err(|error| {
+        Box::new(Issue::error(
+            "SYU-coverage-walk-001",
+            "trace coverage inventory",
+            Some(root.display().to_string()),
+            format!("Failed to walk `{}` while building trace coverage inventory: {error}", root.display()),
+            Some("Fix the directory layout or disable `validate.require_symbol_trace_coverage` until the workspace can be scanned.".to_string()),
+        ))
+    })?;
+    Ok(files)
+}
+
+fn collect_typescript_files_recursive(
+    directory: &Path,
+    extension: &str,
+    files: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
+    for entry in fs::read_dir(directory)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_typescript_files_recursive(&path, extension, files)?;
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) == Some(extension) {
+            files.push(path);
+        }
+    }
+    Ok(())
 }
 
 fn collect_rust_files_recursive(directory: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -90,10 +90,11 @@ struct PythonSymbolInspection {
 }
 
 #[derive(Debug, Clone)]
-struct TypeScriptSymbolInspection {
-    name: String,
-    docs: String,
-    line: usize,
+pub(crate) struct TypeScriptSymbolInspection {
+    pub(crate) name: String,
+    pub(crate) docs: String,
+    pub(crate) line: usize,
+    pub(crate) is_exported: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -294,7 +295,10 @@ fn inspect_typescript_symbol(
     Ok(symbols.into_iter().find(|item| item.name == symbol))
 }
 
-fn inspect_typescript_file(path: &Path, contents: &str) -> Result<Vec<TypeScriptSymbolInspection>> {
+pub(crate) fn inspect_typescript_file(
+    path: &Path,
+    contents: &str,
+) -> Result<Vec<TypeScriptSymbolInspection>> {
     let mut parser = Parser::new();
     let language = match path.extension().and_then(|ext| ext.to_str()) {
         Some("tsx" | "jsx") => tree_sitter_typescript::LANGUAGE_TSX,
@@ -309,16 +313,26 @@ fn inspect_typescript_file(path: &Path, contents: &str) -> Result<Vec<TypeScript
         .ok_or_else(|| anyhow::anyhow!("failed to parse TypeScript source"))?;
 
     let mut symbols = Vec::new();
-    collect_typescript_symbols(tree.root_node(), contents, &mut symbols);
+    collect_typescript_symbols(tree.root_node(), contents, false, &mut symbols);
     Ok(symbols)
 }
 
 fn collect_typescript_symbols(
     node: tree_sitter::Node<'_>,
     contents: &str,
+    parent_is_export: bool,
     symbols: &mut Vec<TypeScriptSymbolInspection>,
 ) {
     match node.kind() {
+        "export_statement" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.is_named() {
+                    collect_typescript_symbols(child, contents, true, symbols);
+                }
+            }
+            return;
+        }
         "function_declaration"
         | "class_declaration"
         | "interface_declaration"
@@ -332,6 +346,7 @@ fn collect_typescript_symbols(
                     .map(|block| block.text)
                     .unwrap_or_default(),
                 line: node.start_position().row + 1,
+                is_exported: parent_is_export,
             });
         }
         "variable_declarator" => {
@@ -342,6 +357,7 @@ fn collect_typescript_symbols(
                     .map(|block| block.text)
                     .unwrap_or_default(),
                 line: node.start_position().row + 1,
+                is_exported: parent_is_export,
             });
         }
         _ => {}
@@ -350,7 +366,7 @@ fn collect_typescript_symbols(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.is_named() {
-            collect_typescript_symbols(child, contents, symbols);
+            collect_typescript_symbols(child, contents, false, symbols);
         }
     }
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -389,9 +389,9 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(codeql_workflow.contains("Analyze (rust)"));
     assert!(codeql_workflow.contains("dtolnay/rust-toolchain@stable"));
     assert!(codeql_workflow.contains("Swatinem/rust-cache@v2"));
-    assert!(codeql_workflow.contains("github/codeql-action/init@v3"));
-    assert!(codeql_workflow.contains("github/codeql-action/autobuild@v3"));
-    assert!(codeql_workflow.contains("github/codeql-action/analyze@v3"));
+    assert!(codeql_workflow.contains("github/codeql-action/init@v4"));
+    assert!(codeql_workflow.contains("github/codeql-action/autobuild@v4"));
+    assert!(codeql_workflow.contains("github/codeql-action/analyze@v4"));
 
     assert!(release_artifacts.contains("Restore Rust cache"));
     assert!(release_artifacts.contains("Swatinem/rust-cache@v2"));

--- a/tests/trace_coverage_validation.rs
+++ b/tests/trace_coverage_validation.rs
@@ -116,3 +116,151 @@ fn validate_accepts_wildcard_file_coverage() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+fn write_typescript_workspace(root: &std::path::Path, cover_everything: bool) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_symbol_trace_coverage: true\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep the graph explicit\n    product_design_principle: Every layer should be connected.\n    coding_guideline: Prefer explicit ownership.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Coverage can be enforced when needed\n    summary: Public symbols and tests may require ownership.\n    description: This fixture turns the strict coverage rule on.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    let requirement_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - testCoveredCase\n"
+    };
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Tests must stay justified\n    description: Each test should link to a requirement.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      typescript:\n        - file: tests/coverage.test.ts\n{requirement_symbols}",
+        ),
+    )
+    .expect("requirement");
+
+    let feature_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - coveredApi\n"
+    };
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        format!(
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Public APIs must stay owned\n    summary: Each public API should link to a feature.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      typescript:\n        - file: src/api.ts\n{feature_symbols}",
+        ),
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("src/api.ts"),
+        "/** FEAT-001 */\nexport function coveredApi(): void {}\n\nexport function uncoveredApi(): void {}\n",
+    )
+    .expect("source");
+    fs::write(
+        root.join("tests/coverage.test.ts"),
+        "/** REQ-001 */\nexport function testCoveredCase(): void {}\n\nexport function testUncoveredCase(): void {}\n",
+    )
+    .expect("tests");
+}
+
+#[test]
+fn validate_reports_untracked_typescript_symbols_and_tests() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), false);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "typescript coverage gaps should fail"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SYU-coverage-public-001"),
+        "expected public coverage error, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("SYU-coverage-test-001"),
+        "expected test coverage error, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn validate_accepts_wildcard_typescript_coverage() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn typescript_non_exported_symbols_are_not_required_to_be_traced() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), false);
+
+    // Add a non-exported function that should NOT trigger a coverage error
+    fs::write(
+        tempdir.path().join("src/api.ts"),
+        "/** FEAT-001 */\nexport function coveredApi(): void {}\n\nexport function uncoveredApi(): void {}\n\nfunction internalHelper(): void {}\n",
+    )
+    .expect("source with internal fn");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("internalHelper"),
+        "non-exported symbols should be excluded from coverage, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Extends `validate.require_symbol_trace_coverage` to inventory TypeScript/JavaScript exported symbols and test functions alongside Rust, closing the adoption cliff for teams whose feature work lands primarily in TS/JS.

## Changes

- **`src/inspect.rs`**: Make `TypeScriptSymbolInspection` and `inspect_typescript_file` `pub(crate)`; add `is_exported` field tracked via `export_statement` parent detection in tree-sitter AST traversal
- **`src/coverage.rs`**: Add `discover_typescript_targets` that scans `src/**/*.{ts,tsx,js,jsx}` for exported symbols and `tests/**/*.{ts,tsx,js,jsx}` for `test*`-prefixed functions
- **`tests/trace_coverage_validation.rs`**: Add 3 integration tests covering TS/JS public symbols, test functions, and non-exported symbol exclusions
- **`docs/syu/requirements/core/validation.yaml`**: Update REQ-CORE-002 to fully describe multi-language coverage
- **`docs/syu/features/repository/quality.yaml`**, **`tests/repository_quality.rs`**: Fix codeql-action v3→v4 reference to match the already-merged dependabot upgrade

## Motivation

Closes #53

PHIL-002: Language-agnostic ownership  
POL-003, POL-006: Consistent enforcement across all first-class languages