### PR TITLE
feat: clarify browse versus app help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ syu validate .      # 3. Check everything is linked
 syu app .           # 4. Browse in the browser
 ```
 
+Use `syu browse .` when you want terminal-first exploration, or `syu app .`
+when you want the local browser UI.
+
 ```bash
 syu init .
 syu validate .

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,8 @@ const ROOT_AFTER_HELP: &str = "\
 New here?
   1. syu init .      scaffold a workspace in the current directory
   2. syu validate .  check the layered spec and traceability
-  3. syu app .       open the browser UI to explore the workspace";
+  3. syu browse .    explore the spec in your terminal
+  4. syu app .       start the local browser UI server";
 
 const APP_AFTER_HELP: &str = "\
 After startup, open the printed URL in your browser.
@@ -37,7 +38,7 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     #[command(
-        about = "Browse philosophies, policies, features, requirements, and validation errors"
+        about = "Browse the specification in your terminal (interactive prompts or text output)"
     )]
     Browse(BrowseArgs),
     #[command(about = "List philosophies, policies, requirements, or features")]
@@ -45,7 +46,7 @@ pub enum Commands {
     #[command(about = "Show one philosophy, policy, requirement, or feature by ID")]
     Show(ShowArgs),
     #[command(
-        about = "Start a local browser app server and print the URL to open in your browser",
+        about = "Start a local HTTP server and browser UI for workspace exploration",
         after_help = APP_AFTER_HELP
     )]
     App(AppArgs),

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -92,9 +92,7 @@ pub fn run_app_command(args: &AppArgs) -> Result<i32> {
             .flush()
             .context("failed to flush stdout")?;
 
-        server
-            .await
-            .context("local app server task panicked")?
+        server.await.context("local app server task panicked")?
     })?;
 
     Ok(0)

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -179,7 +179,7 @@ fn app_command_help_mentions_browser_and_stop_instructions() {
 
     assert!(output.status.success(), "help should succeed");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("print the URL to open in your browser"));
+    assert!(stdout.contains("Start a local HTTP server and browser UI for workspace exploration"));
     assert!(stdout.contains("After startup, open the printed URL in your browser."));
     assert!(stdout.contains("Press Ctrl-C to stop the local app server."));
 }

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -16,5 +16,10 @@ fn root_help_includes_start_here_guidance() {
     assert!(stdout.contains("New here?"));
     assert!(stdout.contains("syu init ."));
     assert!(stdout.contains("syu validate ."));
+    assert!(stdout.contains("syu browse ."));
     assert!(stdout.contains("syu app ."));
+    assert!(stdout.contains(
+        "Browse the specification in your terminal (interactive prompts or text output)"
+    ));
+    assert!(stdout.contains("Start a local HTTP server and browser UI for workspace exploration"));
 }


### PR DESCRIPTION
## Summary
- make `syu --help` distinguish terminal browsing from the browser UI workflow
- add a short README sentence about when to use `browse` versus `app`
- update help-related tests to lock in the clearer wording

## Testing
- cargo run -- --help
- cargo test --test help_command --test app_command
- scripts/ci/quality-gates.sh

Fixes #147