### PR TITLE
fix: clarify workspace help defaults

### DIFF
--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -23,6 +23,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - root_help_includes_start_here_guidance
+            - workspace_help_uses_current_directory_default_consistently
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,8 @@ const APP_AFTER_HELP: &str = concat!(
     "Press Ctrl-C to stop the local app server."
 );
 
+const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "syu",
@@ -65,7 +67,7 @@ pub enum Commands {
 
 #[derive(Debug, Clone, Args)]
 pub struct BrowseArgs {
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
 
@@ -130,7 +132,7 @@ pub struct ShowArgs {
     #[arg(help = "Definition ID to show (for example PHIL-001 or REQ-CORE-001)")]
     pub id: String,
 
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
 
@@ -141,7 +143,7 @@ pub struct ShowArgs {
 
 #[derive(Debug, Clone, Args)]
 pub struct AppArgs {
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
 
@@ -156,7 +158,7 @@ pub struct AppArgs {
 
 #[derive(Debug, Clone, Args)]
 pub struct ValidateArgs {
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
 
@@ -197,7 +199,7 @@ pub type CheckArgs = ValidateArgs;
 
 #[derive(Debug, Clone, Args)]
 pub struct ReportArgs {
-    #[arg(help = "Workspace root containing syu.yaml and the spec tree (default: docs/syu)")]
+    #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
 

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -26,7 +26,7 @@ fn root_help_includes_start_here_guidance() {
 
 #[test]
 fn workspace_help_uses_current_directory_default_consistently() {
-    for command in ["browse", "show", "app", "validate", "report"] {
+    for command in ["browse", "show", "app", "validate", "check", "report"] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
             .args([command, "--help"])

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -23,3 +23,30 @@ fn root_help_includes_start_here_guidance() {
     ));
     assert!(stdout.contains("Start a local HTTP server and browser UI for workspace exploration"));
 }
+
+#[test]
+fn workspace_help_uses_current_directory_default_consistently() {
+    for command in ["browse", "show", "app", "validate", "report"] {
+        let output = Command::cargo_bin("syu")
+            .expect("binary should build")
+            .args([command, "--help"])
+            .output()
+            .expect("help should render");
+
+        assert!(output.status.success(), "{command} help should succeed");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("Workspace root containing syu.yaml and the configured spec tree"),
+            "{command} help should describe the workspace root consistently",
+        );
+        assert!(
+            stdout.contains("[default: .]"),
+            "{command} help should keep the current-directory default",
+        );
+        assert!(
+            !stdout.contains("default: docs/syu"),
+            "{command} help should not claim docs/syu is the workspace default",
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- remove the misleading docs/syu default from shared WORKSPACE help text
- keep Clap's current-directory default as the only default shown in command help
- trace the new help regression test to the documentation requirement

Closes #170

## Validation
- scripts/ci/quality-gates.sh
- scripts/ci/coverage.sh summary