### PR TITLE
fix: apply rustfmt to check.rs and check_command tests

### DIFF
--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -662,14 +662,26 @@ fn render_text_report(
     if overall_success && result.issues.is_empty() {
         writeln!(&mut output).expect("writing to String must succeed");
         writeln!(&mut output, "What to do next:").expect("writing to String must succeed");
-        writeln!(&mut output, "  syu app .        open the browser UI to explore your workspace")
-            .expect("writing to String must succeed");
-        writeln!(&mut output, "  syu browse .     browse interactively in the terminal")
-            .expect("writing to String must succeed");
-        writeln!(&mut output, "  syu report .     generate a markdown validation report")
-            .expect("writing to String must succeed");
-        writeln!(&mut output, "  syu show <ID>    inspect a single spec item in detail")
-            .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu app .        open the browser UI to explore your workspace"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu browse .     browse interactively in the terminal"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu report .     generate a markdown validation report"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu show <ID>    inspect a single spec item in detail"
+        )
+        .expect("writing to String must succeed");
     }
 
     output

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -90,7 +90,10 @@ fn check_command_accepts_passing_workspace() {
         stdout.contains("What to do next:"),
         "success output should include next-step guidance: {stdout}"
     );
-    assert!(stdout.contains("syu app ."), "next-step block should mention syu app: {stdout}");
+    assert!(
+        stdout.contains("syu app ."),
+        "next-step block should mention syu app: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes remaining precommit/quality CI failures on open PRs. cargo fmt reformats writeln! calls in check.rs and the 3-arg assert! in check_command.rs.