### PR TITLE
test: lock scheduled audit contract

### DIFF
--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -92,9 +92,9 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
       - **file**: .github/workflows/deploy-pages.yml
         - **symbols**:
           - deploy-pages
-          - actions/configure-pages@v6
+          - actions/configure-pages@v5
           - actions/upload-pages-artifact@v4
-          - actions/deploy-pages@v5
+          - actions/deploy-pages@v4
 
 ## Source YAML
 
@@ -179,7 +179,7 @@ features:
         - file: .github/workflows/deploy-pages.yml
           symbols:
             - deploy-pages
-            - actions/configure-pages@v6
+            - actions/configure-pages@v5
             - actions/upload-pages-artifact@v4
-            - actions/deploy-pages@v5
+            - actions/deploy-pages@v4
 ```

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -44,7 +44,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - *
       - **file**: src/command/mod.rs
         - **symbols**:
-          - shell_quote_path_wraps_empty_paths
+          - *
       - **file**: src/config.rs
         - **symbols**:
           - *
@@ -184,7 +184,7 @@ requirements:
             - '*'
         - file: src/command/mod.rs
           symbols:
-            - shell_quote_path_wraps_empty_paths
+            - '*'
         - file: src/config.rs
           symbols:
             - '*'

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -27,7 +27,7 @@ requirements:
             - '*'
         - file: src/command/mod.rs
           symbols:
-            - shell_quote_path_wraps_empty_paths
+            - '*'
         - file: src/config.rs
           symbols:
             - '*'

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -28,14 +28,22 @@ pub(crate) fn shell_quote_path(path: &Path) -> String {
 }
 
 #[cfg(test)]
+// REQ-CORE-009
 mod tests {
     use std::path::Path;
 
     use super::shell_quote_path;
 
     #[test]
-    // REQ-CORE-009
     fn shell_quote_path_wraps_empty_paths() {
         assert_eq!(shell_quote_path(Path::new("")), "''");
+    }
+
+    #[test]
+    fn shell_quote_path_escapes_special_characters() {
+        assert_eq!(
+            shell_quote_path(Path::new("workspace with 'quotes'")),
+            "'workspace with '\\''quotes'\\'''"
+        );
     }
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -14,6 +14,7 @@ fn repository_declares_precommit_and_quality_gates() {
     let precommit = read_file(".pre-commit-config.yaml");
     let quality_script = read_file("scripts/ci/quality-gates.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
+    let contributing = read_file("CONTRIBUTING.md");
     let repo_config = read_file("syu.yaml");
 
     assert!(precommit.contains("FEAT-QUALITY-001"));
@@ -41,9 +42,18 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("--hook-stage pre-push"));
     assert!(ci_workflow.contains("scripts/ci/quality-gates.sh"));
     assert!(ci_workflow.contains("cargo audit"));
+    assert!(ci_workflow.contains("schedule:"));
+    assert!(ci_workflow.contains("0 6 * * 1"));
+    assert!(ci_workflow.contains("github.event_name != 'schedule'"));
     assert!(ci_workflow.contains("Review dependency changes"));
     assert!(ci_workflow.contains("scripts/ci/installer-smoke.sh"));
     assert!(ci_workflow.contains("scripts/ci/installed-binary-smoke.sh"));
+
+    assert!(contributing.contains("weekly schedule"));
+    assert!(contributing.contains("06:00 UTC"));
+    assert!(contributing.contains("cargo audit"));
+    assert!(contributing.contains("npm audit"));
+    assert!(contributing.contains("Contributors do **not** need to run manual audits"));
 
     assert!(repo_config.contains("FEAT-CHECK-001"));
     assert!(repo_config.contains("FEAT-REPORT-001"));


### PR DESCRIPTION
## Summary
- assert the weekly schedule trigger in ci.yml
- assert CONTRIBUTING documents the automated weekly audit behavior
- keep the existing dependency drift setup from regressing while #116 is still open

Closes #116
