### PR TITLE
fix: accept workspace-first syu list arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,14 @@ const APP_AFTER_HELP: &str = concat!(
 
 const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
 
+const LIST_AFTER_HELP: &str = "\
+Examples:
+  syu list
+  syu list docs/syu
+  syu list requirement
+  syu list requirement docs/syu
+  syu list docs/syu requirement";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "syu",
@@ -45,7 +53,10 @@ pub enum Commands {
         about = "Browse the specification in your terminal (interactive prompts or text output)"
     )]
     Browse(BrowseArgs),
-    #[command(about = "List philosophies, policies, requirements, or features")]
+    #[command(
+        about = "List philosophies, policies, requirements, or features",
+        after_help = LIST_AFTER_HELP
+    )]
     List(ListArgs),
     #[command(about = "Show one philosophy, policy, requirement, or feature by ID")]
     Show(ShowArgs),
@@ -111,10 +122,9 @@ impl LookupKind {
 
 #[derive(Debug, Clone, Args)]
 pub struct ListArgs {
-    /// Layer kind to list, or a workspace path to list all kinds.
-    /// Usage: syu list [KIND] [WORKSPACE]
-    ///        syu list [WORKSPACE]     (lists all kinds)
-    ///        syu list                 (lists all kinds in the current directory)
+    /// Optional layer kind and workspace path.
+    /// Accepted as either `syu list [KIND] [WORKSPACE]` or `syu list [WORKSPACE] [KIND]`.
+    /// With one positional argument, syu treats known kinds as layer filters and everything else as a workspace path.
     #[arg(
         num_args = 0..=2,
         value_name = "KIND_OR_WORKSPACE",

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -2,7 +2,7 @@
 // FEAT-LIST-002
 // REQ-CORE-018
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use clap::ValueEnum as _;
@@ -93,17 +93,43 @@ fn parse_list_positionals(positional: &[String]) -> Result<(Option<LookupKind>, 
                 Ok((None, PathBuf::from(first)))
             }
         }
-        [kind_str, workspace_str, ..] => {
-            let kind = LookupKind::from_str(kind_str, true).map_err(|_| {
-                invalid_kind_error(
-                    kind_str,
-                    Some(workspace_str),
-                    suggested_lookup_kind(kind_str),
-                )
-            })?;
-            Ok((Some(kind), PathBuf::from(workspace_str)))
-        }
+        [first, second, ..] => parse_list_two_positionals(first, second),
     }
+}
+
+fn parse_list_two_positionals(first: &str, second: &str) -> Result<(Option<LookupKind>, PathBuf)> {
+    match (
+        LookupKind::from_str(first, true),
+        LookupKind::from_str(second, true),
+    ) {
+        (Ok(_), Ok(_)) => Err(ambiguous_kind_error(first, second)),
+        (Ok(kind), Err(_)) => Ok((Some(kind), PathBuf::from(second))),
+        (Err(_), Ok(kind)) => Ok((Some(kind), PathBuf::from(first))),
+        (Err(_), Err(_)) if looks_like_workspace_path(first) => Err(invalid_kind_error(
+            second,
+            Some(first),
+            suggested_lookup_kind(second),
+        )),
+        (Err(_), Err(_)) => Err(invalid_kind_error(
+            first,
+            Some(second),
+            suggested_lookup_kind(first),
+        )),
+    }
+}
+
+fn looks_like_workspace_path(value: &str) -> bool {
+    let path = Path::new(value);
+    path.exists() || value == "." || value == ".." || path.components().count() > 1
+}
+
+fn ambiguous_kind_error(first: &str, second: &str) -> anyhow::Error {
+    anyhow!(
+        "received two layer kinds: '{first}' and '{second}'\n  \
+         pass only one kind plus an optional workspace path\n  \
+         Examples: `syu list {first} .` or `syu list . {first}`\n  \
+         Hint: run `syu list` to list every kind in the current workspace"
+    )
 }
 
 fn invalid_kind_error(
@@ -113,7 +139,7 @@ fn invalid_kind_error(
 ) -> anyhow::Error {
     let mut message = format!(
         "invalid value '{}' for KIND\n  possible values: philosophy, policy, requirement, feature",
-        value
+        value,
     );
     if let Some(suggestion) = suggestion {
         message.push_str(&format!("\n  did you mean `{suggestion}`?"));
@@ -230,6 +256,16 @@ mod tests {
 
     #[test]
     // FEAT-LIST-001
+    fn parse_list_positionals_workspace_and_kind_returns_both() {
+        let (kind, workspace) =
+            parse_list_positionals(&["/tmp/ws".to_string(), "feature".to_string()])
+                .expect("should succeed");
+        assert_eq!(kind, Some(LookupKind::Feature));
+        assert_eq!(workspace, PathBuf::from("/tmp/ws"));
+    }
+
+    #[test]
+    // FEAT-LIST-001
     fn parse_list_positionals_kind_plural_alias_works() {
         let (kind, _workspace) =
             parse_list_positionals(&["requirements".to_string()]).expect("should succeed");
@@ -244,6 +280,29 @@ mod tests {
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("invalid value"), "error: {msg}");
         assert!(msg.contains("syu list ."), "hint missing: {msg}");
+    }
+
+    #[test]
+    // FEAT-LIST-001
+    fn parse_list_positionals_workspace_then_invalid_kind_preserves_workspace_hint() {
+        let result = parse_list_positionals(&["/tmp/ws".to_string(), "notakind".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid value 'notakind'"), "error: {msg}");
+        assert!(msg.contains("syu list /tmp/ws"), "hint missing: {msg}");
+    }
+
+    #[test]
+    // FEAT-LIST-001
+    fn parse_list_positionals_two_kinds_returns_usage_error() {
+        let result = parse_list_positionals(&["requirement".to_string(), "feature".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("received two layer kinds"), "error: {msg}");
+        assert!(
+            msg.contains("syu list requirement ."),
+            "hint missing: {msg}"
+        );
     }
 
     #[test]

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -77,6 +77,96 @@ fn list_command_accepts_plural_lookup_aliases() {
 
 #[test]
 // REQ-CORE-018
+fn list_command_accepts_workspace_before_kind() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg(fixture_path("passing"))
+        .arg("requirements")
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("REQ-TRACE-003"));
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_workspace_first_invalid_kind_preserves_workspace_hint() {
+    let workspace = fixture_path("passing");
+    let workspace_display = workspace.display().to_string();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg(&workspace)
+        .arg("requirment")
+        .output()
+        .expect("command should run");
+
+    assert!(!output.status.success(), "invalid kind should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value 'requirment'"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("syu list {workspace_display}")),
+        "stderr should preserve the workspace path in the recovery hint:\n{stderr}",
+    );
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_help_documents_both_argument_orders() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg("--help")
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success(), "help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("syu list requirement docs/syu"),
+        "help should show the kind-first example:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("syu list docs/syu requirement"),
+        "help should show the workspace-first example:\n{stdout}",
+    );
+}
+
+#[test]
+// REQ-CORE-018
+fn list_command_rejects_two_kind_positionals() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("list")
+        .arg("requirement")
+        .arg("feature")
+        .output()
+        .expect("command should run");
+
+    assert!(!output.status.success(), "two kinds should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("received two layer kinds"),
+        "stderr should explain the positional ambiguity:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("syu list requirement ."),
+        "stderr should show a direct usage example:\n{stderr}",
+    );
+}
+
+#[test]
+// REQ-CORE-018
 fn list_command_without_kind_lists_all_kinds() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")


### PR DESCRIPTION
## Summary
- accept `syu list <workspace> <kind>` in addition to the existing kind-first order
- keep workspace-first recovery hints anchored to the workspace path when the kind is invalid
- document both argument orders in the list help examples and cover the behavior with tests

Closes #172