### PR TITLE
feat: extend strict symbol trace coverage to TypeScript and JavaScript

### DIFF
--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -65,16 +65,17 @@ requirements:
     description: |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the trace path uses canonical
+      today: Rust, Python, and TypeScript/JavaScript. A declared trace is valid
+      only when the file exists, the symbol exists, the trace path uses canonical
       repository-relative form, the file explicitly mentions the owning ID, and
       any `doc_contains` snippets are present in the symbol documentation.
       Validation MUST also reject duplicate trace mappings inside a single
       language list, support wildcard file ownership, and provide an optional
       mode that requires every public symbol (non-underscore-prefixed for Python,
-      `pub` for Rust) and every test symbol (`test_*` functions for Python,
-      `#[test]` for Rust) in repository source and test roots to belong to some
-      feature or requirement respectively.
+      `pub` for Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `#[test]` for Rust, `test*`-prefixed
+      functions for TypeScript/JavaScript) in repository source and test roots
+      to belong to some feature or requirement respectively.
     priority: high
     status: implemented
     linked_policies:
@@ -116,6 +117,10 @@ requirements:
         - file: tests/fixtures/workspaces/passing/python/test_traceability.py
           symbols:
             - test_req_trace_py
+      typescript:
+        - file: tests/fixtures/workspaces/passing/frontend/test_traceability.ts
+          symbols:
+            - '*'
   - id: REQ-CORE-003
     title: Support conservative autofix and config-driven default_fix
     description: |

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -11,7 +11,7 @@ use syn::{Attribute, ImplItem, Item, Visibility};
 
 use crate::{
     config::SyuConfig,
-    inspect::inspect_python_file,
+    inspect::{inspect_python_file, inspect_typescript_file},
     model::{Feature, Issue, Requirement, TraceReference},
     workspace::Workspace,
 };
@@ -50,6 +50,14 @@ pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Is
 
     match discover_python_targets(&workspace.config, &workspace.root) {
         Ok(python_targets) => targets.extend(python_targets),
+        Err(issue) => {
+            issues.push(*issue);
+            return;
+        }
+    }
+
+    match discover_typescript_targets(&workspace.root) {
+        Ok(ts_targets) => targets.extend(ts_targets),
         Err(issue) => {
             issues.push(*issue);
             return;
@@ -436,6 +444,118 @@ fn python_files_under(root: &Path) -> Result<Vec<PathBuf>, Box<Issue>> {
 
 fn collect_rust_files_recursive(directory: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
     collect_files_recursive_by_extension(directory, "rs", files)
+}
+
+fn discover_typescript_targets(root: &Path) -> Result<Vec<CoverageTarget>, Box<Issue>> {
+    const TS_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
+
+    let src_dir = root.join("src");
+    let tests_dir = root.join("tests");
+
+    let mut src_files: Vec<PathBuf> = Vec::new();
+    let mut test_files: Vec<PathBuf> = Vec::new();
+
+    for ext in TS_EXTENSIONS {
+        src_files.extend(typescript_files_under(&src_dir, ext)?);
+        test_files.extend(typescript_files_under(&tests_dir, ext)?);
+    }
+
+    if src_files.is_empty() && test_files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut targets = Vec::new();
+
+    for path in &src_files {
+        let contents = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let symbols = match inspect_typescript_file(path, &contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned file should remain under the workspace root")
+            .to_path_buf();
+        for symbol in symbols {
+            if symbol.is_exported {
+                targets.push(CoverageTarget {
+                    file: relative.clone(),
+                    symbol: symbol.name,
+                    kind: CoverageTargetKind::PublicSymbol,
+                });
+            }
+        }
+    }
+
+    for path in &test_files {
+        let contents = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let symbols = match inspect_typescript_file(path, &contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned file should remain under the workspace root")
+            .to_path_buf();
+        for symbol in symbols {
+            if symbol.name.starts_with("test") || symbol.name.starts_with("Test") {
+                targets.push(CoverageTarget {
+                    file: relative.clone(),
+                    symbol: symbol.name,
+                    kind: CoverageTargetKind::TestSymbol,
+                });
+            }
+        }
+    }
+
+    targets.sort_by(|left, right| {
+        (
+            left.file.as_os_str(),
+            left.symbol.as_str(),
+            match left.kind {
+                CoverageTargetKind::PublicSymbol => 0,
+                CoverageTargetKind::TestSymbol => 1,
+            },
+        )
+            .cmp(&(
+                right.file.as_os_str(),
+                right.symbol.as_str(),
+                match right.kind {
+                    CoverageTargetKind::PublicSymbol => 0,
+                    CoverageTargetKind::TestSymbol => 1,
+                },
+            ))
+    });
+    targets.dedup();
+
+    Ok(targets)
+}
+
+fn typescript_files_under(root: &Path, extension: &str) -> Result<Vec<PathBuf>, Box<Issue>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_files_recursive_by_extension(root, extension, &mut files).map_err(|error| {
+        Box::new(Issue::error(
+            "SYU-coverage-walk-001",
+            "trace coverage inventory",
+            Some(root.display().to_string()),
+            format!(
+                "Failed to walk `{}` while building trace coverage inventory: {error}",
+                root.display()
+            ),
+            Some("Fix the directory layout or disable `validate.require_symbol_trace_coverage` until the workspace can be scanned.".to_string()),
+        ))
+    })?;
+    Ok(files)
 }
 
 fn collect_files_recursive_by_extension(

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -90,10 +90,11 @@ pub(crate) struct PythonSymbolInspection {
 }
 
 #[derive(Debug, Clone)]
-struct TypeScriptSymbolInspection {
-    name: String,
-    docs: String,
-    line: usize,
+pub(crate) struct TypeScriptSymbolInspection {
+    pub(crate) name: String,
+    pub(crate) docs: String,
+    pub(crate) line: usize,
+    pub(crate) is_exported: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -297,7 +298,10 @@ fn inspect_typescript_symbol(
     Ok(symbols.into_iter().find(|item| item.name == symbol))
 }
 
-fn inspect_typescript_file(path: &Path, contents: &str) -> Result<Vec<TypeScriptSymbolInspection>> {
+pub(crate) fn inspect_typescript_file(
+    path: &Path,
+    contents: &str,
+) -> Result<Vec<TypeScriptSymbolInspection>> {
     let mut parser = Parser::new();
     let language = match path.extension().and_then(|ext| ext.to_str()) {
         Some("tsx" | "jsx") => tree_sitter_typescript::LANGUAGE_TSX,
@@ -312,15 +316,18 @@ fn inspect_typescript_file(path: &Path, contents: &str) -> Result<Vec<TypeScript
         .ok_or_else(|| anyhow::anyhow!("failed to parse TypeScript source"))?;
 
     let mut symbols = Vec::new();
-    collect_typescript_symbols(tree.root_node(), contents, &mut symbols);
+    collect_typescript_symbols(tree.root_node(), contents, false, &mut symbols);
     Ok(symbols)
 }
 
 fn collect_typescript_symbols(
     node: tree_sitter::Node<'_>,
     contents: &str,
+    parent_is_export: bool,
     symbols: &mut Vec<TypeScriptSymbolInspection>,
 ) {
+    let is_export = parent_is_export || node.kind() == "export_statement";
+
     match node.kind() {
         "function_declaration"
         | "class_declaration"
@@ -335,6 +342,7 @@ fn collect_typescript_symbols(
                     .map(|block| block.text)
                     .unwrap_or_default(),
                 line: node.start_position().row + 1,
+                is_exported: is_export,
             });
         }
         "variable_declarator" => {
@@ -345,6 +353,7 @@ fn collect_typescript_symbols(
                     .map(|block| block.text)
                     .unwrap_or_default(),
                 line: node.start_position().row + 1,
+                is_exported: is_export,
             });
         }
         _ => {}
@@ -353,7 +362,7 @@ fn collect_typescript_symbols(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.is_named() {
-            collect_typescript_symbols(child, contents, symbols);
+            collect_typescript_symbols(child, contents, is_export, symbols);
         }
     }
 }

--- a/tests/fixtures/workspaces/passing/frontend/test_traceability.ts
+++ b/tests/fixtures/workspaces/passing/frontend/test_traceability.ts
@@ -1,0 +1,5 @@
+// REQ-CORE-002
+
+export function testTsTraceCoverage(): boolean {
+  return true;
+}

--- a/tests/trace_coverage_validation.rs
+++ b/tests/trace_coverage_validation.rs
@@ -261,3 +261,151 @@ fn python_private_symbols_are_not_required_to_be_traced() {
         "private symbols should be excluded from coverage, got:\n{stdout}"
     );
 }
+
+fn write_typescript_workspace(root: &Path, cover_everything: bool) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_symbol_trace_coverage: true\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep the graph explicit\n    product_design_principle: Every layer should be connected.\n    coding_guideline: Prefer explicit ownership.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Every symbol must be owned\n    summary: Public symbols and tests may require ownership.\n    description: This fixture turns the strict coverage rule on.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    let requirement_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - testCoveredTs\n"
+    };
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Tests must stay justified\n    description: Each test should link to a requirement.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      typescript:\n        - file: tests/coverage.test.ts\n{requirement_symbols}",
+        ),
+    )
+    .expect("requirement");
+
+    let feature_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - coveredApi\n"
+    };
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        format!(
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Public APIs must stay owned\n    summary: Each public API should link to a feature.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      typescript:\n        - file: src/api.ts\n{feature_symbols}",
+        ),
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("src/api.ts"),
+        "// FEAT-001\n\nexport function coveredApi(): boolean { return true; }\nexport function uncoveredApi(): boolean { return false; }\n",
+    )
+    .expect("source");
+    fs::write(
+        root.join("tests/coverage.test.ts"),
+        "// REQ-001\n\nexport function testCoveredTs(): void {}\nexport function testUncoveredTs(): void {}\n",
+    )
+    .expect("tests");
+}
+
+#[test]
+fn validate_reports_untracked_typescript_symbols_and_tests() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), false);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "typescript coverage gaps should fail"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SYU-coverage-public-001"),
+        "expected public coverage error, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("SYU-coverage-test-001"),
+        "expected test coverage error, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn validate_accepts_wildcard_typescript_coverage() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn typescript_non_exported_symbols_are_not_required_to_be_traced() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_typescript_workspace(tempdir.path(), false);
+
+    // Add a non-exported function that should NOT trigger a coverage error
+    fs::write(
+        tempdir.path().join("src/api.ts"),
+        "// FEAT-001\n\nexport function coveredApi(): boolean { return true; }\nexport function uncoveredApi(): boolean { return false; }\nfunction internalHelper(): void {}\n",
+    )
+    .expect("source with internal fn");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("internalHelper"),
+        "non-exported symbols should be excluded from coverage, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Extends the strict symbol trace coverage system to TypeScript and JavaScript sources, completing multi-language coverage alongside the existing Rust and Python support.

## Changes

- **`src/inspect.rs`**: Make `TypeScriptSymbolInspection` and `inspect_typescript_file` `pub(crate)`; add `is_exported: bool` field; modify `collect_typescript_symbols` to accept `parent_is_export` flag and track `export_statement` nodes
- **`src/coverage.rs`**: Add `discover_typescript_targets` that scans `src/**/*.{ts,tsx,js,jsx}` for exported symbols and `tests/**/*.{ts,tsx,js,jsx}` for `test*`-prefixed functions; call it from `validate_symbol_trace_coverage`
- **`tests/trace_coverage_validation.rs`**: Add `write_typescript_workspace` helper and 3 TypeScript integration tests
- **`docs/syu/requirements/core/validation.yaml`**: Update REQ-CORE-002 description and add TypeScript test trace entry
- **`tests/fixtures/workspaces/passing/frontend/test_traceability.ts`**: Add fixture file for REQ-CORE-002 TypeScript trace

## Closes #53