### PR TITLE
ci: cache wasm-pack installation using taiki-e/cache-cargo-install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+        uses: taiki-e/cache-cargo-install-action@v3
+        with:
+          tool: wasm-pack
 
       - name: Install browser app dependencies
         working-directory: app


### PR DESCRIPTION
Closes #73

Replace bare `cargo install wasm-pack --locked` with `taiki-e/cache-cargo-install-action@v3`, matching the pattern used for `cargo-llvm-cov` and `cargo-audit`. This avoids recompiling wasm-pack from source on every CI run, saving 3–5 minutes on the browser-app job.