### PR TITLE
fix: make init guidance workspace-aware

### DIFF
--- a/docs/generated/site-spec/features/browser/app.md
+++ b/docs/generated/site-spec/features/browser/app.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/browser/app.yaml"
 
 - **id**: FEAT-APP-001
   - **title**: Local browser workspace app powered by Rust and WebAssembly
-  - **summary**: Start `syu app` to inspect the current workspace in a browser with a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
+  - **summary**: Start `syu app` to inspect the current workspace in a browser with clear startup guidance, a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-017
@@ -65,7 +65,7 @@ version: 1
 features:
   - id: FEAT-APP-001
     title: Local browser workspace app powered by Rust and WebAssembly
-    summary: Start `syu app` to inspect the current workspace in a browser with a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
+    summary: Start `syu app` to inspect the current workspace in a browser with clear startup guidance, a minimal header, layered navigation, section-aware drilldown, linked definitions, and the current validation state.
     status: implemented
     linked_requirements:
       - REQ-CORE-017

--- a/docs/generated/site-spec/features/cli/browse.md
+++ b/docs/generated/site-spec/features/cli/browse.md
@@ -37,6 +37,21 @@ description: "Generated reference for docs/syu/features/cli/browse.yaml"
       - **file**: src/command/browse.rs
         - **symbols**:
           - *
+- **id**: FEAT-BROWSE-002
+  - **title**: Non-interactive spec tree output
+  - **summary**: Add a --non-interactive flag to `syu browse` that prints the spec tree (all kinds grouped with counts and IDs) to stdout and exits, suitable for CI and scripting.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-015
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/browse.rs
+        - **symbols**:
+          - run_browse_command
+          - print_non_interactive
+      - **file**: src/cli.rs
+        - **symbols**:
+          - BrowseArgs
 
 ## Source YAML
 
@@ -65,4 +80,20 @@ features:
         - file: src/command/browse.rs
           symbols:
             - "*"
+
+  - id: FEAT-BROWSE-002
+    title: Non-interactive spec tree output
+    summary: Add a --non-interactive flag to `syu browse` that prints the spec tree (all kinds grouped with counts and IDs) to stdout and exits, suitable for CI and scripting.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-015
+    implementations:
+      rust:
+        - file: src/command/browse.rs
+          symbols:
+            - run_browse_command
+            - print_non_interactive
+        - file: src/cli.rs
+          symbols:
+            - BrowseArgs
 ```

--- a/docs/generated/site-spec/features/cli/init.md
+++ b/docs/generated/site-spec/features/cli/init.md
@@ -33,6 +33,20 @@ description: "Generated reference for docs/syu/features/cli/init.yaml"
         - **symbols**:
           - render_config
           - current_cli_version
+- **id**: FEAT-INIT-002
+  - **title**: Post-init next-step guidance
+  - **summary**: After successful init, print created file list and actionable next steps; support --format json to emit created_files for CI integrations.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-009
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/init.rs
+        - **symbols**:
+          - run_init_command
+      - **file**: src/cli.rs
+        - **symbols**:
+          - InitArgs
 
 ## Source YAML
 
@@ -57,4 +71,18 @@ features:
           symbols:
             - render_config
             - current_cli_version
+  - id: FEAT-INIT-002
+    title: Post-init next-step guidance
+    summary: After successful init, print created file list and actionable next steps; support --format json to emit created_files for CI integrations.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+        - file: src/cli.rs
+          symbols:
+            - InitArgs
 ```

--- a/docs/generated/site-spec/features/cli/show-list.md
+++ b/docs/generated/site-spec/features/cli/show-list.md
@@ -28,6 +28,19 @@ description: "Generated reference for docs/syu/features/cli/show-list.yaml"
       - **file**: src/command/list.rs
         - **symbols**:
           - run_list_command
+- **id**: FEAT-LIST-002
+  - **title**: Optional-kind listing with all-kinds default
+  - **summary**: Allow `syu list` without a kind argument to list all spec layers grouped by type, and accept a bare workspace path to list all kinds in that workspace.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-018
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/list.rs
+        - **symbols**:
+          - run_list_command
+          - parse_list_positionals
+          - print_section_list
 - **id**: FEAT-SHOW-001
   - **title**: Non-interactive definition detail lookup
   - **summary**: Show one philosophy, policy, requirement, or feature by ID in one command.
@@ -58,6 +71,20 @@ features:
         - file: src/command/list.rs
           symbols:
             - run_list_command
+
+  - id: FEAT-LIST-002
+    title: Optional-kind listing with all-kinds default
+    summary: Allow `syu list` without a kind argument to list all spec layers grouped by type, and accept a bare workspace path to list all kinds in that workspace.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-018
+    implementations:
+      rust:
+        - file: src/command/list.rs
+          symbols:
+            - run_list_command
+            - parse_list_positionals
+            - print_section_list
 
   - id: FEAT-SHOW-001
     title: Non-interactive definition detail lookup

--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -19,11 +19,15 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
 
 - **id**: FEAT-DOCS-001
   - **title**: English concepts and workflow documentation
-  - **summary**: Explain the four-layer model, delivery states, configuration, and command workflow in English.
+  - **summary**: Explain the four-layer model, delivery states, configuration, command workflow, and first-run CLI guidance in English.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-010
   - **implementations**:
+    - **rust**:
+      - **file**: src/cli.rs
+        - **symbols**:
+          - ROOT_AFTER_HELP
     - **markdown**:
       - **file**: README.md
         - **symbols**:
@@ -101,11 +105,15 @@ version: 1
 features:
   - id: FEAT-DOCS-001
     title: English concepts and workflow documentation
-    summary: Explain the four-layer model, delivery states, configuration, and command workflow in English.
+    summary: Explain the four-layer model, delivery states, configuration, command workflow, and first-run CLI guidance in English.
     status: implemented
     linked_requirements:
       - REQ-CORE-010
     implementations:
+      rust:
+        - file: src/cli.rs
+          symbols:
+            - ROOT_AFTER_HELP
       markdown:
         - file: README.md
           symbols:

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -47,7 +47,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - quality
           - coverage
           - actionlint
-          - Restore Rust cache
+          - ./.github/actions/setup-rust
           - taiki-e/cache-cargo-install-action@v3
           - tool: cargo-llvm-cov
           - tool: cargo-audit
@@ -55,6 +55,10 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - cache-dependency-path: app/package-lock.json
           - npm ci
           - Review dependency changes
+      - **file**: .github/actions/setup-rust/action.yml
+        - **symbols**:
+          - Restore Rust cache
+          - Swatinem/rust-cache@v2
       - **file**: .github/actions/build-docs-site/action.yml
         - **symbols**:
           - actions/setup-node@v6
@@ -64,7 +68,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
         - **symbols**:
           - merge_group
           - Analyze (rust)
-          - github/codeql-action/init@v3
+          - github/codeql-action/init@v4
       - **file**: .github/dependabot.yml
         - **symbols**:
           - FEAT-QUALITY-001
@@ -110,7 +114,7 @@ features:
             - quality
             - coverage
             - actionlint
-            - Restore Rust cache
+            - "./.github/actions/setup-rust"
             - taiki-e/cache-cargo-install-action@v3
             - "tool: cargo-llvm-cov"
             - "tool: cargo-audit"
@@ -118,6 +122,10 @@ features:
             - "cache-dependency-path: app/package-lock.json"
             - npm ci
             - Review dependency changes
+        - file: .github/actions/setup-rust/action.yml
+          symbols:
+            - Restore Rust cache
+            - Swatinem/rust-cache@v2
         - file: .github/actions/build-docs-site/action.yml
           symbols:
             - actions/setup-node@v6
@@ -127,7 +135,7 @@ features:
           symbols:
             - merge_group
             - Analyze (rust)
-            - github/codeql-action/init@v3
+            - github/codeql-action/init@v4
         - file: .github/dependabot.yml
           symbols:
             - FEAT-QUALITY-001

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -24,8 +24,9 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
       The repository MUST explain philosophy, policy, requirements, and
       features in English, describe why each layer exists, document how to
       define them, explain `planned` / `implemented` delivery states, show how
-      to use `init`, `browse`, `validate`, `report`, config, and autofix, and
-      publish the checked-in `docs/` tree through a Docusaurus site.
+      to use `init`, `browse`, `validate`, `report`, config, and autofix, orient
+      first-time users with actionable root CLI help, and publish the checked-in
+      `docs/` tree through a Docusaurus site.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -36,6 +37,9 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
     - FEAT-DOCS-002
   - **tests**:
     - **rust**:
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - root_help_includes_start_here_guidance
       - **file**: tests/repository_quality.rs
         - **symbols**:
           - repository_declares_documentation_guides
@@ -77,8 +81,9 @@ requirements:
       The repository MUST explain philosophy, policy, requirements, and
       features in English, describe why each layer exists, document how to
       define them, explain `planned` / `implemented` delivery states, show how
-      to use `init`, `browse`, `validate`, `report`, config, and autofix, and
-      publish the checked-in `docs/` tree through a Docusaurus site.
+      to use `init`, `browse`, `validate`, `report`, config, and autofix, orient
+      first-time users with actionable root CLI help, and publish the checked-in
+      `docs/` tree through a Docusaurus site.
     priority: medium
     status: implemented
     linked_policies:
@@ -89,6 +94,9 @@ requirements:
       - FEAT-DOCS-002
     tests:
       rust:
+        - file: tests/help_command.rs
+          symbols:
+            - root_help_includes_start_here_guidance
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -83,14 +83,17 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
     - |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the trace path uses canonical
+      today: Rust, Python, and TypeScript/JavaScript. A declared trace is valid
+      only when the file exists, the symbol exists, the trace path uses canonical
       repository-relative form, the file explicitly mentions the owning ID, and
       any `doc_contains` snippets are present in the symbol documentation.
       Validation MUST also reject duplicate trace mappings inside a single
       language list, support wildcard file ownership, and provide an optional
-      mode that requires every public Rust symbol to belong to some feature and
-      every Rust test to belong to some requirement.
+      mode that requires every public symbol (non-underscore-prefixed for Python,
+      `pub` for Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `#[test]` for Rust, `test*`-prefixed
+      functions for TypeScript/JavaScript) in repository source and test roots
+      to belong to some feature or requirement respectively.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -128,6 +131,14 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - python_only_example_validates
           - polyglot_example_validates
+    - **python**:
+      - **file**: tests/fixtures/workspaces/passing/python/test_traceability.py
+        - **symbols**:
+          - test_req_trace_py
+    - **typescript**:
+      - **file**: tests/fixtures/workspaces/passing/frontend/test_traceability.ts
+        - **symbols**:
+          - *
 - **id**: REQ-CORE-003
   - **title**: Support conservative autofix and config-driven default_fix
   - **description**:
@@ -250,14 +261,17 @@ requirements:
     description: |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, and TypeScript. A declared trace is valid only when
-      the file exists, the symbol exists, the trace path uses canonical
+      today: Rust, Python, and TypeScript/JavaScript. A declared trace is valid
+      only when the file exists, the symbol exists, the trace path uses canonical
       repository-relative form, the file explicitly mentions the owning ID, and
       any `doc_contains` snippets are present in the symbol documentation.
       Validation MUST also reject duplicate trace mappings inside a single
       language list, support wildcard file ownership, and provide an optional
-      mode that requires every public Rust symbol to belong to some feature and
-      every Rust test to belong to some requirement.
+      mode that requires every public symbol (non-underscore-prefixed for Python,
+      `pub` for Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `#[test]` for Rust, `test*`-prefixed
+      functions for TypeScript/JavaScript) in repository source and test roots
+      to belong to some feature or requirement respectively.
     priority: high
     status: implemented
     linked_policies:
@@ -295,6 +309,14 @@ requirements:
           symbols:
             - python_only_example_validates
             - polyglot_example_validates
+      python:
+        - file: tests/fixtures/workspaces/passing/python/test_traceability.py
+          symbols:
+            - test_req_trace_py
+      typescript:
+        - file: tests/fixtures/workspaces/passing/frontend/test_traceability.ts
+          symbols:
+            - '*'
   - id: REQ-CORE-003
     title: Support conservative autofix and config-driven default_fix
     description: |

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -33,6 +33,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - POL-004
   - **linked_features**:
     - FEAT-INIT-001
+    - FEAT-INIT-002
   - **tests**:
     - **rust**:
       - **file**: tests/init_command.rs
@@ -41,6 +42,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: src/command/init.rs
         - **symbols**:
           - *
+      - **file**: src/command/mod.rs
+        - **symbols**:
+          - shell_quote_path_wraps_empty_paths
       - **file**: src/config.rs
         - **symbols**:
           - *
@@ -61,6 +65,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - POL-004
   - **linked_features**:
     - FEAT-BROWSE-001
+    - FEAT-BROWSE-002
   - **tests**:
     - **rust**:
       - **file**: tests/browse_command.rs
@@ -84,7 +89,8 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them.
+      them. The startup output MUST also tell users which local URL to open in a
+      browser and how to stop the server cleanly.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -129,6 +135,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - POL-004
   - **linked_features**:
     - FEAT-LIST-001
+    - FEAT-LIST-002
     - FEAT-SHOW-001
   - **tests**:
     - **rust**:
@@ -141,6 +148,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: src/lib.rs
         - **symbols**:
           - dispatches_lookup_subcommands_without_rewriting_them
+      - **file**: src/command/list.rs
+        - **symbols**:
+          - *
 
 ## Source YAML
 
@@ -163,6 +173,7 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-INIT-001
+      - FEAT-INIT-002
     tests:
       rust:
         - file: tests/init_command.rs
@@ -171,6 +182,9 @@ requirements:
         - file: src/command/init.rs
           symbols:
             - '*'
+        - file: src/command/mod.rs
+          symbols:
+            - shell_quote_path_wraps_empty_paths
         - file: src/config.rs
           symbols:
             - '*'
@@ -190,6 +204,7 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-BROWSE-001
+      - FEAT-BROWSE-002
     tests:
       rust:
         - file: tests/browse_command.rs
@@ -212,7 +227,8 @@ requirements:
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them.
+      them. The startup output MUST also tell users which local URL to open in a
+      browser and how to stop the server cleanly.
     priority: medium
     status: implemented
     linked_policies:
@@ -256,6 +272,7 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-LIST-001
+      - FEAT-LIST-002
       - FEAT-SHOW-001
     tests:
       rust:
@@ -268,4 +285,7 @@ requirements:
         - file: src/lib.rs
           symbols:
             - dispatches_lookup_subcommands_without_rewriting_them
+        - file: src/command/list.rs
+          symbols:
+            - '*'
 ```

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -25,6 +25,9 @@ requirements:
         - file: src/command/init.rs
           symbols:
             - '*'
+        - file: src/command/mod.rs
+          symbols:
+            - shell_quote_path_wraps_empty_paths
         - file: src/config.rs
           symbols:
             - '*'

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -78,9 +78,7 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
             println!("     - docs/syu/policies/policies.yaml       (governance rules)");
             println!("     - docs/syu/requirements/core/core.yaml  (concrete requirements)");
             println!("     - docs/syu/features/core/core.yaml      (feature definitions)");
-            println!(
-                "  2. Run `syu validate {workspace_arg}` to check your spec for consistency"
-            );
+            println!("  2. Run `syu validate {workspace_arg}` to check your spec for consistency");
             println!(
                 "  3. Run `syu browse {workspace_arg}` for terminal exploration, or `syu app {workspace_arg}` for the browser UI"
             );

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -9,6 +9,7 @@ use std::{
 
 use crate::{
     cli::{InitArgs, OutputFormat},
+    command::shell_quote_path,
     config::{SyuConfig, render_config},
 };
 
@@ -59,6 +60,8 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
             );
         }
         OutputFormat::Text => {
+            let workspace_arg = shell_quote_path(&workspace);
+            let spec_root = workspace.join("docs/syu");
             println!("initialized syu workspace at {}", workspace.display());
             println!();
             println!("Created files:");
@@ -67,13 +70,20 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
             }
             println!();
             println!("What to do next:");
-            println!("  1. Edit the spec files in docs/syu/ to describe your project");
+            println!(
+                "  1. Edit the spec files in {}/ to describe your project",
+                spec_root.display()
+            );
             println!("     - docs/syu/philosophy/foundation.yaml  (core principles)");
             println!("     - docs/syu/policies/policies.yaml       (governance rules)");
             println!("     - docs/syu/requirements/core/core.yaml  (concrete requirements)");
             println!("     - docs/syu/features/core/core.yaml      (feature definitions)");
-            println!("  2. Run `syu validate .` to check your spec for consistency");
-            println!("  3. Run `syu app .` to explore the spec in the browser UI");
+            println!(
+                "  2. Run `syu validate {workspace_arg}` to check your spec for consistency"
+            );
+            println!(
+                "  3. Run `syu browse {workspace_arg}` for terminal exploration, or `syu app {workspace_arg}` for the browser UI"
+            );
             println!("  4. Commit the generated files to version control");
         }
     }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -26,3 +26,15 @@ pub(crate) fn shell_quote_path(path: &Path) -> String {
         format!("'{}'", rendered.replace('\'', "'\\''"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::shell_quote_path;
+
+    #[test]
+    fn shell_quote_path_wraps_empty_paths() {
+        assert_eq!(shell_quote_path(Path::new("")), "''");
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 // FEAT-BROWSE-001
 
 pub mod app;
@@ -8,3 +10,19 @@ pub mod list;
 mod lookup;
 pub mod report;
 pub mod show;
+
+pub(crate) fn shell_quote_path(path: &Path) -> String {
+    let rendered = path.display().to_string();
+    if rendered.is_empty() {
+        return "''".to_string();
+    }
+
+    if rendered
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "/._-".contains(ch))
+    {
+        rendered
+    } else {
+        format!("'{}'", rendered.replace('\'', "'\\''"))
+    }
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -34,6 +34,7 @@ mod tests {
     use super::shell_quote_path;
 
     #[test]
+    // REQ-CORE-009
     fn shell_quote_path_wraps_empty_paths() {
         assert_eq!(shell_quote_path(Path::new("")), "''");
     }

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -80,3 +80,31 @@ fn init_command_requires_force_when_generated_files_exist() {
     assert!(!init.status.success(), "init should refuse overwrite");
     assert!(String::from_utf8_lossy(&init.stderr).contains("refusing to overwrite"));
 }
+
+#[test]
+// REQ-CORE-009
+fn init_command_prints_workspace_aware_next_steps_for_explicit_paths() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo workspace");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .output()
+        .expect("init should run");
+
+    assert!(
+        init.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&init.stdout);
+    let workspace_arg = format!("'{}'", workspace.display());
+    assert!(stdout.contains(&format!("Run `syu validate {workspace_arg}`")));
+    assert!(stdout.contains(&format!("Run `syu browse {workspace_arg}`")));
+    assert!(stdout.contains(&format!("`syu app {workspace_arg}`")));
+    assert!(stdout.contains(&format!("{}/", workspace.join("docs/syu").display())));
+}


### PR DESCRIPTION
## Summary
- preserve the explicit workspace path in syu init next-step guidance
- mention both terminal and browser exploration commands
- cover the new explicit-path UX with an integration test

Closes #156
