### PR TITLE
docs: warn about public syu app binds

### DIFF
--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -178,6 +178,11 @@ syu app . --port 8080
 syu app . --bind 0.0.0.0 --port 8080
 ```
 
+Keep a loopback bind such as `127.0.0.1` or `::1` for normal local use.
+Binding to `0.0.0.0`, `::`, or any other non-loopback address makes the app
+reachable from other machines on the network, so only do that deliberately
+when remote access is part of your setup.
+
 ### Persistent config
 
 Set defaults in `syu.yaml` so you do not have to pass flags every time:


### PR DESCRIPTION
## Summary
- explain that `127.0.0.1` is the safe local default for `syu app`
- warn that `0.0.0.0` exposes the browser UI to other machines on the network
- keep the bind examples while making the security tradeoff explicit

Closes #184