### PR TITLE
docs: fix quick-start show command for fresh workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ syu validate .
 syu validate . --fix
 syu browse .
 syu list requirement
-syu show REQ-CORE-015
+syu show REQ-001
 syu app .
 syu report . --output reports/syu.md
 ```

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ syu list feature path/to/workspace --format json
 Show one definition by ID:
 
 ```bash
-syu show REQ-CORE-015
+syu show REQ-001
 syu show FEAT-BROWSE-001 path/to/workspace --format json
 ```
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -207,6 +207,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
     assert!(readme.contains("syu show"));
+    assert!(readme.contains("syu show REQ-001"));
     assert!(readme.contains("syu app"));
     assert!(readme.contains("examples/polyglot"));
     assert!(readme.contains("CONTRIBUTING.md"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -208,6 +208,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu list"));
     assert!(readme.contains("syu show"));
     assert!(readme.contains("syu show REQ-001"));
+    assert!(!readme.contains("syu show REQ-CORE-015"));
     assert!(readme.contains("syu app"));
     assert!(readme.contains("examples/polyglot"));
     assert!(readme.contains("CONTRIBUTING.md"));


### PR DESCRIPTION
## Summary
- replace the README quick-start `syu show` example with the scaffolded `REQ-001` ID
- cover the fresh-workspace example in repository quality checks
- verify the documented flow with a real `syu init` + `syu show REQ-001` run

## Testing
- cargo run -- init <tmpdir>
- cargo run -- show REQ-001 <tmpdir>
- cargo test --test repository_quality
- scripts/ci/quality-gates.sh

Fixes #146