### PR TITLE
docs: add README.md to each example directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,3 @@ Commit messages that appear in the changelog follow the
 
 Write the subject line in the imperative mood (e.g. `feat: add syu list command`)
 so the generated changelog reads naturally.
-

--- a/examples/polyglot/README.md
+++ b/examples/polyglot/README.md
@@ -1,0 +1,52 @@
+# polyglot example
+
+This example demonstrates a multi-language workspace where a single
+requirement and feature are traced across **Rust**, **Python**, and
+**TypeScript** source files simultaneously.
+
+## Files
+
+| Path | What it defines |
+|------|-----------------|
+| `docs/syu/philosophy/foundation.yaml` | `PHIL-MIX-001` — the guiding principle |
+| `docs/syu/policies/policies.yaml` | `POL-MIX-001` linked to `PHIL-MIX-001` |
+| `docs/syu/requirements/core/polyglot.yaml` | `REQ-MIX-001` with traces in Rust, Python, and TypeScript |
+| `docs/syu/features/languages/polyglot.yaml` | `FEAT-MIX-001` with implementation traces in all three languages |
+| `src/trace.rs` | Rust sources with `mixed_rust_requirement` and `mixed_rust_feature` |
+| `python/test_traceability.py` | Python test with `test_python_requirement` |
+| `python/app.py` | Python source with `python_feature_impl` |
+| `frontend/traceability.test.ts` | TypeScript test with `typescriptRequirementTest` |
+| `frontend/feature.ts` | TypeScript source with `typescriptFeature` |
+
+## Try it
+
+```bash
+cd examples/polyglot
+syu validate .
+syu list requirement
+syu show REQ-MIX-001
+syu app .
+```
+
+A successful `syu validate .` produces output similar to:
+
+```
+syu validate passed
+workspace: examples/polyglot
+definitions: philosophies=1 policies=1 requirements=1 features=1
+traceability: requirements=6/6 features=6/6
+```
+
+## Key things to notice
+
+- **Multi-language traces** — a single `REQ-MIX-001` declares test traces in
+  three different `tests` language keys (`rust`, `python`, `typescript`). Each
+  language block names the file, the symbol, and the required doc-comment string.
+- **Per-language doc-comment conventions** — Rust uses `///` doc comments,
+  Python uses docstrings (`"""…"""`), and TypeScript uses JSDoc (`/** … */`).
+  Look at the respective source files to see how each format satisfies
+  `doc_contains`.
+- **Runtime configuration** — `syu.yaml` declares `runtimes.python.command`
+  and `runtimes.node.command` so syu knows how to invoke each language parser.
+- **Reciprocal links** — `REQ-MIX-001` and `FEAT-MIX-001` must reference
+  each other in both directions.

--- a/examples/python-only/README.md
+++ b/examples/python-only/README.md
@@ -1,0 +1,46 @@
+# python-only example
+
+This example demonstrates a minimal single-language Python workspace.
+It contains one philosophy, one policy, one requirement, and one feature —
+all mutually linked and traced to a Python test file.
+
+## Files
+
+| Path | What it defines |
+|------|-----------------|
+| `docs/syu/philosophy/foundation.yaml` | `PHIL-PY-001` — the guiding principle |
+| `docs/syu/policies/policies.yaml` | `POL-PY-001` linked to `PHIL-PY-001` |
+| `docs/syu/requirements/core/python.yaml` | `REQ-PY-001` with a test trace to `python/test_traceability.py` |
+| `docs/syu/features/languages/python.yaml` | `FEAT-PY-001` with an implementation trace to `python/app.py` |
+| `python/test_traceability.py` | Python test file containing the traced test function |
+| `python/app.py` | Python source containing the traced implementation function |
+
+## Try it
+
+```bash
+cd examples/python-only
+syu validate .
+syu list requirement
+syu show REQ-PY-001
+syu app .
+```
+
+A successful `syu validate .` produces output similar to:
+
+```
+syu validate passed
+workspace: examples/python-only
+definitions: philosophies=1 policies=1 requirements=1 features=1
+traceability: requirements=2/2 features=2/2
+```
+
+## Key things to notice
+
+- **Python tracing** — syu parses Python source files to verify that the
+  named symbols (functions and classes) exist and contain the required
+  `doc_contains` strings in their docstrings.
+- **Docstring format** — `doc_contains: ["requirement doc line"]` means the
+  string `"requirement doc line"` must appear somewhere in the function's
+  docstring. Open `python/test_traceability.py` to see a working example.
+- **Reciprocal links** — `REQ-PY-001` and `FEAT-PY-001` must each reference
+  the other; syu checks both directions.

--- a/examples/rust-only/README.md
+++ b/examples/rust-only/README.md
@@ -1,0 +1,46 @@
+# rust-only example
+
+This example demonstrates a minimal single-language Rust workspace.
+It contains one philosophy, one policy, one requirement, and one feature —
+all mutually linked and traced to a Rust source file.
+
+## Files
+
+| Path | What it defines |
+|------|-----------------|
+| `docs/syu/philosophy/foundation.yaml` | `PHIL-RUST-001` — the guiding principle |
+| `docs/syu/policies/policies.yaml` | `POL-RUST-001` linked to `PHIL-RUST-001` |
+| `docs/syu/requirements/core/rust.yaml` | `REQ-RUST-001` with a test trace to `src/trace.rs` |
+| `docs/syu/features/languages/rust.yaml` | `FEAT-RUST-001` with an implementation trace to `src/trace.rs` |
+| `src/trace.rs` | Rust source containing the traced symbols |
+
+## Try it
+
+```bash
+cd examples/rust-only
+syu validate .
+syu list requirement
+syu show REQ-RUST-001
+syu app .
+```
+
+A successful `syu validate .` produces output similar to:
+
+```
+syu validate passed
+workspace: examples/rust-only
+definitions: philosophies=1 policies=1 requirements=1 features=1
+traceability: requirements=2/2 features=2/2
+```
+
+## Key things to notice
+
+- **Reciprocal links** — `REQ-RUST-001` lists `FEAT-RUST-001` in its
+  `linked_features`, and `FEAT-RUST-001` lists `REQ-RUST-001` back in its
+  `linked_requirements`. Both directions are required.
+- **`doc_contains`** — the trace entries require certain strings to appear in
+  the doc comments of the traced symbols inside `src/trace.rs`. Open that file
+  to see how `/// requirement doc line` and `/// feature doc line` satisfy the
+  constraint.
+- **`symbols`** — each trace names the exact function (`rust_requirement_test`,
+  `rust_feature_impl`) that must exist in the file.


### PR DESCRIPTION
Closes #102

Adds README.md to examples/rust-only, examples/python-only, and examples/polyglot with orientation, file maps, try-it commands, and key concepts.