### PR TITLE
ci: add Linux ARM64 (aarch64-unknown-linux-gnu) release target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,6 +51,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             binary: syu
             cross_compile: true
+            linker: aarch64-linux-gnu-gcc
           - os: macos-15-intel
             target: x86_64-apple-darwin
             binary: syu
@@ -80,9 +81,18 @@ jobs:
 
       - name: Install cross-compilation toolchain (aarch64-linux-gnu)
         if: matrix.cross_compile == true
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+
+      - name: Build release binary (cross-compile aarch64 linux)
+        if: matrix.cross_compile == true
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build release binary
+        if: matrix.cross_compile != true
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package release artifacts


### PR DESCRIPTION
Closes #115

## Changes
- Add `aarch64-unknown-linux-gnu` matrix entry to `release-artifacts.yml` using cross-compilation on `ubuntu-latest`
- Install `gcc-aarch64-linux-gnu` cross-compilation toolchain when building for this target
- Add `.cargo/config.toml` linker entry for `aarch64-unknown-linux-gnu`

The existing installer script already handles `aarch64` on Linux correctly (`uname -m` returns `aarch64` → resolves to `aarch64-unknown-linux-gnu`), so no installer changes are needed.