### PR TITLE
docs: describe syu app validation snapshots accurately

### DIFF
--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -108,7 +108,10 @@ evidence still needs to be added before the item becomes implemented.
 
 ## Validation panel
 
-The validation panel appears at the bottom of the page and lists all issues found during the last `syu validate` run that was used to generate the app data.
+The validation panel appears at the bottom of the page and lists the current
+issues from the workspace snapshot that `syu app` loaded itself. You do not
+need to run `syu validate` first: the app computes the same validation snapshot
+when it starts and whenever the browser refresh flow loads updated spec data.
 
 Each row shows:
 
@@ -144,8 +147,10 @@ Use the validation flow in this order:
 2. Pick the requirement document you are working on from the sidebar.
 3. Open a requirement with `status: planned`.
 4. In the detail pane, look for the planned placeholder under **Tests**.
-5. Add the missing trace entries in YAML, run `syu validate .`, then refresh the
-   app snapshot by restarting `syu app .`.
+5. Add the missing trace entries in YAML, then wait for the browser refresh flow
+   to load the updated snapshot while the tab stays visible. Run `syu validate
+   .` separately only if you also want the same validation details in a
+   terminal.
 
 ### I got a validation error - how do I find the affected item?
 
@@ -224,7 +229,9 @@ Two caveats still matter:
 
 1. The browser keeps your current deep link when possible, but if the selected
    item disappears you may land on the first available item in that section.
-2. Changes outside the spec snapshot flow, such as app server flags or
+2. The polling loop pauses while the tab is hidden, so a background tab may stay
+   stale until you focus it again or reload the page.
+3. Changes outside the spec snapshot flow, such as app server flags or
    configuration in `syu.yaml`, still require restarting `syu app`.
 
 ---

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -111,7 +111,8 @@ evidence still needs to be added before the item becomes implemented.
 The validation panel appears at the bottom of the page and lists the current
 issues from the workspace snapshot that `syu app` loaded itself. You do not
 need to run `syu validate` first: the app computes the same validation snapshot
-when it starts and whenever the browser refresh flow loads updated spec data.
+when it starts, refreshes it while the tab stays visible, and catches up again
+when you return to the tab after spec changes.
 
 Each row shows:
 
@@ -147,10 +148,10 @@ Use the validation flow in this order:
 2. Pick the requirement document you are working on from the sidebar.
 3. Open a requirement with `status: planned`.
 4. In the detail pane, look for the planned placeholder under **Tests**.
-5. Add the missing trace entries in YAML, then wait for the browser refresh flow
-   to load the updated snapshot while the tab stays visible. Run `syu validate
-   .` separately only if you also want the same validation details in a
-   terminal.
+5. Add the missing trace entries in YAML, then keep the app tab visible or
+   switch back to it so the browser refresh flow loads the updated snapshot.
+   Run `syu validate .` separately only if you also want the same validation
+   details in a terminal.
 
 ### I got a validation error - how do I find the affected item?
 


### PR DESCRIPTION
## Summary
- explain that `syu app` computes its own validation snapshot instead of relying on a prior `syu validate` run
- update the workflow guidance to use the browser refresh flow instead of restarting the app
- keep `syu validate` positioned as an optional terminal view of the same diagnostics

Closes #183