### PR TITLE
feat: improve syu list and syu browse UX (#70)

### DIFF
--- a/docs/syu/features/cli/browse.yaml
+++ b/docs/syu/features/cli/browse.yaml
@@ -22,3 +22,19 @@ features:
         - file: src/command/browse.rs
           symbols:
             - "*"
+
+  - id: FEAT-BROWSE-002
+    title: Non-interactive spec tree output
+    summary: Add a --non-interactive flag to `syu browse` that prints the spec tree (all kinds grouped with counts and IDs) to stdout and exits, suitable for CI and scripting.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-015
+    implementations:
+      rust:
+        - file: src/command/browse.rs
+          symbols:
+            - run_browse_command
+            - print_non_interactive
+        - file: src/cli.rs
+          symbols:
+            - BrowseArgs

--- a/docs/syu/features/cli/show-list.yaml
+++ b/docs/syu/features/cli/show-list.yaml
@@ -14,6 +14,20 @@ features:
           symbols:
             - run_list_command
 
+  - id: FEAT-LIST-002
+    title: Optional-kind listing with all-kinds default
+    summary: Allow `syu list` without a kind argument to list all spec layers grouped by type, and accept a bare workspace path to list all kinds in that workspace.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/list.rs
+          symbols:
+            - run_list_command
+            - parse_list_positionals
+            - print_section_list
+
   - id: FEAT-SHOW-001
     title: Non-interactive definition detail lookup
     summary: Show one philosophy, policy, requirement, or feature by ID in one command.

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -44,6 +44,7 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-BROWSE-001
+      - FEAT-BROWSE-002
     tests:
       rust:
         - file: tests/browse_command.rs
@@ -110,6 +111,7 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-LIST-001
+      - FEAT-LIST-002
       - FEAT-SHOW-001
     tests:
       rust:
@@ -122,3 +124,6 @@ requirements:
         - file: src/lib.rs
           symbols:
             - dispatches_lookup_subcommands_without_rewriting_them
+        - file: src/command/list.rs
+          symbols:
+            - '*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 // FEAT-APP-001
 // FEAT-BROWSE-001
+// FEAT-BROWSE-002
+// FEAT-LIST-002
 // FEAT-REPORT-001
 // FEAT-INIT-002
 // REQ-CORE-001
@@ -48,12 +50,18 @@ pub struct BrowseArgs {
     #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
+
+    /// Print the spec tree to stdout and exit without entering interactive mode.
+    /// Useful in CI pipelines and scripts.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub non_interactive: bool,
 }
 
 impl Default for BrowseArgs {
     fn default() -> Self {
         Self {
             workspace: PathBuf::from("."),
+            non_interactive: false,
         }
     }
 }
@@ -83,13 +91,16 @@ impl LookupKind {
 
 #[derive(Debug, Clone, Args)]
 pub struct ListArgs {
-    #[arg(help = "Layer kind to list")]
-    #[arg(value_enum)]
-    pub kind: LookupKind,
-
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
-    #[arg(default_value = ".")]
-    pub workspace: PathBuf,
+    /// Layer kind to list, or a workspace path to list all kinds.
+    /// Usage: syu list [KIND] [WORKSPACE]
+    ///        syu list [WORKSPACE]     (lists all kinds)
+    ///        syu list                 (lists all kinds in the current directory)
+    #[arg(
+        num_args = 0..=2,
+        value_name = "KIND_OR_WORKSPACE",
+        help = "Optional kind (philosophy|policy|requirement|feature) and/or workspace path"
+    )]
+    pub positional: Vec<String>,
 
     #[arg(help = "Output format for listed items")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -1,4 +1,5 @@
 // FEAT-BROWSE-001
+// FEAT-BROWSE-002
 // REQ-CORE-015
 
 use std::io::{self, Write};
@@ -43,6 +44,12 @@ pub fn run_browse_command(args: &BrowseArgs) -> Result<i32> {
     let result = collect_check_result(&args.workspace);
     let workspace = load_workspace(&args.workspace).ok();
     let state = BrowseState { workspace, result };
+
+    if args.non_interactive {
+        state.print_non_interactive();
+        return Ok(0);
+    }
+
     state.run()
 }
 
@@ -341,6 +348,32 @@ impl BrowseState {
             self.result.issues.len()
         );
         println!();
+    }
+
+    fn print_non_interactive(&self) {
+        self.print_summary("syu spec tree");
+
+        for (heading, kind) in [
+            ("philosophy", EntityKind::Philosophy),
+            ("policy", EntityKind::Policy),
+            ("requirement", EntityKind::Requirement),
+            ("feature", EntityKind::Feature),
+        ] {
+            let entries = self.entity_entries(kind);
+            println!("=== {} ({}) ===", heading, entries.len());
+            for (id, title) in &entries {
+                println!("  {id}\t{title}");
+            }
+            println!();
+        }
+
+        if !self.result.issues.is_empty() {
+            println!("=== errors ({}) ===", self.result.issues.len());
+            for issue in &self.result.issues {
+                println!("  [{}] {}", issue.code, issue.subject);
+            }
+            println!();
+        }
     }
 
     fn print_links<F>(

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -1,11 +1,15 @@
 // FEAT-LIST-001
+// FEAT-LIST-002
 // REQ-CORE-018
 
-use anyhow::Result;
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow};
+use clap::ValueEnum as _;
 use serde::Serialize;
 
 use crate::{
-    cli::{ListArgs, OutputFormat},
+    cli::{ListArgs, LookupKind, OutputFormat},
     workspace::load_workspace,
 };
 
@@ -17,27 +21,170 @@ struct JsonListOutput {
     items: Vec<EntitySummary>,
 }
 
-pub fn run_list_command(args: &ListArgs) -> Result<i32> {
-    let workspace = load_workspace(&args.workspace)?;
-    let items = WorkspaceLookup::new(&workspace).entries(args.kind);
+#[derive(Debug, Serialize)]
+struct JsonAllKindsOutput {
+    philosophy: Vec<EntitySummary>,
+    policy: Vec<EntitySummary>,
+    requirement: Vec<EntitySummary>,
+    feature: Vec<EntitySummary>,
+}
 
-    match args.format {
-        OutputFormat::Text => print_text_list(&items),
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&JsonListOutput {
-                kind: args.kind.label(),
-                items,
-            })
-            .expect("serializing list output to JSON should succeed")
-        ),
+pub fn run_list_command(args: &ListArgs) -> Result<i32> {
+    let (kind, workspace) = parse_list_positionals(&args.positional)?;
+    let workspace = load_workspace(&workspace)?;
+    let lookup = WorkspaceLookup::new(&workspace);
+
+    match kind {
+        Some(k) => {
+            let items = lookup.entries(k);
+            match args.format {
+                OutputFormat::Text => print_text_list(&items),
+                OutputFormat::Json => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&JsonListOutput {
+                        kind: k.label(),
+                        items,
+                    })
+                    .expect("serializing list output to JSON should succeed")
+                ),
+            }
+        }
+        None => {
+            let philosophies = lookup.entries(LookupKind::Philosophy);
+            let policies = lookup.entries(LookupKind::Policy);
+            let requirements = lookup.entries(LookupKind::Requirement);
+            let features = lookup.entries(LookupKind::Feature);
+
+            match args.format {
+                OutputFormat::Text => {
+                    print_section_list("philosophy", &philosophies);
+                    print_section_list("policy", &policies);
+                    print_section_list("requirement", &requirements);
+                    print_section_list("feature", &features);
+                }
+                OutputFormat::Json => println!(
+                    "{}",
+                    serde_json::to_string_pretty(&JsonAllKindsOutput {
+                        philosophy: philosophies,
+                        policy: policies,
+                        requirement: requirements,
+                        feature: features,
+                    })
+                    .expect("serializing all-kinds output to JSON should succeed")
+                ),
+            }
+        }
     }
 
     Ok(0)
 }
 
+fn parse_list_positionals(positional: &[String]) -> Result<(Option<LookupKind>, PathBuf)> {
+    match positional {
+        [] => Ok((None, PathBuf::from("."))),
+        [first] => {
+            if let Ok(kind) = LookupKind::from_str(first, true) {
+                Ok((Some(kind), PathBuf::from(".")))
+            } else {
+                Ok((None, PathBuf::from(first)))
+            }
+        }
+        [kind_str, workspace_str, ..] => {
+            let kind = LookupKind::from_str(kind_str, true).map_err(|_| {
+                anyhow!(
+                    "invalid value '{}' for KIND\n  \
+                     possible values: philosophy, policy, requirement, feature\n  \
+                     Hint: to list all kinds in a workspace, run `syu list {}`",
+                    kind_str,
+                    workspace_str
+                )
+            })?;
+            Ok((Some(kind), PathBuf::from(workspace_str)))
+        }
+    }
+}
+
 fn print_text_list(items: &[EntitySummary]) {
     for item in items {
         println!("{}\t{}", item.id, item.title);
+    }
+}
+
+fn print_section_list(heading: &str, items: &[EntitySummary]) {
+    println!("=== {} ({}) ===", heading, items.len());
+    for item in items {
+        println!("{}\t{}", item.id, item.title);
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::cli::LookupKind;
+
+    use super::parse_list_positionals;
+
+    #[test]
+    // FEAT-LIST-002
+    fn parse_list_positionals_empty_returns_all_kinds_in_cwd() {
+        let (kind, workspace) = parse_list_positionals(&[]).expect("should succeed");
+        assert!(kind.is_none());
+        assert_eq!(workspace, PathBuf::from("."));
+    }
+
+    #[test]
+    // FEAT-LIST-002
+    fn parse_list_positionals_path_returns_all_kinds_in_given_workspace() {
+        let (kind, workspace) =
+            parse_list_positionals(&["/tmp/myproject".to_string()]).expect("should succeed");
+        assert!(kind.is_none());
+        assert_eq!(workspace, PathBuf::from("/tmp/myproject"));
+    }
+
+    #[test]
+    // FEAT-LIST-002
+    fn parse_list_positionals_dot_returns_all_kinds_in_cwd() {
+        let (kind, workspace) = parse_list_positionals(&[".".to_string()]).expect("should succeed");
+        assert!(kind.is_none());
+        assert_eq!(workspace, PathBuf::from("."));
+    }
+
+    #[test]
+    // FEAT-LIST-001
+    fn parse_list_positionals_kind_only_returns_kind_with_cwd() {
+        let (kind, workspace) =
+            parse_list_positionals(&["requirement".to_string()]).expect("should succeed");
+        assert_eq!(kind, Some(LookupKind::Requirement));
+        assert_eq!(workspace, PathBuf::from("."));
+    }
+
+    #[test]
+    // FEAT-LIST-001
+    fn parse_list_positionals_kind_and_workspace_returns_both() {
+        let (kind, workspace) =
+            parse_list_positionals(&["feature".to_string(), "/tmp/ws".to_string()])
+                .expect("should succeed");
+        assert_eq!(kind, Some(LookupKind::Feature));
+        assert_eq!(workspace, PathBuf::from("/tmp/ws"));
+    }
+
+    #[test]
+    // FEAT-LIST-001
+    fn parse_list_positionals_kind_plural_alias_works() {
+        let (kind, _workspace) =
+            parse_list_positionals(&["requirements".to_string()]).expect("should succeed");
+        assert_eq!(kind, Some(LookupKind::Requirement));
+    }
+
+    #[test]
+    // FEAT-LIST-002
+    fn parse_list_positionals_two_args_invalid_kind_returns_error() {
+        let result = parse_list_positionals(&["notakind".to_string(), ".".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid value"), "error: {msg}");
+        assert!(msg.contains("syu list ."), "hint missing: {msg}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub fn run() -> Result<i32> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::cli::{AppArgs, Cli, Commands, ListArgs, LookupKind, OutputFormat, ShowArgs};
+    use crate::cli::{AppArgs, Cli, Commands, ListArgs, OutputFormat, ShowArgs};
 
     // REQ-CORE-015
     #[test]
@@ -82,7 +82,7 @@ mod tests {
         let action = super::dispatch(Cli { command: None }, true, true);
         assert!(matches!(
             action,
-            super::Dispatch::Browse(crate::cli::BrowseArgs { workspace })
+            super::Dispatch::Browse(crate::cli::BrowseArgs { workspace, .. })
                 if workspace == Path::new(".")
         ));
     }
@@ -115,8 +115,7 @@ mod tests {
         let list = super::dispatch(
             Cli {
                 command: Some(Commands::List(ListArgs {
-                    kind: LookupKind::Requirement,
-                    workspace: PathBuf::from("workspace"),
+                    positional: vec!["requirement".to_string(), "workspace".to_string()],
                     format: OutputFormat::Json,
                 })),
             },
@@ -125,9 +124,8 @@ mod tests {
         );
         assert!(matches!(
             list,
-            super::Dispatch::List(crate::cli::ListArgs { kind, workspace, format })
-                if kind == LookupKind::Requirement
-                    && workspace == Path::new("workspace")
+            super::Dispatch::List(crate::cli::ListArgs { ref positional, format })
+                if positional == &["requirement", "workspace"]
                     && format == OutputFormat::Json
         ));
 

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -142,3 +142,67 @@ fn browse_command_handles_empty_workspaces_and_prompt_retries() {
     assert!(stdout.contains("Please enter a number between 0 and 5."));
     assert!(stdout.contains("No philosophy entries are currently available."));
 }
+
+#[test]
+// REQ-CORE-015
+fn browse_command_non_interactive_prints_spec_tree_and_exits() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("browse")
+        .arg(fixture_path("passing"))
+        .arg("--non-interactive")
+        .output()
+        .expect("browse command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== syu spec tree ==="),
+        "should show spec tree header"
+    );
+    assert!(
+        stdout.contains("=== philosophy"),
+        "should show philosophy section"
+    );
+    assert!(
+        stdout.contains("=== requirement"),
+        "should show requirement section"
+    );
+    assert!(
+        stdout.contains("PHIL-TRACE-001"),
+        "should list philosophy IDs"
+    );
+}
+
+#[test]
+// REQ-CORE-015
+fn browse_command_non_interactive_shows_errors_when_workspace_is_failing() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("browse")
+        .arg(fixture_path("failing"))
+        .arg("--non-interactive")
+        .output()
+        .expect("browse command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== errors ("),
+        "should show errors section: {stdout}"
+    );
+    assert!(
+        stdout.contains("SYU-graph-reference-001"),
+        "should list error codes: {stdout}"
+    );
+}

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -74,3 +74,100 @@ fn list_command_accepts_plural_lookup_aliases() {
     assert!(output.status.success(), "plural alias should be accepted");
     assert!(String::from_utf8_lossy(&output.stdout).contains("REQ-TRACE-003"));
 }
+
+#[test]
+// REQ-CORE-018
+fn list_command_without_kind_lists_all_kinds() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== philosophy ("),
+        "should show philosophy section"
+    );
+    assert!(
+        stdout.contains("=== policy ("),
+        "should show policy section"
+    );
+    assert!(
+        stdout.contains("=== requirement ("),
+        "should show requirement section"
+    );
+    assert!(
+        stdout.contains("=== feature ("),
+        "should show feature section"
+    );
+    assert!(
+        stdout.contains("PHIL-TRACE-001"),
+        "should include philosophies"
+    );
+    assert!(stdout.contains("FEAT-TRACE-001"), "should include features");
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_dot_as_workspace_lists_all_kinds() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "syu list <path> should list all kinds: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("PHIL-TRACE-001"),
+        "should list philosophies"
+    );
+    assert!(stdout.contains("FEAT-TRACE-001"), "should list features");
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_all_kinds_supports_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg(fixture_path("passing"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert!(
+        json["philosophy"].is_array(),
+        "JSON should have philosophy array"
+    );
+    assert!(json["policy"].is_array(), "JSON should have policy array");
+    assert!(
+        json["requirement"].is_array(),
+        "JSON should have requirement array"
+    );
+    assert!(json["feature"].is_array(), "JSON should have feature array");
+    assert_eq!(json["philosophy"][0]["id"], "PHIL-TRACE-001");
+}


### PR DESCRIPTION
Closes #70

## Changes

### `syu list` improvements (FEAT-LIST-002)
- **No args**: list all kinds (philosophy/policy/requirement/feature) in CWD
- **1 arg (path)**: list all kinds in the specified workspace  
- **1 arg (kind)**: list that kind in CWD (backward-compatible)
- **2 args (kind path)**: list kind in workspace (backward-compatible)
- `--format json` outputs structured JSON with all kinds as arrays

### `syu browse --non-interactive` (FEAT-BROWSE-002)
- Prints the full spec tree and exits without launching the interactive TUI
- Useful for CI pipelines, scripts, and shell integrations
- Shows validation errors when present

## Spec compliance
- Added FEAT-LIST-002 to `docs/syu/features/cli/show-list.yaml`
- Added FEAT-BROWSE-002 to `docs/syu/features/cli/browse.yaml`
- Updated requirements REQ-CORE-018 and REQ-CORE-015 with reciprocal links
- All validation rules and traceability checks pass (requirements=53/53 features=73/73)