### PR TITLE
docs: add end-to-end tutorial with Filestore worked example

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -120,6 +120,7 @@ The repository includes complete examples:
 
 ## Keep exploring
 
+- Follow the [end-to-end tutorial](./tutorial.md) to build a complete four-layer spec from scratch
 - Read [syu concepts](./concepts.md) for the reasoning behind the four layers
 - Review [configuration](./configuration.md) before tightening validation in a real repository
 - Start `syu app .` when you want a browser view of the same workspace

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -1,0 +1,277 @@
+# End-to-end tutorial
+
+<!-- FEAT-DOCS-001 -->
+
+This tutorial walks through building a small, realistic workspace from scratch. By the end you will have a four-layer spec (philosophy → policy → requirement → feature), a passing `syu validate .`, and a browsable `syu app .`.
+
+The example project is **Filestore** — a minimal file-storage library.
+
+---
+
+## 1. Bootstrap the workspace
+
+```bash
+mkdir filestore && cd filestore
+syu init .
+```
+
+`syu init` creates:
+
+```
+syu.yaml
+docs/syu/
+  philosophy/foundation.yaml
+  policies/policies.yaml
+  requirements/core/core.yaml
+  features/
+    features.yaml
+    core/core.yaml
+```
+
+`syu.yaml` points the validator at that tree:
+
+```yaml
+# syu.yaml
+workspace: docs/syu
+```
+
+---
+
+## 2. Write a philosophy entry
+
+Replace the starter content in `docs/syu/philosophy/foundation.yaml`:
+
+```yaml
+category: Philosophy
+version: 1
+language: en
+
+philosophies:
+  - id: PHIL-STORE-001
+    title: Data integrity is non-negotiable
+    product_design_principle: >
+      Every file stored by Filestore must arrive at the caller in exactly
+      the byte-for-byte state it was written. Corruption must be detected,
+      never silently accepted.
+    coding_guideline: >
+      All write paths must flush and fsync before returning success.
+      All read paths must verify a checksum before returning data.
+    linked_policies:
+      - POL-STORE-001
+```
+
+> **Key fields**
+> - `id` — a stable, unique identifier. The `PHIL-` prefix is conventional for philosophies.
+> - `product_design_principle` — the *why* behind product decisions.
+> - `coding_guideline` — the *how* that engineers must follow.
+> - `linked_policies` — the policies that operationalise this philosophy.
+
+---
+
+## 3. Write a policy entry
+
+Edit `docs/syu/policies/policies.yaml`:
+
+```yaml
+category: Policies
+version: 1
+language: en
+
+policies:
+  - id: POL-STORE-001
+    title: Write paths must verify integrity on every operation
+    summary: >
+      Every store-write operation must confirm data integrity before
+      reporting success to the caller.
+    description: >
+      Corruption at rest is one of the most expensive bugs to diagnose.
+      This policy operationalises PHIL-STORE-001 by mandating an
+      explicit integrity check (checksum or equivalent) on every write.
+    linked_philosophies:
+      - PHIL-STORE-001
+    linked_requirements:
+      - REQ-STORE-001
+```
+
+> **Reciprocal links are required.** `POL-STORE-001` links *up* to `PHIL-STORE-001`
+> and the philosophy links *down* to `POL-STORE-001`. Both directions must be present
+> or `SYU-graph-reciprocal-001` will fire.
+
+---
+
+## 4. Write a requirement
+
+Edit `docs/syu/requirements/core/core.yaml`:
+
+```yaml
+category: Filestore Core Requirements
+prefix: REQ-STORE
+
+requirements:
+  - id: REQ-STORE-001
+    title: write() must return an error if the checksum does not match
+    description: >
+      After flushing bytes to disk, the store computes a checksum of the
+      written data and compares it with the expected value. If they differ,
+      write() returns an error; the partial file is removed.
+    priority: high
+    status: planned
+    linked_policies:
+      - POL-STORE-001
+    linked_features:
+      - FEAT-STORE-001
+```
+
+`status: planned` means the feature is not yet implemented. No trace entries are
+required yet — the validator will reject them on a `planned` item.
+
+---
+
+## 5. Write a feature
+
+Edit `docs/syu/features/core/core.yaml`:
+
+```yaml
+category: Filestore Core Features
+version: 1
+
+features:
+  - id: FEAT-STORE-001
+    title: Integrity-checked write
+    summary: >
+      The write() implementation computes a SHA-256 checksum after flush
+      and returns an error when the checksum mismatches.
+    status: planned
+    linked_requirements:
+      - REQ-STORE-001
+```
+
+Register this document in `docs/syu/features/features.yaml`:
+
+```yaml
+version: 1
+documents:
+  - path: core/core.yaml
+```
+
+---
+
+## 6. Validate — first run
+
+```bash
+syu validate .
+```
+
+Expected output when everything links correctly:
+
+```
+✓ workspace loaded
+✓ no blank fields
+✓ no duplicate IDs
+✓ all references resolve
+✓ all links are reciprocal
+✓ no orphaned items
+✓ delivery status is consistent
+syu validate: 0 errors, 0 warnings
+```
+
+If you see `SYU-graph-reciprocal-001` it means a link is one-directional. Add
+the missing reverse link and re-run. See the
+[validation error reference](./getting-started.md#understanding-validation-output)
+for a complete list of common errors.
+
+---
+
+## 7. Mark a feature as implemented
+
+When the code for `FEAT-STORE-001` is written (say, in `src/store.rs`), change
+the status and add trace entries in **both** the requirement and the feature:
+
+**`docs/syu/requirements/core/core.yaml`** — add `tests`:
+
+```yaml
+    status: implemented
+    linked_policies:
+      - POL-STORE-001
+    linked_features:
+      - FEAT-STORE-001
+    tests:
+      rust:
+        - file: src/store.rs
+          symbols:
+            - test_write_checksum_mismatch
+          doc_contains:
+            - REQ-STORE-001
+```
+
+**`docs/syu/features/core/core.yaml`** — add `implementations`:
+
+```yaml
+    status: implemented
+    linked_requirements:
+      - REQ-STORE-001
+    implementations:
+      rust:
+        - file: src/store.rs
+          symbols:
+            - write
+          doc_contains:
+            - FEAT-STORE-001
+```
+
+In `src/store.rs` make sure the symbol and doc-comment are present:
+
+```rust
+/// FEAT-STORE-001: Integrity-checked write.
+pub fn write(path: &Path, data: &[u8]) -> Result<()> {
+    // ... flush, checksum, return error on mismatch
+}
+
+#[test]
+fn test_write_checksum_mismatch() {
+    // REQ-STORE-001: write() must return an error on checksum mismatch
+    // ...
+}
+```
+
+Run validation again — it should still pass with zero errors.
+
+---
+
+## 8. Explore with the CLI
+
+```bash
+# List all requirements
+syu list requirement
+
+# Inspect a single item
+syu show REQ-STORE-001
+
+# Interactive terminal browser
+syu browse .
+```
+
+---
+
+## 9. Open the browser UI
+
+```bash
+syu app .
+```
+
+This serves a local web UI at `http://localhost:<port>` (the port is printed on
+startup). The UI shows the four layers as tabs, displays validation badges next
+to each section, and lets you click through linked items.
+
+---
+
+## What's next?
+
+- Add more layers: create additional requirement and feature documents, organise
+  them in sub-folders, and update `features.yaml`.
+- Read [syu concepts](./concepts.md) to understand the design decisions behind
+  the four-layer model.
+- Review [configuration](./configuration.md) to tighten validation thresholds
+  for your team.
+- Browse the built-in [validation rule catalog](../syu/features/validation/validation.yaml)
+  to understand every check `syu validate` performs.


### PR DESCRIPTION
Closes #77

## Changes
- Added `docs/guide/tutorial.md`: complete walkthrough from `syu init` to `syu validate` passing, using a plausible 'Filestore' library scenario
- Covers all four layers (philosophy → policy → requirement → feature) with annotated YAML examples and reciprocal-link explanations
- Shows `status: planned` → `status: implemented` transition with trace entries and matching Rust source snippets
- Links CLI commands (`syu list`, `syu show`, `syu browse`, `syu app`) to the file model at each step
- Added link to the tutorial from the getting-started 'Keep exploring' section

## Specification impact
Relates to FEAT-DOCS-001.