### PR TITLE
docs: align installer guidance for alpha track

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Current installer entrypoint:
 curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | bash
 ```
 
-Pin a specific release track:
+During the alpha phase, prefer the `alpha` track selector so the same installer
+entrypoint always resolves to the latest published alpha:
 
 ```bash
 curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,10 +23,12 @@ Make sure `syu` is installed and available on your `PATH`.
 **Option A — Install from a release (recommended)**
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash
 ```
 
-This places `syu` in `~/.local/bin`. Add that directory to your `PATH` if it is not already there.
+This uses the current installer entrypoint plus `SYU_VERSION=alpha` so you stay
+on the latest alpha during the prerelease phase. It places `syu` in
+`~/.local/bin`. Add that directory to your `PATH` if it is not already there.
 
 **Option B — Build from source**
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -228,6 +228,11 @@ fn repository_declares_documentation_guides() {
     assert!(concepts.contains("Specification Reference"));
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));
+    assert!(getting_started.contains("install-syu.sh"));
+    assert!(getting_started.contains("SYU_VERSION=alpha"));
+    assert!(getting_started.contains(&format!(
+        "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
+    )));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("syu list feature"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -233,6 +233,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu list feature"));
     assert!(getting_started.contains("syu show REQ-CORE-015"));
     assert!(getting_started.contains("syu app ."));
+    assert!(getting_started.contains("install-syu.sh"));
+    assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
     assert_eq!(


### PR DESCRIPTION
## Summary
- align the getting-started installer command with the shipped install-syu entrypoint
- recommend the alpha track selector during prerelease installs
- extend repository quality coverage for the getting-started install guidance

## Testing
- cargo test --test repository_quality
- scripts/ci/quality-gates.sh

Fixes #139