### PR TITLE
fix: remove extra trailing newline from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,3 @@ Commit messages that appear in the changelog follow the
 
 Write the subject line in the imperative mood (e.g. `feat: add syu list command`)
 so the generated changelog reads naturally.
-


### PR DESCRIPTION
Removes the extra trailing blank line from CONTRIBUTING.md that was causing the `end-of-file-fixer` pre-commit hook to fail in CI on all subsequent PRs.