### PR TITLE
fix: add browser and stop guidance to syu app

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ syu app .
 syu app . --bind 127.0.0.1 --port 3000
 ```
 
+After startup, `syu app` prints the local URL to open in your browser and a
+`Ctrl-C` reminder for stopping the server.
+
 The browser app serves a VitePlus / React / Tailwind UI and uses Rust plus
 WebAssembly to build the layered browser view from the live workspace data.
 When `syu.yaml` defines `app.bind` or `app.port`, `syu app` uses those defaults

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -6,10 +6,13 @@
 
 ```bash
 syu app .
-# → Serving on http://127.0.0.1:3000  (Ctrl-C to stop)
+# → syu app listening on http://127.0.0.1:3000
+# → Open http://127.0.0.1:3000 in your browser.
+# → Press Ctrl-C to stop.
 ```
 
-Open the printed URL in any browser.
+Open the printed URL in any browser, then press `Ctrl-C` in the terminal when
+you are done.
 
 ---
 

--- a/docs/syu/features/browser/app.yaml
+++ b/docs/syu/features/browser/app.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-APP-001
     title: Local browser workspace app powered by Rust and WebAssembly
-    summary: Start `syu app` to inspect the current workspace in a browser with a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
+    summary: Start `syu app` to inspect the current workspace in a browser with clear startup guidance, a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
     status: implemented
     linked_requirements:
       - REQ-CORE-017

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -67,7 +67,8 @@ requirements:
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them.
+      them. The startup output MUST also tell users which local URL to open in a
+      browser and how to stop the server cleanly.
     priority: medium
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,10 @@ New here?
   2. syu validate .  check the layered spec and traceability
   3. syu app .       open the browser UI to explore the workspace";
 
+const APP_AFTER_HELP: &str = "\
+After startup, open the printed URL in your browser.
+Press Ctrl-C to stop the local app server.";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "syu",
@@ -40,7 +44,10 @@ pub enum Commands {
     List(ListArgs),
     #[command(about = "Show one philosophy, policy, requirement, or feature by ID")]
     Show(ShowArgs),
-    #[command(about = "Start a local browser app for exploring the current workspace")]
+    #[command(
+        about = "Start a local browser app server and print the URL to open in your browser",
+        after_help = APP_AFTER_HELP
+    )]
     App(AppArgs),
     #[command(
         visible_alias = "check",

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -69,6 +69,8 @@ pub fn run_app_command(args: &AppArgs) -> Result<i32> {
             .local_addr()
             .context("failed to inspect bind address")?;
         println!("syu app listening on http://{local_addr}");
+        println!("Open http://{local_addr} in your browser.");
+        println!("Press Ctrl-C to stop.");
         std::io::stdout()
             .flush()
             .context("failed to flush stdout")?;

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Child, Command, Output, Stdio},
     thread,
     time::Duration,
 };
@@ -94,6 +94,20 @@ fn shutdown_child(child: &mut Child) {
     assert!(status.success(), "app command should exit cleanly");
 }
 
+fn shutdown_child_with_output(child: Child) -> Output {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGINT);
+    }
+
+    #[cfg(not(unix))]
+    child.kill().expect("child should terminate");
+
+    let output = child.wait_with_output().expect("child should exit");
+    assert!(output.status.success(), "app command should exit cleanly");
+    output
+}
+
 // REQ-CORE-017
 #[test]
 fn app_command_serves_browser_ui_and_payload() {
@@ -126,6 +140,48 @@ fn app_command_serves_browser_ui_and_payload() {
     assert!(payload.contains("foundation.yaml"));
 
     shutdown_child(&mut child);
+}
+
+#[test]
+fn app_command_startup_message_explains_browser_and_stop_flow() {
+    let port = reserve_port();
+    let child = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("app")
+        .arg(fixture_path("passing"))
+        .arg("--bind")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(port.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("app command should start");
+
+    wait_for_server(port);
+
+    let output = shutdown_child_with_output(child);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(&format!("syu app listening on http://127.0.0.1:{port}")));
+    assert!(stdout.contains(&format!("Open http://127.0.0.1:{port} in your browser.")));
+    assert!(stdout.contains("Press Ctrl-C to stop."));
+}
+
+#[test]
+fn app_command_help_mentions_browser_and_stop_instructions() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("app")
+        .arg("--help")
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("print the URL to open in your browser"));
+    assert!(stdout.contains("After startup, open the printed URL in your browser."));
+    assert!(stdout.contains("Press Ctrl-C to stop the local app server."));
 }
 
 #[test]


### PR DESCRIPTION
Summary: improve the syu app first-run experience so users know which URL to open and how to stop the server.

Changes:
- update syu app help with browser and stop guidance
- print explicit browser-open and Ctrl-C instructions on startup
- extend app command tests for help text and startup output
- update README, app guide, and self-hosted spec wording to match

Closes #134
