### PR TITLE
fix: format long assert! in show_command test

### DIFF
--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -261,7 +261,10 @@ fn show_command_errors_when_the_id_is_missing() {
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("was not found"));
-    assert!(stderr.contains("syu list"), "hint should suggest syu list: {stderr}");
+    assert!(
+        stderr.contains("syu list"),
+        "hint should suggest syu list: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes precommit/quality CI failures on all open PRs. The assert! call was over the line length limit and rustfmt wants it split across multiple lines.