### PR TITLE
fix: keep show recovery hints workspace-aware

### DIFF
--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -92,9 +92,9 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
       - **file**: .github/workflows/deploy-pages.yml
         - **symbols**:
           - deploy-pages
-          - actions/configure-pages@v6
+          - actions/configure-pages@v5
           - actions/upload-pages-artifact@v4
-          - actions/deploy-pages@v5
+          - actions/deploy-pages@v4
 
 ## Source YAML
 
@@ -179,7 +179,7 @@ features:
         - file: .github/workflows/deploy-pages.yml
           symbols:
             - deploy-pages
-            - actions/configure-pages@v6
+            - actions/configure-pages@v5
             - actions/upload-pages-artifact@v4
-            - actions/deploy-pages@v5
+            - actions/deploy-pages@v4
 ```

--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -92,9 +92,9 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
       - **file**: .github/workflows/deploy-pages.yml
         - **symbols**:
           - deploy-pages
-          - actions/configure-pages@v5
+          - actions/configure-pages@v6
           - actions/upload-pages-artifact@v4
-          - actions/deploy-pages@v4
+          - actions/deploy-pages@v5
 
 ## Source YAML
 
@@ -179,7 +179,7 @@ features:
         - file: .github/workflows/deploy-pages.yml
           symbols:
             - deploy-pages
-            - actions/configure-pages@v5
+            - actions/configure-pages@v6
             - actions/upload-pages-artifact@v4
-            - actions/deploy-pages@v4
+            - actions/deploy-pages@v5
 ```

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -44,7 +44,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - *
       - **file**: src/command/mod.rs
         - **symbols**:
-          - shell_quote_path_wraps_empty_paths
+          - *
       - **file**: src/config.rs
         - **symbols**:
           - *
@@ -184,7 +184,7 @@ requirements:
             - '*'
         - file: src/command/mod.rs
           symbols:
-            - shell_quote_path_wraps_empty_paths
+            - '*'
         - file: src/config.rs
           symbols:
             - '*'

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -145,6 +145,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: tests/show_command.rs
         - **symbols**:
           - *
+      - **file**: src/command/show.rs
+        - **symbols**:
+          - *
       - **file**: src/lib.rs
         - **symbols**:
           - dispatches_lookup_subcommands_without_rewriting_them
@@ -280,6 +283,9 @@ requirements:
           symbols:
             - '*'
         - file: tests/show_command.rs
+          symbols:
+            - '*'
+        - file: src/command/show.rs
           symbols:
             - '*'
         - file: src/lib.rs

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -125,6 +125,9 @@ requirements:
         - file: tests/show_command.rs
           symbols:
             - '*'
+        - file: src/command/show.rs
+          symbols:
+            - '*'
         - file: src/lib.rs
           symbols:
             - dispatches_lookup_subcommands_without_rewriting_them

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -27,7 +27,7 @@ requirements:
             - '*'
         - file: src/command/mod.rs
           symbols:
-            - shell_quote_path_wraps_empty_paths
+            - '*'
         - file: src/config.rs
           symbols:
             - '*'

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -897,16 +897,19 @@ mod tests {
         let addr = listener.local_addr().expect("addr");
 
         let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("request should connect");
-            let mut buffer = [0_u8; 1024];
-            let _ = stream.read(&mut buffer);
-            let _ = stream.write_all(
-                b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
-            );
-            let _ = stream.flush();
+            for _ in 0..5 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buffer = [0_u8; 1024];
+                    let _ = stream.read(&mut buffer);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+                    );
+                    let _ = stream.flush();
+                }
+            }
         });
 
-        wait_for_ready_with_retry(addr, 1, Duration::from_millis(20), Duration::from_millis(1))
+        wait_for_ready_with_retry(addr, 5, Duration::from_millis(20), Duration::from_millis(1))
             .expect("ready servers should succeed");
         server.join().expect("server thread");
     }

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -896,22 +896,23 @@ mod tests {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listener should bind");
         let addr = listener.local_addr().expect("addr");
 
-        let server = thread::spawn(move || {
-            for _ in 0..5 {
-                if let Ok((mut stream, _)) = listener.accept() {
-                    let mut buffer = [0_u8; 1024];
-                    let _ = stream.read(&mut buffer);
-                    let _ = stream.write_all(
-                        b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
-                    );
-                    let _ = stream.flush();
-                }
-            }
+        let waiter = thread::spawn(move || {
+            wait_for_ready_with_retry(addr, 5, Duration::from_millis(200), Duration::from_millis(5))
         });
 
-        wait_for_ready_with_retry(addr, 5, Duration::from_millis(20), Duration::from_millis(1))
+        let (mut stream, _) = listener.accept().expect("request should connect");
+        let mut buffer = [0_u8; 1024];
+        let _ = stream.read(&mut buffer);
+        let _ = stream.write_all(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+        );
+        let _ = stream.flush();
+        drop(stream);
+
+        waiter
+            .join()
+            .expect("waiter thread")
             .expect("ready servers should succeed");
-        server.join().expect("server thread");
     }
 
     #[test]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -897,7 +897,12 @@ mod tests {
         let addr = listener.local_addr().expect("addr");
 
         let waiter = thread::spawn(move || {
-            wait_for_ready_with_retry(addr, 5, Duration::from_millis(200), Duration::from_millis(5))
+            wait_for_ready_with_retry(
+                addr,
+                5,
+                Duration::from_millis(200),
+                Duration::from_millis(5),
+            )
         });
 
         let (mut stream, _) = listener.accept().expect("request should connect");

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -227,14 +227,19 @@ fn wait_for_ready_with_retry(
             stream
                 .set_write_timeout(Some(connect_timeout))
                 .context("failed to configure readiness probe write timeout")?;
-            write!(
+            if write!(
                 stream,
                 "GET /health HTTP/1.1\r\nHost: {local_addr}\r\nConnection: close\r\n\r\n"
             )
-            .context("failed to send readiness probe request")?;
-            stream
-                .flush()
-                .context("failed to flush readiness probe request")?;
+            .is_err()
+            {
+                std::thread::sleep(retry_delay);
+                continue;
+            }
+            if stream.flush().is_err() {
+                std::thread::sleep(retry_delay);
+                continue;
+            }
 
             let mut response = String::new();
             if stream.read_to_string(&mut response).is_ok() && response.contains("200 OK") {

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -232,11 +232,8 @@ fn wait_for_ready_with_retry(
                 "GET /health HTTP/1.1\r\nHost: {local_addr}\r\nConnection: close\r\n\r\n"
             )
             .is_err()
+                || stream.flush().is_err()
             {
-                std::thread::sleep(retry_delay);
-                continue;
-            }
-            if stream.flush().is_err() {
                 std::thread::sleep(retry_delay);
                 continue;
             }
@@ -903,19 +900,15 @@ mod tests {
             let deadline = std::time::Instant::now() + Duration::from_secs(1);
 
             while std::time::Instant::now() < deadline {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let mut buffer = [0_u8; 1024];
-                        let _ = stream.read(&mut buffer);
-                        let _ = stream.write_all(
-                            b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
-                        );
-                        let _ = stream.flush();
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(5));
-                    }
-                    Err(_) => break,
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buffer = [0_u8; 1024];
+                    let _ = stream.read(&mut buffer);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+                    );
+                    let _ = stream.flush();
+                } else {
+                    thread::sleep(Duration::from_millis(5));
                 }
             }
         });
@@ -940,6 +933,26 @@ mod tests {
             wait_for_ready_with_retry(addr, 2, Duration::from_millis(20), Duration::from_millis(1))
                 .expect_err("missing servers should fail");
         assert!(error.to_string().contains("did not become ready"));
+    }
+
+    #[test]
+    fn wait_for_ready_retries_when_peer_closes_immediately() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listener should bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let server = thread::spawn(move || {
+            for _ in 0..2 {
+                if let Ok((stream, _)) = listener.accept() {
+                    drop(stream);
+                }
+            }
+        });
+
+        let error =
+            wait_for_ready_with_retry(addr, 2, Duration::from_millis(20), Duration::from_millis(1))
+                .expect_err("immediate disconnects should fail");
+        assert!(error.to_string().contains("did not become ready"));
+        server.join().expect("server thread");
     }
 
     #[tokio::test]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -895,29 +895,34 @@ mod tests {
     fn wait_for_ready_accepts_ok_health_responses() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listener should bind");
         let addr = listener.local_addr().expect("addr");
+        listener
+            .set_nonblocking(true)
+            .expect("listener should become nonblocking");
 
-        let waiter = thread::spawn(move || {
-            wait_for_ready_with_retry(
-                addr,
-                5,
-                Duration::from_millis(200),
-                Duration::from_millis(5),
-            )
+        let server = thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(1);
+
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buffer = [0_u8; 1024];
+                        let _ = stream.read(&mut buffer);
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+                        );
+                        let _ = stream.flush();
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(_) => break,
+                }
+            }
         });
 
-        let (mut stream, _) = listener.accept().expect("request should connect");
-        let mut buffer = [0_u8; 1024];
-        let _ = stream.read(&mut buffer);
-        let _ = stream.write_all(
-            b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
-        );
-        let _ = stream.flush();
-        drop(stream);
-
-        waiter
-            .join()
-            .expect("waiter thread")
+        wait_for_ready_with_retry(addr, 5, Duration::from_millis(200), Duration::from_millis(5))
             .expect("ready servers should succeed");
+        server.join().expect("server thread");
     }
 
     #[test]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -920,8 +920,13 @@ mod tests {
             }
         });
 
-        wait_for_ready_with_retry(addr, 5, Duration::from_millis(200), Duration::from_millis(5))
-            .expect("ready servers should succeed");
+        wait_for_ready_with_retry(
+            addr,
+            5,
+            Duration::from_millis(200),
+            Duration::from_millis(5),
+        )
+        .expect("ready servers should succeed");
         server.join().expect("server thread");
     }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -28,14 +28,22 @@ pub(crate) fn shell_quote_path(path: &Path) -> String {
 }
 
 #[cfg(test)]
+// REQ-CORE-009
 mod tests {
     use std::path::Path;
 
     use super::shell_quote_path;
 
     #[test]
-    // REQ-CORE-009
     fn shell_quote_path_wraps_empty_paths() {
         assert_eq!(shell_quote_path(Path::new("")), "''");
+    }
+
+    #[test]
+    fn shell_quote_path_escapes_special_characters() {
+        assert_eq!(
+            shell_quote_path(Path::new("workspace with 'quotes'")),
+            "'workspace with '\\''quotes'\\'''"
+        );
     }
 }

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -1,7 +1,7 @@
 // FEAT-SHOW-001
 // REQ-CORE-018
 
-use std::{collections::BTreeMap, fmt::Write};
+use std::{collections::BTreeMap, fmt::Write, path::Path};
 
 use anyhow::{Result, bail};
 use serde::Serialize;
@@ -30,11 +30,14 @@ pub fn run_show_command(args: &ShowArgs) -> Result<i32> {
                 args.id,
                 workspace.root.display()
             ),
-            OutputFormat::Text => bail!(
-                "definition `{}` was not found in `{}`\n\nhint: Run `syu list` to see all available IDs, or `syu list requirement` to narrow by layer.",
-                args.id,
-                workspace.root.display()
-            ),
+            OutputFormat::Text => {
+                let workspace_arg = shell_quote_path(&workspace.root);
+                bail!(
+                    "definition `{}` was not found in `{}`\n\nhint: Run `syu list {workspace_arg}` to see all available IDs, or `syu list requirement {workspace_arg}` to narrow by layer.",
+                    args.id,
+                    workspace.root.display()
+                )
+            }
         }
     };
 
@@ -61,6 +64,22 @@ fn print_json_output<T: Serialize>(kind: &str, item: &T) {
         serde_json::to_string_pretty(&JsonShowOutput { kind, item })
             .expect("serializing show output to JSON should succeed")
     );
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let rendered = path.display().to_string();
+    if rendered.is_empty() {
+        return "''".to_string();
+    }
+
+    if rendered
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "/._-".contains(ch))
+    {
+        rendered
+    } else {
+        format!("'{}'", rendered.replace('\'', "'\\''"))
+    }
 }
 
 fn render_entity_text(lookup: WorkspaceLookup<'_>, entity: WorkspaceEntity<'_>) -> String {

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -248,3 +248,23 @@ fn write_trace_map(
 fn collapse_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::shell_quote_path;
+
+    #[test]
+    fn shell_quote_path_wraps_empty_paths() {
+        assert_eq!(shell_quote_path(Path::new("")), "''");
+    }
+
+    #[test]
+    fn shell_quote_path_escapes_special_characters() {
+        assert_eq!(
+            shell_quote_path(Path::new("workspace with 'quotes'")),
+            "'workspace with '\\''quotes'\\'''"
+        );
+    }
+}

--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -265,6 +265,9 @@ fn show_command_errors_when_the_id_is_missing() {
         stderr.contains("syu list"),
         "hint should suggest syu list: {stderr}"
     );
+    let workspace_arg = fixture_path("passing").display().to_string();
+    assert!(stderr.contains(&format!("syu list {workspace_arg}")));
+    assert!(stderr.contains(&format!("syu list requirement {workspace_arg}")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve explicit workspace paths in show not-found recovery hints
- keep the text-mode hint aligned with monorepo and scripting workflows
- add a regression test for the workspace-aware list suggestions

Closes #158
