### PR TITLE
ci: run Playwright E2E tests in browser-app CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,3 +230,13 @@ jobs:
           npm run build:wasm
           npm run check
           npm run build
+
+      - name: Install Playwright browsers
+        working-directory: app
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright E2E tests
+        working-directory: app
+        run: npm run test:e2e
+        env:
+          CI: "true"


### PR DESCRIPTION
Closes #97

Adds Playwright browser installation and E2E test execution to the browser-app CI job so browser regressions are caught automatically.