### PR TITLE
ci: check generated docs freshness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ scripts/ci/coverage.sh summary
 cargo run -- validate .
 ```
 
+`scripts/ci/quality-gates.sh` also checks that the committed `docs/generated/`
+artifacts are fresh. To refresh those files directly, run:
+
+```bash
+scripts/ci/check-generated-docs-freshness.sh
+```
+
 ### Rust version
 
 The minimum supported Rust version (MSRV) is **1.88**. CI verifies this with a

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The self-hosted repository keeps its latest generated report at
 `docs/generated/syu-report.md`.
 Set `report.output` in `syu.yaml` when a repository wants that checked-in path
 to become the default, while keeping `--output` available for one-off overrides.
+Contributors can refresh that report and the checked-in site-spec pages together
+with `scripts/ci/check-generated-docs-freshness.sh`.
 
 ## Browser app
 

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -34,6 +34,9 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
         - **symbols**:
           - configure_llvm_tools
           - run_coverage
+      - **file**: scripts/ci/check-generated-docs-freshness.sh
+        - **symbols**:
+          - check_generated_docs_freshness
     - **yaml**:
       - **file**: .pre-commit-config.yaml
         - **symbols**:
@@ -101,6 +104,9 @@ features:
           symbols:
             - configure_llvm_tools
             - run_coverage
+        - file: scripts/ci/check-generated-docs-freshness.sh
+          symbols:
+            - check_generated_docs_freshness
       yaml:
         - file: .pre-commit-config.yaml
           symbols:

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -40,6 +40,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
       - **file**: tests/help_command.rs
         - **symbols**:
           - root_help_includes_start_here_guidance
+          - workspace_help_uses_current_directory_default_consistently
       - **file**: tests/repository_quality.rs
         - **symbols**:
           - repository_declares_documentation_guides
@@ -97,6 +98,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - root_help_includes_start_here_guidance
+            - workspace_help_uses_current_directory_default_consistently
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -3,19 +3,19 @@
 ## Status
 
 - Result: **PASS**
-- Workspace: `/Volumes/myssd/work/syu`
+- Workspace: `.`
 
 ## Definitions
 
 - Philosophies: 3
 - Policies: 7
-- Requirements: 16
-- Features: 13
+- Requirements: 18
+- Features: 19
 
 ## Traceability
 
-- Requirement-to-test traceability: 37/37
-- Feature-to-implementation traceability: 50/50
+- Requirement-to-test traceability: 56/56
+- Feature-to-implementation traceability: 76/76
 
 ## Issues
 

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -19,6 +19,9 @@ features:
           symbols:
             - configure_llvm_tools
             - run_coverage
+        - file: scripts/ci/check-generated-docs-freshness.sh
+          symbols:
+            - check_generated_docs_freshness
       yaml:
         - file: .pre-commit-config.yaml
           symbols:

--- a/scripts/ci/check-generated-docs-freshness.sh
+++ b/scripts/ci/check-generated-docs-freshness.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+snapshot_generated_docs() {
+  if [[ ! -d docs/generated ]]; then
+    printf '__missing__\n'
+    return 0
+  fi
+
+  while IFS= read -r path; do
+    sha256sum "$path"
+  done < <(find docs/generated -type f | LC_ALL=C sort)
+}
+
+check_generated_docs_freshness() {
+  local repo_root
+  local before_snapshot
+  local after_snapshot
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  before_snapshot="$(mktemp)"
+  after_snapshot="$(mktemp)"
+  trap "rm -f '$before_snapshot' '$after_snapshot'" EXIT
+
+  cd "$repo_root"
+  snapshot_generated_docs >"$before_snapshot"
+  python3 scripts/generate-site-docs.py
+  cargo run --quiet -- report . --output docs/generated/syu-report.md >/dev/null
+  snapshot_generated_docs >"$after_snapshot"
+
+  if ! cmp -s "$before_snapshot" "$after_snapshot"; then
+    echo "Checked-in generated documentation under docs/generated is stale." >&2
+    echo "Commit the regenerated docs/generated output after reviewing the diff." >&2
+    git --no-pager status --short -- docs/generated >&2
+    git --no-pager diff --stat -- docs/generated >&2
+    exit 1
+  fi
+}
+
+check_generated_docs_freshness "$@"

--- a/scripts/ci/check-generated-docs-freshness.sh
+++ b/scripts/ci/check-generated-docs-freshness.sh
@@ -52,6 +52,7 @@ check_generated_docs_freshness() {
     echo "Commit the regenerated docs/generated output after reviewing the diff." >&2
     git --no-pager status --short -- docs/generated >&2
     git --no-pager diff --stat -- docs/generated >&2
+    git --no-pager diff -- docs/generated >&2
     exit 1
   fi
 }

--- a/scripts/ci/check-generated-docs-freshness.sh
+++ b/scripts/ci/check-generated-docs-freshness.sh
@@ -3,6 +3,23 @@
 
 set -euo pipefail
 
+write_sha256() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path"
+    return 0
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path"
+    return 0
+  fi
+
+  echo "sha256sum or shasum is required to snapshot docs/generated" >&2
+  exit 1
+}
+
 snapshot_generated_docs() {
   if [[ ! -d docs/generated ]]; then
     printf '__missing__\n'
@@ -10,7 +27,7 @@ snapshot_generated_docs() {
   fi
 
   while IFS= read -r path; do
-    sha256sum "$path"
+    write_sha256 "$path"
   done < <(find docs/generated -type f | LC_ALL=C sort)
 }
 
@@ -22,7 +39,7 @@ check_generated_docs_freshness() {
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   before_snapshot="$(mktemp)"
   after_snapshot="$(mktemp)"
-  trap "rm -f '$before_snapshot' '$after_snapshot'" EXIT
+  trap 'rm -f "${before_snapshot:-}" "${after_snapshot:-}"' EXIT
 
   cd "$repo_root"
   snapshot_generated_docs >"$before_snapshot"

--- a/scripts/ci/quality-gates.sh
+++ b/scripts/ci/quality-gates.sh
@@ -13,6 +13,7 @@ run_quality_gates() {
   cargo clippy --all-targets --all-features -- -D warnings
   cargo test
   cargo run -- validate .
+  bash scripts/ci/check-generated-docs-freshness.sh
 
   mkdir -p target/quality
   cargo run -- report . --output target/quality/syu-report.md >/dev/null

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -723,8 +723,9 @@ mod tests {
         browser_root_labels, build_app_payload, collect_feature_sources,
         collect_yaml_sources_recursive, content_type_for_path, is_asset_like,
         normalized_asset_path, readiness_probe_request_sent, readiness_probe_succeeds,
-        redacted_root_label, refresh_current_once, relative_display, resolve_app_server_settings,
-        spec_snapshot, validation_snapshot, wait_for_ready_with_retry,
+        redacted_relative_label, redacted_root_label, refresh_current_once, relative_display,
+        resolve_app_server_settings, spec_snapshot, trailing_path_components_label,
+        validation_snapshot, wait_for_ready_with_retry,
     };
 
     fn fixture_root(name: &str) -> PathBuf {
@@ -927,6 +928,32 @@ mod tests {
         assert_eq!(
             redacted_root_label(&workspace_root),
             "~/src/example/spec-workspace"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn redacted_root_label_falls_back_to_trailing_components() {
+        assert_eq!(
+            redacted_root_label(Path::new("/var/tmp/spec-workspace")),
+            "tmp/spec-workspace"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn redacted_root_label_uses_workspace_for_root_paths() {
+        assert_eq!(redacted_root_label(Path::new("/")), "workspace");
+        assert!(trailing_path_components_label(Path::new("/"), 2).is_empty());
+    }
+
+    #[test]
+    fn redacted_relative_label_returns_prefix_for_matching_roots() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        assert_eq!(
+            redacted_relative_label(Some(tempdir.path().to_path_buf()), tempdir.path(), ".")
+                .as_deref(),
+            Some(".")
         );
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,6 +1,6 @@
 // REQ-CORE-004
 
-use std::{collections::BTreeSet, fmt::Write};
+use std::{collections::BTreeSet, env, fmt::Write, path::Path};
 
 use crate::model::{CheckResult, Issue, Severity};
 
@@ -17,7 +17,7 @@ pub fn render_markdown_report(result: &CheckResult) -> String {
     writeln!(
         &mut output,
         "- Workspace: `{}`",
-        result.workspace_root.display()
+        display_workspace_root(&result.workspace_root)
     )
     .expect("writing to String must succeed");
     writeln!(&mut output).expect("writing to String must succeed");
@@ -147,6 +147,21 @@ fn collect_suggestions(issues: &[Issue]) -> BTreeSet<String> {
         .collect()
 }
 
+fn display_workspace_root(workspace_root: &Path) -> String {
+    let Ok(current_dir) = env::current_dir() else {
+        return workspace_root.display().to_string();
+    };
+    let Ok(relative) = workspace_root.strip_prefix(&current_dir) else {
+        return workspace_root.display().to_string();
+    };
+
+    if relative.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        relative.display().to_string()
+    }
+}
+
 fn severity_label(severity: &Severity) -> &'static str {
     match severity {
         Severity::Error => "error",
@@ -164,11 +179,13 @@ fn collapse_whitespace(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{env, fs, path::PathBuf};
+
+    use tempfile::tempdir;
 
     use crate::model::{CheckResult, DefinitionCounts, Issue, Severity, TraceCount, TraceSummary};
 
-    use super::render_markdown_report;
+    use super::{display_workspace_root, render_markdown_report};
 
     #[test]
     fn report_renders_successful_result() {
@@ -251,5 +268,37 @@ mod tests {
         assert!(report.contains("message\\|with pipe"));
         assert!(report.contains("## Referenced rules"));
         assert_eq!(report.matches("- fix it").count(), 1);
+    }
+
+    #[test]
+    fn display_workspace_root_prefers_current_directory_relative_paths() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let previous = env::current_dir().expect("cwd should be readable");
+        env::set_current_dir(tempdir.path()).expect("should chdir into tempdir");
+
+        assert_eq!(display_workspace_root(tempdir.path()), ".");
+        assert_eq!(
+            display_workspace_root(&tempdir.path().join("nested/workspace")),
+            "nested/workspace"
+        );
+
+        env::set_current_dir(previous).expect("should restore cwd");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn display_workspace_root_falls_back_when_current_directory_is_unavailable() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let removed_root = tempdir.path().to_path_buf();
+        let previous = env::current_dir().expect("cwd should be readable");
+        env::set_current_dir(&removed_root).expect("should chdir into tempdir");
+        fs::remove_dir_all(&removed_root).expect("tempdir should be removable");
+
+        assert_eq!(
+            display_workspace_root(PathBuf::from("/tmp/workspace").as_path()),
+            "/tmp/workspace"
+        );
+
+        env::set_current_dir(previous).expect("should restore cwd");
     }
 }

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
-    process::{Child, Command, Output, Stdio},
+    process::{Child, Command, Stdio},
     thread,
     time::Duration,
 };
@@ -95,18 +95,18 @@ fn shutdown_child(child: &mut Child) {
     assert!(status.success(), "app command should exit cleanly");
 }
 
-fn shutdown_child_with_output(child: Child) -> Output {
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(child.id() as i32, libc::SIGINT);
+fn wait_for_output_fragment(path: &Path, fragment: &str) {
+    for _ in 0..80 {
+        if fs::read_to_string(path)
+            .map(|contents| contents.contains(fragment))
+            .unwrap_or(false)
+        {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
     }
 
-    #[cfg(not(unix))]
-    child.kill().expect("child should terminate");
-
-    let output = child.wait_with_output().expect("child should exit");
-    assert!(output.status.success(), "app command should exit cleanly");
-    output
+    panic!("process output did not contain {fragment:?}");
 }
 
 // REQ-CORE-017
@@ -164,7 +164,12 @@ fn app_command_serves_browser_ui_and_payload() {
 #[test]
 fn app_command_startup_message_explains_browser_and_stop_flow() {
     let port = reserve_port();
-    let child = Command::cargo_bin("syu")
+    let tempdir = tempdir().expect("tempdir should exist");
+    let stdout_path = tempdir.path().join("stdout.log");
+    let stderr_path = tempdir.path().join("stderr.log");
+    let stdout = fs::File::create(&stdout_path).expect("stdout log should open");
+    let stderr = fs::File::create(&stderr_path).expect("stderr log should open");
+    let mut child = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("app")
         .arg(fixture_path("passing"))
@@ -173,15 +178,17 @@ fn app_command_startup_message_explains_browser_and_stop_flow() {
         .arg("--port")
         .arg(port.to_string())
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
         .spawn()
         .expect("app command should start");
 
     wait_for_server(port);
+    wait_for_output_fragment(&stdout_path, "Press Ctrl-C to stop.");
 
-    let output = shutdown_child_with_output(child);
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    shutdown_child(&mut child);
+
+    let stdout = fs::read_to_string(&stdout_path).expect("stdout should be readable");
     assert!(stdout.contains(&format!("syu app listening on http://127.0.0.1:{port}")));
     assert!(stdout.contains(&format!("syu app ready: http://127.0.0.1:{port}")));
     assert!(stdout.contains(&format!("Open http://127.0.0.1:{port} in your browser.")));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -29,6 +29,7 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(quality_script.contains("cargo clippy --all-targets --all-features -- -D warnings"));
     assert!(quality_script.contains("cargo test"));
     assert!(quality_script.contains("cargo run -- validate ."));
+    assert!(quality_script.contains("check-generated-docs-freshness.sh"));
 
     assert!(ci_workflow.contains("FEAT-QUALITY-001"));
     assert!(ci_workflow.contains("precommit:"));
@@ -54,6 +55,8 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(contributing.contains("cargo audit"));
     assert!(contributing.contains("npm audit"));
     assert!(contributing.contains("Contributors do **not** need to run manual audits"));
+    assert!(contributing.contains("check-generated-docs-freshness.sh"));
+    assert!(contributing.contains("docs/generated/"));
 
     assert!(repo_config.contains("FEAT-CHECK-001"));
     assert!(repo_config.contains("FEAT-REPORT-001"));
@@ -215,6 +218,7 @@ fn repository_declares_documentation_guides() {
     let generated_site_index = read_file("docs/generated/site-spec/index.md");
     let generated_validation =
         read_file("docs/generated/site-spec/features/validation/validation.md");
+    let generated_docs_freshness = read_file("scripts/ci/check-generated-docs-freshness.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
     let docs_deploy_workflow = read_file(".github/workflows/deploy-pages.yml");
     let docs_build_action = read_file(".github/actions/build-docs-site/action.yml");
@@ -306,6 +310,11 @@ fn repository_declares_documentation_guides() {
     assert!(generated_site_index.contains("/docs/generated/site-spec/features/validation"));
     assert!(generated_validation.contains("docs/syu/features/validation/validation.yaml"));
     assert!(generated_validation.contains("SYU-graph-reference-001"));
+    assert!(generated_docs_freshness.contains("FEAT-QUALITY-001"));
+    assert!(generated_docs_freshness.contains("check_generated_docs_freshness"));
+    assert!(generated_docs_freshness.contains("python3 scripts/generate-site-docs.py"));
+    assert!(generated_docs_freshness.contains("docs/generated/syu-report.md"));
+    assert!(generated_docs_freshness.contains("git --no-pager diff --stat -- docs/generated"));
     assert!(ci_workflow.contains("./.github/actions/build-docs-site"));
     assert!(docs_build_action.contains("FEAT-DOCS-002"));
     assert!(docs_build_action.contains("actions/setup-node@v6"));
@@ -382,6 +391,8 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("main"));
     assert!(contributing.contains(".worktrees/"));
     assert!(contributing.contains("scripts/ci/quality-gates.sh"));
+    assert!(contributing.contains("scripts/ci/check-generated-docs-freshness.sh"));
+    assert!(contributing.contains("docs/generated/"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("GitHub Pages"));
     assert!(contributing.contains("release track"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -278,6 +278,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains(&format!("version: {current_version}")));
     assert!(getting_started.contains("kind: core"));
     assert!(getting_started.contains("freshly initialized project will not have them yet"));
+    assert!(generated_docs_freshness.contains("write_sha256"));
+    assert!(generated_docs_freshness.contains("sha256sum or shasum is required"));
+    assert!(generated_docs_freshness.contains("shasum -a 256"));
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/site-spec"));
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/syu-report"));
     assert!(getting_started.contains("status: implemented"));


### PR DESCRIPTION
## Summary

Add a shared CI/local script that regenerates the checked-in `docs/generated` artifacts and fails on drift, wire it into the shared quality gate, document the refresh workflow, and make the self-hosted report render a stable relative workspace path so the generated report stays deterministic across machines.

## Linked issue or specification

- Issue: Closes #181
- Requirement / feature IDs: FEAT-QUALITY-001, FEAT-REPORT-001

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [x] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed
