### PR TITLE
docs: close getting-started discovery gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ below. The rest of this section assumes you installed the published CLI.
 
 Step 0: required — run `syu init .` before any of the other commands in a new repository.
 
+Understand the model first? Start with [`docs/guide/concepts.md`](docs/guide/concepts.md)
+before you begin editing YAML.
+
 ```bash
 syu init .          # 1. Create spec scaffold
 # edit docs/syu/... # 2. Add your spec items

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -76,6 +76,16 @@ As the workspace grows, you can group requirement and feature files into nested
 folders. Keep feature discovery explicit by updating `docs/syu/features/features.yaml`
 whenever you add or move a feature document.
 
+Requirements are discovered by walking the `requirements/` tree, but features use
+an explicit registry because implementation claims should stay deliberate and
+reviewable. That registry is a short YAML list of feature documents:
+
+```yaml
+version: 0.0.1-alpha.7
+files:
+  - file: core/core.yaml
+```
+
 Make sure links are reciprocal:
 
 - philosophy ↔ policy
@@ -216,5 +226,10 @@ The repository includes complete examples:
 - Review [configuration](./configuration.md) before tightening validation in a real repository
 - Read the [syu app browser guide](./app.md) to learn how to navigate the browser UI
 - Check the [troubleshooting guide](./troubleshooting.md) when `syu validate` returns an unfamiliar error code
-- Browse the [Specification Reference](../generated/site-spec/index.md) to see how `syu` self-hosts its own contract
-- Open the [latest validation report](../generated/syu-report.md) to inspect the checked-in repository status
+- If you run `syu report`, your own project can generate a local Markdown report.
+  The checked-in `docs/generated/` links below exist in the `syu` repository itself,
+  so a freshly initialized project will not have them yet.
+- Browse the live [Specification Reference](https://ugoite.github.io/syu/docs/generated/site-spec)
+  to see how `syu` self-hosts its own contract
+- Open the live [validation report](https://ugoite.github.io/syu/docs/generated/syu-report)
+  to inspect the checked-in repository status

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -83,7 +83,8 @@ reviewable. That registry is a short YAML list of feature documents:
 ```yaml
 version: 0.0.1-alpha.7
 files:
-  - file: core/core.yaml
+  - kind: core
+    file: core/core.yaml
 ```
 
 Make sure links are reciprocal:

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -233,6 +233,12 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu list feature"));
     assert!(getting_started.contains("syu show REQ-CORE-015"));
     assert!(getting_started.contains("syu app ."));
+    assert!(getting_started.contains("Requirements are discovered"));
+    assert!(getting_started.contains("implementation claims should stay deliberate"));
+    assert!(getting_started.contains("version: 0.0.1-alpha.7"));
+    assert!(getting_started.contains("freshly initialized project will not have them yet"));
+    assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/site-spec"));
+    assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/syu-report"));
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
     assert_eq!(
@@ -241,7 +247,8 @@ fn repository_declares_documentation_guides() {
             .count(),
         1
     );
-    assert!(getting_started.contains("latest validation report"));
+    assert!(getting_started.contains("live [validation report]"));
+    assert!(readme.contains("Understand the model first?"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("validate.allow_planned"));
     assert!(configuration.contains(&format!("version: {current_version}")));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -235,7 +235,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu app ."));
     assert!(getting_started.contains("Requirements are discovered"));
     assert!(getting_started.contains("implementation claims should stay deliberate"));
-    assert!(getting_started.contains("version: 0.0.1-alpha.7"));
+    assert!(getting_started.contains(&format!("version: {current_version}")));
+    assert!(getting_started.contains("kind: core"));
     assert!(getting_started.contains("freshly initialized project will not have them yet"));
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/site-spec"));
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/syu-report"));


### PR DESCRIPTION
## Summary
- add a first-mention explanation and example for the feature registry
- replace self-hosted-only generated links with fresh-workspace guidance and live docs links
- surface the concepts guide directly from the README quick start section

## Testing
- cargo test --test repository_quality
- scripts/ci/quality-gates.sh

Fixes #141