### PR TITLE
feat: add temporary validate overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,16 @@ syu validate . --rule SYU-trace-file-002
 syu validate . --id REQ-001
 syu validate . --fix
 syu validate . --no-fix
+syu validate . --allow-planned=false
+syu validate . --require-reciprocal-links=false
+syu validate . --require-symbol-trace-coverage
 ```
 
 `check` remains available as a compatibility alias for `validate`.
 Use `--severity`, `--genre`, `--rule`, and `--id` to narrow the rendered issue list
 without changing the underlying validation result or exit code.
+Use the validate override flags for one-off stricter or looser runs without
+editing `syu.yaml`.
 
 For a plain-English guide to common validation errors, see the
 [troubleshooting guide](docs/guide/troubleshooting.md).

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -25,6 +25,18 @@ description: "Generated reference for docs/syu/config/validate.yaml"
   - --fix
   - --no-fix
   - validate.default_fix
+- **allow_planned**:
+  - --allow-planned[=true|false]
+  - validate.allow_planned
+- **require_non_orphaned_items**:
+  - --require-non-orphaned-items[=true|false]
+  - validate.require_non_orphaned_items
+- **require_reciprocal_links**:
+  - --require-reciprocal-links[=true|false]
+  - validate.require_reciprocal_links
+- **require_symbol_trace_coverage**:
+  - --require-symbol-trace-coverage[=true|false]
+  - validate.require_symbol_trace_coverage
 
 ### Items
 
@@ -44,7 +56,8 @@ description: "Generated reference for docs/syu/config/validate.yaml"
     - |
       `planned` items remain valid only while they avoid declaring real traces.
       Setting this to `false` tightens a workspace so backlog-style entries are
-      rejected entirely.
+      rejected entirely. The validate command can also override this value for a
+      single run with `--allow-planned` or `--allow-planned=false`.
 - **key**: validate.require_non_orphaned_items
   - **type**: boolean
   - **default**: True
@@ -52,7 +65,9 @@ description: "Generated reference for docs/syu/config/validate.yaml"
   - **description**:
     - |
       This keeps the adjacent-layer graph deliberate by requiring every item to
-      stay connected to at least one neighboring layer.
+      stay connected to at least one neighboring layer. Use
+      `--require-non-orphaned-items=false` when a migration needs a temporary
+      exception without changing the checked-in config.
 - **key**: validate.require_reciprocal_links
   - **type**: boolean
   - **default**: True
@@ -62,7 +77,9 @@ description: "Generated reference for docs/syu/config/validate.yaml"
       This keeps navigation explainable by making philosophy, policy,
       requirement, and feature relationships agree in both directions.
       Repositories doing a gradual migration can temporarily set it to `false`
-      while still keeping broken-reference validation enabled.
+      while still keeping broken-reference validation enabled. For one-off runs,
+      `syu validate . --require-reciprocal-links=false` provides the same
+      temporary relaxation without editing `syu.yaml`.
 - **key**: validate.require_symbol_trace_coverage
   - **type**: boolean
   - **default**: False
@@ -71,7 +88,9 @@ description: "Generated reference for docs/syu/config/validate.yaml"
     - |
       When enabled, `syu` requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement, in addition to
-      verifying declared traces.
+      verifying declared traces. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
+      `--require-symbol-trace-coverage=false`.
 
 ## Source YAML
 
@@ -84,6 +103,18 @@ precedence:
     - --fix
     - --no-fix
     - validate.default_fix
+  allow_planned:
+    - --allow-planned[=true|false]
+    - validate.allow_planned
+  require_non_orphaned_items:
+    - --require-non-orphaned-items[=true|false]
+    - validate.require_non_orphaned_items
+  require_reciprocal_links:
+    - --require-reciprocal-links[=true|false]
+    - validate.require_reciprocal_links
+  require_symbol_trace_coverage:
+    - --require-symbol-trace-coverage[=true|false]
+    - validate.require_symbol_trace_coverage
 items:
   - key: validate.default_fix
     type: boolean
@@ -99,14 +130,17 @@ items:
     description: |
       `planned` items remain valid only while they avoid declaring real traces.
       Setting this to `false` tightens a workspace so backlog-style entries are
-      rejected entirely.
+      rejected entirely. The validate command can also override this value for a
+      single run with `--allow-planned` or `--allow-planned=false`.
   - key: validate.require_non_orphaned_items
     type: boolean
     default: true
     summary: Rejects isolated philosophy, policy, requirement, and feature nodes.
     description: |
       This keeps the adjacent-layer graph deliberate by requiring every item to
-      stay connected to at least one neighboring layer.
+      stay connected to at least one neighboring layer. Use
+      `--require-non-orphaned-items=false` when a migration needs a temporary
+      exception without changing the checked-in config.
   - key: validate.require_reciprocal_links
     type: boolean
     default: true
@@ -115,7 +149,9 @@ items:
       This keeps navigation explainable by making philosophy, policy,
       requirement, and feature relationships agree in both directions.
       Repositories doing a gradual migration can temporarily set it to `false`
-      while still keeping broken-reference validation enabled.
+      while still keeping broken-reference validation enabled. For one-off runs,
+      `syu validate . --require-reciprocal-links=false` provides the same
+      temporary relaxation without editing `syu.yaml`.
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
@@ -123,5 +159,7 @@ items:
     description: |
       When enabled, `syu` requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement, in addition to
-      verifying declared traces.
+      verifying declared traces. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
+      `--require-symbol-trace-coverage=false`.
 ```

--- a/docs/generated/site-spec/features/cli/check.md
+++ b/docs/generated/site-spec/features/cli/check.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/check.yaml"
 
 - **id**: FEAT-CHECK-001
   - **title**: Unified validation command
-  - **summary**: Validate graph links, rule-backed diagnostics, trace ownership, optional strict coverage, and safe autofix with one command.
+  - **summary**: Validate graph links, rule-backed diagnostics, trace ownership, temporary strictness overrides, optional strict coverage, and safe autofix with one command.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-001
@@ -59,6 +59,7 @@ description: "Generated reference for docs/syu/features/cli/check.yaml"
       - **file**: syu.yaml
         - **symbols**:
           - FEAT-CHECK-001
+          - allow_planned
           - require_non_orphaned_items
           - require_reciprocal_links
           - require_symbol_trace_coverage
@@ -77,7 +78,7 @@ version: 1
 features:
   - id: FEAT-CHECK-001
     title: Unified validation command
-    summary: Validate graph links, rule-backed diagnostics, trace ownership, optional strict coverage, and safe autofix with one command.
+    summary: Validate graph links, rule-backed diagnostics, trace ownership, temporary strictness overrides, optional strict coverage, and safe autofix with one command.
     status: implemented
     linked_requirements:
       - REQ-CORE-001
@@ -117,6 +118,7 @@ features:
         - file: syu.yaml
           symbols:
             - FEAT-CHECK-001
+            - allow_planned
             - require_non_orphaned_items
             - require_reciprocal_links
             - require_symbol_trace_coverage

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -41,6 +41,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
         - **symbols**:
           - root_help_includes_start_here_guidance
           - workspace_help_uses_current_directory_default_consistently
+          - validate_help_lists_temporary_config_overrides
       - **file**: tests/repository_quality.rs
         - **symbols**:
           - repository_declares_documentation_guides
@@ -99,6 +100,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -62,6 +62,12 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/reciprocal_validation.rs
         - **symbols**:
           - *
+      - **file**: tests/validate_override_command.rs
+        - **symbols**:
+          - validate_cli_override_can_allow_planned_items
+          - validate_cli_override_can_forbid_planned_items
+          - validate_cli_override_can_disable_orphan_checks
+          - validate_cli_override_can_disable_reciprocal_checks
       - **file**: src/command/check.rs
         - **symbols**:
           - *
@@ -112,6 +118,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/trace_coverage_validation.rs
         - **symbols**:
           - *
+      - **file**: tests/validate_override_command.rs
+        - **symbols**:
+          - validate_cli_override_can_enable_symbol_trace_coverage
       - **file**: tests/duplicate_validation.rs
         - **symbols**:
           - validate_reports_duplicate_trace_entries
@@ -241,6 +250,12 @@ requirements:
         - file: tests/reciprocal_validation.rs
           symbols:
             - '*'
+        - file: tests/validate_override_command.rs
+          symbols:
+            - validate_cli_override_can_allow_planned_items
+            - validate_cli_override_can_forbid_planned_items
+            - validate_cli_override_can_disable_orphan_checks
+            - validate_cli_override_can_disable_reciprocal_checks
         - file: src/command/check.rs
           symbols:
             - '*'
@@ -290,6 +305,9 @@ requirements:
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'
+        - file: tests/validate_override_command.rs
+          symbols:
+            - validate_cli_override_can_enable_symbol_trace_coverage
         - file: tests/duplicate_validation.rs
           symbols:
             - validate_reports_duplicate_trace_entries

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -66,6 +66,7 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - validate_cli_override_can_allow_planned_items
           - validate_cli_override_can_forbid_planned_items
+          - validate_cli_override_for_planned_items_mentions_cli_source
           - validate_cli_override_can_disable_orphan_checks
           - validate_cli_override_can_disable_reciprocal_checks
       - **file**: src/command/check.rs
@@ -254,6 +255,7 @@ requirements:
           symbols:
             - validate_cli_override_can_allow_planned_items
             - validate_cli_override_can_forbid_planned_items
+            - validate_cli_override_for_planned_items_mentions_cli_source
             - validate_cli_override_can_disable_orphan_checks
             - validate_cli_override_can_disable_reciprocal_checks
         - file: src/command/check.rs

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 57/57
+- Requirement-to-test traceability: 59/59
 - Feature-to-implementation traceability: 77/77
 
 ## Issues

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -106,11 +106,17 @@ Controls whether `planned` requirements and features are allowed.
 - `true`: `planned` items are valid, but they must not declare traces yet
 - `false`: any `planned` or legacy `planed` status is rejected
 
+Use `syu validate . --allow-planned` or `syu validate . --allow-planned=false`
+when you want to trial a looser or stricter run without editing `syu.yaml`.
+
 ### `validate.require_non_orphaned_items`
 
 When `true`, philosophy, policy, requirement, and feature entries must each
 connect to at least one adjacent layer. This is on by default because isolated
 definitions usually mean the specification has drifted away from the repository.
+
+Use `syu validate . --require-non-orphaned-items=false` for a one-off migration
+run when you do not want to commit a config change.
 
 ### `validate.require_reciprocal_links`
 
@@ -122,6 +128,8 @@ When `true`, adjacent-layer relationships must be confirmed from both sides.
 Keep this enabled for steady-state self-hosting. Turning it off is mainly useful
 when a repository is migrating an existing spec graph and wants to phase in
 backlinks after the forward links are already trustworthy.
+For one-off runs, use `syu validate . --require-reciprocal-links=false` instead
+of editing `syu.yaml`.
 
 ### `validate.require_symbol_trace_coverage`
 
@@ -133,6 +141,7 @@ symbol belongs to some feature and every test belongs to some requirement.
 
 This is useful once the repository wants maintenance work to stay fully owned by
 the specification.
+For an experimental strict run, use `syu validate . --require-symbol-trace-coverage`.
 
 ### `app.bind`
 
@@ -183,12 +192,23 @@ For autofix behavior, CLI flags override config:
 2. `--no-fix`
 3. `validate.default_fix`
 
-`validate.allow_planned` is configuration-only. There is no CLI flag to
-override it.
+For delivery and validation strictness, CLI flags override config for a single
+invocation:
 
-`validate.require_non_orphaned_items`,
-`validate.require_reciprocal_links`, and
-`validate.require_symbol_trace_coverage` are also configuration-only.
+1. `--allow-planned[=true|false]`
+2. `validate.allow_planned`
+
+1. `--require-non-orphaned-items[=true|false]`
+2. `validate.require_non_orphaned_items`
+
+1. `--require-reciprocal-links[=true|false]`
+2. `validate.require_reciprocal_links`
+
+1. `--require-symbol-trace-coverage[=true|false]`
+2. `validate.require_symbol_trace_coverage`
+
+Passing the flag with no value means `true`. Use `=false` when you want a
+temporary relaxed run without changing the checked-in config.
 
 For report output paths, CLI flags override config:
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -112,9 +112,10 @@ in that feature.
     - REQ-AUTH-001
 ```
 
-> **Config escape hatch:** If isolated nodes are intentional (e.g. early
-> planning), set `validate.require_non_orphaned_items: false` in `syu.yaml`
-> to disable this check.
+> **Escape hatch:** For a one-off run, use
+> `syu validate . --require-non-orphaned-items=false`. If the repository should
+> stay relaxed by default, set `validate.require_non_orphaned_items: false` in
+> `syu.yaml`.
 
 ---
 
@@ -134,8 +135,10 @@ linked_requirements: []   # ← missing back-reference
 
 **Fix:** Add the reverse reference to the other layer's YAML file.
 
-> **Config escape hatch:** If you intentionally want one-way references, set
-> `validate.require_reciprocal_links: false` in `syu.yaml`.
+> **Escape hatch:** For a one-off run, use
+> `syu validate . --require-reciprocal-links=false`. If the repository should
+> stay relaxed by default, set `validate.require_reciprocal_links: false` in
+> `syu.yaml`.
 
 ---
 
@@ -294,6 +297,9 @@ symbol non-public if it is not part of the intended API.
   private).
 - **Python:** remove it from `__all__` or rename it to start with `_`.
 - **TypeScript:** stop exporting it from the module.
+
+> **Strictness toggle:** Use `syu validate . --require-symbol-trace-coverage`
+> when you want to trial this stricter rule without committing a config change.
 
 ---
 

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -6,6 +6,18 @@ precedence:
     - --fix
     - --no-fix
     - validate.default_fix
+  allow_planned:
+    - --allow-planned[=true|false]
+    - validate.allow_planned
+  require_non_orphaned_items:
+    - --require-non-orphaned-items[=true|false]
+    - validate.require_non_orphaned_items
+  require_reciprocal_links:
+    - --require-reciprocal-links[=true|false]
+    - validate.require_reciprocal_links
+  require_symbol_trace_coverage:
+    - --require-symbol-trace-coverage[=true|false]
+    - validate.require_symbol_trace_coverage
 items:
   - key: validate.default_fix
     type: boolean
@@ -21,14 +33,17 @@ items:
     description: |
       `planned` items remain valid only while they avoid declaring real traces.
       Setting this to `false` tightens a workspace so backlog-style entries are
-      rejected entirely.
+      rejected entirely. The validate command can also override this value for a
+      single run with `--allow-planned` or `--allow-planned=false`.
   - key: validate.require_non_orphaned_items
     type: boolean
     default: true
     summary: Rejects isolated philosophy, policy, requirement, and feature nodes.
     description: |
       This keeps the adjacent-layer graph deliberate by requiring every item to
-      stay connected to at least one neighboring layer.
+      stay connected to at least one neighboring layer. Use
+      `--require-non-orphaned-items=false` when a migration needs a temporary
+      exception without changing the checked-in config.
   - key: validate.require_reciprocal_links
     type: boolean
     default: true
@@ -37,7 +52,9 @@ items:
       This keeps navigation explainable by making philosophy, policy,
       requirement, and feature relationships agree in both directions.
       Repositories doing a gradual migration can temporarily set it to `false`
-      while still keeping broken-reference validation enabled.
+      while still keeping broken-reference validation enabled. For one-off runs,
+      `syu validate . --require-reciprocal-links=false` provides the same
+      temporary relaxation without editing `syu.yaml`.
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
@@ -45,4 +62,6 @@ items:
     description: |
       When enabled, `syu` requires every public Rust symbol to belong to some
       feature and every Rust test to belong to some requirement, in addition to
-      verifying declared traces.
+      verifying declared traces. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
+      `--require-symbol-trace-coverage=false`.

--- a/docs/syu/features/cli/check.yaml
+++ b/docs/syu/features/cli/check.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-CHECK-001
     title: Unified validation command
-    summary: Validate graph links, rule-backed diagnostics, trace ownership, optional strict coverage, and safe autofix with one command.
+    summary: Validate graph links, rule-backed diagnostics, trace ownership, temporary strictness overrides, optional strict coverage, and safe autofix with one command.
     status: implemented
     linked_requirements:
       - REQ-CORE-001
@@ -44,6 +44,7 @@ features:
         - file: syu.yaml
           symbols:
             - FEAT-CHECK-001
+            - allow_planned
             - require_non_orphaned_items
             - require_reciprocal_links
             - require_symbol_trace_coverage

--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -24,6 +24,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -45,6 +45,12 @@ requirements:
         - file: tests/reciprocal_validation.rs
           symbols:
             - '*'
+        - file: tests/validate_override_command.rs
+          symbols:
+            - validate_cli_override_can_allow_planned_items
+            - validate_cli_override_can_forbid_planned_items
+            - validate_cli_override_can_disable_orphan_checks
+            - validate_cli_override_can_disable_reciprocal_checks
         - file: src/command/check.rs
           symbols:
             - '*'
@@ -94,6 +100,9 @@ requirements:
         - file: tests/trace_coverage_validation.rs
           symbols:
             - '*'
+        - file: tests/validate_override_command.rs
+          symbols:
+            - validate_cli_override_can_enable_symbol_trace_coverage
         - file: tests/duplicate_validation.rs
           symbols:
             - validate_reports_duplicate_trace_entries

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -49,6 +49,7 @@ requirements:
           symbols:
             - validate_cli_override_can_allow_planned_items
             - validate_cli_override_can_forbid_planned_items
+            - validate_cli_override_for_planned_items_mentions_cli_source
             - validate_cli_override_can_disable_orphan_checks
             - validate_cli_override_can_disable_reciprocal_checks
         - file: src/command/check.rs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -335,7 +335,7 @@ impl ValidationGenreFilter {
 mod tests {
     use clap::Parser;
 
-    use super::{Cli, Commands, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
+    use super::{Cli, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -365,14 +365,12 @@ mod tests {
         ])
         .expect("validate args should parse");
 
-        let Commands::Validate(args) = cli.command.expect("validate command") else {
-            panic!("expected validate command");
-        };
-
-        assert_eq!(args.allow_planned, Some(false));
-        assert_eq!(args.require_non_orphaned_items, Some(false));
-        assert_eq!(args.require_reciprocal_links, Some(true));
-        assert_eq!(args.require_symbol_trace_coverage, Some(true));
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Validate("));
+        assert!(rendered.contains("allow_planned: Some(false)"));
+        assert!(rendered.contains("require_non_orphaned_items: Some(false)"));
+        assert!(rendered.contains("require_reciprocal_links: Some(true)"));
+        assert!(rendered.contains("require_symbol_trace_coverage: Some(true)"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@
 // FEAT-INIT-002
 // REQ-CORE-001
 
-use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
 use std::path::PathBuf;
 
 const ROOT_AFTER_HELP: &str = "\
@@ -204,6 +204,54 @@ pub struct ValidateArgs {
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_fix: bool,
 
+    #[arg(
+        long,
+        value_name = "BOOL",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new(),
+        help = "Temporarily override validate.allow_planned for this run"
+    )]
+    pub allow_planned: Option<bool>,
+
+    #[arg(
+        long,
+        value_name = "BOOL",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new(),
+        help = "Temporarily override validate.require_non_orphaned_items for this run"
+    )]
+    pub require_non_orphaned_items: Option<bool>,
+
+    #[arg(
+        long,
+        value_name = "BOOL",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new(),
+        help = "Temporarily override validate.require_reciprocal_links for this run"
+    )]
+    pub require_reciprocal_links: Option<bool>,
+
+    #[arg(
+        long,
+        value_name = "BOOL",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new(),
+        help = "Temporarily override validate.require_symbol_trace_coverage for this run"
+    )]
+    pub require_symbol_trace_coverage: Option<bool>,
+
     #[arg(help = "Suppress next-step guidance in successful text output")]
     #[arg(short, long, action = ArgAction::SetTrue)]
     pub quiet: bool,
@@ -285,7 +333,9 @@ impl ValidationGenreFilter {
 
 #[cfg(test)]
 mod tests {
-    use super::{LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
+    use clap::Parser;
+
+    use super::{Cli, Commands, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -300,5 +350,37 @@ mod tests {
         assert_eq!(ValidationGenreFilter::Delivery.as_str(), "delivery");
         assert_eq!(ValidationGenreFilter::Trace.as_str(), "trace");
         assert_eq!(ValidationGenreFilter::Coverage.as_str(), "coverage");
+    }
+
+    #[test]
+    fn validate_args_accept_temporary_boolean_overrides() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "validate",
+            ".",
+            "--allow-planned=false",
+            "--require-non-orphaned-items=false",
+            "--require-reciprocal-links",
+            "--require-symbol-trace-coverage",
+        ])
+        .expect("validate args should parse");
+
+        let Commands::Validate(args) = cli.command.expect("validate command") else {
+            panic!("expected validate command");
+        };
+
+        assert_eq!(args.allow_planned, Some(false));
+        assert_eq!(args.require_non_orphaned_items, Some(false));
+        assert_eq!(args.require_reciprocal_links, Some(true));
+        assert_eq!(args.require_symbol_trace_coverage, Some(true));
+    }
+
+    #[test]
+    fn validate_args_reject_non_boolean_override_values() {
+        let error = Cli::try_parse_from(["syu", "validate", ".", "--allow-planned=maybe"])
+            .expect_err("non-boolean overrides should fail");
+
+        let message = error.to_string();
+        assert!(message.contains("--allow-planned"));
     }
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -328,7 +328,8 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             } else {
                 with_validate_overrides(workspace, args)
             };
-            let result = collect_check_result_from_workspace(&workspace);
+            let mut result = collect_check_result_from_workspace(&workspace);
+            apply_cli_override_issue_guidance(&mut result, args);
             let text_summary =
                 TextReportSummary::from_config(&workspace.config, &result.definition_counts);
             (result, fix_summary, Some(text_summary))
@@ -582,6 +583,30 @@ fn with_validate_overrides(mut workspace: Workspace, args: &CheckArgs) -> Worksp
         workspace.config.validate.require_symbol_trace_coverage = value;
     }
     workspace
+}
+
+fn apply_cli_override_issue_guidance(result: &mut CheckResult, args: &CheckArgs) {
+    if args.allow_planned != Some(false) {
+        return;
+    }
+
+    for issue in result
+        .issues
+        .iter_mut()
+        .filter(|issue| issue.code == "SYU-delivery-planned-001")
+    {
+        let (kind, id) = issue
+            .subject
+            .split_once(' ')
+            .expect("planned-item diagnostics should include kind and id");
+
+        issue.message = format!(
+            "{kind} `{id}` is marked `planned`, but `--allow-planned=false` forbids planned items for this run."
+        );
+        issue.suggestion = Some(format!(
+            "Change `{id}` to `implemented` or rerun without `--allow-planned=false`."
+        ));
+    }
 }
 
 #[allow(clippy::question_mark)]
@@ -2346,6 +2371,50 @@ mod tests {
         }
     }
 
+    fn write_valid_planned_workspace(root: &Path) {
+        fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+        fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+        fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+        fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+        fs::write(
+            root.join("syu.yaml"),
+            format!(
+                "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_reciprocal_links: true\n  require_symbol_trace_coverage: false\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+                version = env!("CARGO_PKG_VERSION")
+            ),
+        )
+        .expect("config should exist");
+        fs::write(
+            root.join("docs/syu/philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep planning explicit\n    product_design_principle: Planned work should stay visible until delivery starts.\n    coding_guideline: Prefer explicit status values over implied intent.\n    linked_policies:\n      - POL-001\n",
+        )
+        .expect("philosophy should exist");
+        fs::write(
+            root.join("docs/syu/policies/policies.yaml"),
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Planned work should remain reviewable\n    summary: Delivery states should support gradual adoption.\n    description: This fixture covers the validate --fix reload path.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+        )
+        .expect("policy should exist");
+        fs::write(
+            root.join("docs/syu/requirements/core.yaml"),
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Planned requirements can exist before delivery starts\n    description: Planned items should stay trace-free until implementation begins.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {}\n",
+        )
+        .expect("requirement should exist");
+        fs::write(
+            root.join("docs/syu/features/features.yaml"),
+            format!(
+                "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+                env!("CARGO_PKG_VERSION")
+            ),
+        )
+        .expect("feature registry should exist");
+        fs::write(
+            root.join("docs/syu/features/core.yaml"),
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Planned features can stay undocumented by traces\n    summary: Delivery claims should not appear before the work ships.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {}\n",
+        )
+        .expect("feature should exist");
+    }
+
     #[test]
     fn collect_check_result_reports_load_errors() {
         let result = collect_check_result(Path::new("/definitely/missing-syu-workspace"));
@@ -2439,6 +2508,31 @@ mod tests {
         .expect_err("autofix failures should bubble up");
 
         assert!(error.to_string().contains("Python inspector failed"));
+    }
+
+    #[test]
+    fn run_check_command_with_fix_reloads_workspace_before_cli_overrides() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+
+        let code = run_check_command(&crate::cli::CheckArgs {
+            workspace: tempdir.path().to_path_buf(),
+            format: crate::cli::OutputFormat::Json,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
+            id: Vec::new(),
+            fix: true,
+            no_fix: false,
+            allow_planned: Some(false),
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
+            quiet: false,
+        })
+        .expect("command should complete");
+
+        assert_eq!(code, 1);
     }
 
     #[test]

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -323,11 +323,12 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             } else {
                 None
             };
-            let result = if should_fix {
-                collect_check_result(&args.workspace)
+            let workspace = if should_fix {
+                with_validate_overrides(load_workspace(&args.workspace)?, args)
             } else {
-                collect_check_result_from_workspace(&workspace)
+                with_validate_overrides(workspace, args)
             };
+            let result = collect_check_result_from_workspace(&workspace);
             let text_summary =
                 TextReportSummary::from_config(&workspace.config, &result.definition_counts);
             (result, fix_summary, Some(text_summary))
@@ -565,6 +566,22 @@ fn effective_fix(args: &CheckArgs, config: &SyuConfig) -> bool {
     } else {
         config.validate.default_fix
     }
+}
+
+fn with_validate_overrides(mut workspace: Workspace, args: &CheckArgs) -> Workspace {
+    if let Some(value) = args.allow_planned {
+        workspace.config.validate.allow_planned = value;
+    }
+    if let Some(value) = args.require_non_orphaned_items {
+        workspace.config.validate.require_non_orphaned_items = value;
+    }
+    if let Some(value) = args.require_reciprocal_links {
+        workspace.config.validate.require_reciprocal_links = value;
+    }
+    if let Some(value) = args.require_symbol_trace_coverage {
+        workspace.config.validate.require_symbol_trace_coverage = value;
+    }
+    workspace
 }
 
 #[allow(clippy::question_mark)]
@@ -2347,6 +2364,10 @@ mod tests {
             id: Vec::new(),
             fix: false,
             no_fix: false,
+            allow_planned: None,
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
             quiet: false,
         })
         .expect("command should render load errors");
@@ -2409,6 +2430,10 @@ mod tests {
             id: Vec::new(),
             fix: true,
             no_fix: false,
+            allow_planned: None,
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
             quiet: false,
         })
         .expect_err("autofix failures should bubble up");

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -50,3 +50,20 @@ fn workspace_help_uses_current_directory_default_consistently() {
         );
     }
 }
+
+#[test]
+fn validate_help_lists_temporary_config_overrides() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "validate help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--allow-planned"));
+    assert!(stdout.contains("--require-non-orphaned-items"));
+    assert!(stdout.contains("--require-reciprocal-links"));
+    assert!(stdout.contains("--require-symbol-trace-coverage"));
+}

--- a/tests/validate_override_command.rs
+++ b/tests/validate_override_command.rs
@@ -259,6 +259,30 @@ fn validate_cli_override_can_forbid_planned_items() {
 }
 
 #[test]
+fn validate_cli_override_for_planned_items_mentions_cli_source() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_planned_workspace(tempdir.path(), true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--allow-planned=false")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "CLI override should tighten planned items"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--allow-planned=false"));
+    assert!(!stdout.contains("syu.yaml forbids planned items"));
+    assert!(stdout.contains("rerun without `--allow-planned=false`"));
+}
+
+#[test]
 fn validate_cli_override_can_disable_orphan_checks() {
     let tempdir = tempdir().expect("tempdir should exist");
     write_orphan_workspace(tempdir.path());

--- a/tests/validate_override_command.rs
+++ b/tests/validate_override_command.rs
@@ -1,0 +1,357 @@
+// REQ-CORE-001
+// REQ-CORE-002
+
+use assert_cmd::cargo::CommandCargoExt;
+use std::{fs, path::Path, process::Command};
+use tempfile::tempdir;
+
+fn write_config(
+    root: &Path,
+    allow_planned: bool,
+    require_non_orphaned_items: bool,
+    require_reciprocal_links: bool,
+    require_symbol_trace_coverage: bool,
+) {
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: {allow_planned}\n  require_non_orphaned_items: {require_non_orphaned_items}\n  require_reciprocal_links: {require_reciprocal_links}\n  require_symbol_trace_coverage: {require_symbol_trace_coverage}\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+            allow_planned = if allow_planned { "true" } else { "false" },
+            require_non_orphaned_items = if require_non_orphaned_items { "true" } else { "false" },
+            require_reciprocal_links = if require_reciprocal_links { "true" } else { "false" },
+            require_symbol_trace_coverage = if require_symbol_trace_coverage {
+                "true"
+            } else {
+                "false"
+            },
+        ),
+    )
+    .expect("config");
+}
+
+fn write_planned_workspace(root: &Path, allow_planned: bool) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+    write_config(root, allow_planned, true, true, false);
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep planning explicit\n    product_design_principle: Planned work should stay visible until delivery starts.\n    coding_guideline: Prefer explicit status values over implied intent.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Planned work should remain reviewable\n    summary: Delivery states should support gradual adoption.\n    description: This fixture exercises temporary validate overrides for planned work.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Planned requirements can exist before delivery starts\n    description: Planned items should stay trace-free until implementation begins.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {}\n",
+    )
+    .expect("requirement");
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Planned features can stay undocumented by traces\n    summary: Delivery claims should not appear before the work ships.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {}\n",
+    )
+    .expect("feature");
+}
+
+fn write_orphan_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+    write_config(root, true, true, true, false);
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep the main graph connected\n    product_design_principle: Real work should stay linked across the stack.\n    coding_guideline: Prefer deliberate adjacent-layer links.\n    linked_policies:\n      - POL-001\n  - id: PHIL-ORPHAN-001\n    title: Temporary brainstorm\n    product_design_principle: Early ideas can start disconnected.\n    coding_guideline: This item intentionally has no links yet.\n    linked_policies: []\n",
+    )
+    .expect("philosophy");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Keep the main graph connected\n    summary: One connected chain keeps the fixture otherwise valid.\n    description: The orphan philosophy should be the only failure without overrides.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Connected requirements stay discoverable\n    description: The main path remains valid so the orphan stands out.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {}\n",
+    )
+    .expect("requirement");
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Connected feature stays discoverable\n    summary: This keeps the base fixture valid.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {}\n",
+    )
+    .expect("feature");
+}
+
+fn write_missing_backlink_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+    write_config(root, true, false, true, false);
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Forward links should stay explicit\n    product_design_principle: One-way references should still be explainable during migration.\n    coding_guideline: Back-links can be phased in later.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: One-way links can appear during migration\n    summary: This fixture isolates the reciprocal-link rule.\n    description: The requirement links to the feature but the feature omits the backlink.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Migrating graphs may start one-way\n    description: The requirement points to a real feature during migration.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {}\n",
+    )
+    .expect("requirement");
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Migrating feature backlink\n    summary: This feature intentionally omits the reciprocal requirement link.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n",
+    )
+    .expect("feature");
+}
+
+fn write_coverage_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+
+    write_config(root, true, true, true, false);
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Public APIs should stay owned\n    product_design_principle: Shipped symbols should remain attributable to real features.\n    coding_guideline: Keep requirement tests and feature implementations explicit.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Coverage can be enabled gradually\n    summary: This fixture proves CLI overrides can tighten coverage on demand.\n    description: The repository declares one owned public symbol and one stray public symbol.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Tests should stay owned by requirements\n    description: The requirement trace is valid so coverage is the only tightening.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      rust:\n        - file: tests/coverage.rs\n          symbols:\n            - requirement_test\n",
+    )
+    .expect("requirement");
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Public APIs should stay feature-owned\n    summary: One public symbol is intentionally left unclaimed.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      rust:\n        - file: src/coverage.rs\n          symbols:\n            - owned_symbol\n",
+    )
+    .expect("feature");
+    fs::write(
+        root.join("src/coverage.rs"),
+        "/// FEAT-001\npub fn owned_symbol() {}\n\npub fn stray_symbol() {}\n",
+    )
+    .expect("source");
+    fs::write(
+        root.join("tests/coverage.rs"),
+        "// REQ-001\n#[test]\nfn requirement_test() {\n    assert!(true);\n}\n",
+    )
+    .expect("test");
+}
+
+#[test]
+fn validate_cli_override_can_allow_planned_items() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_planned_workspace(tempdir.path(), false);
+
+    let baseline = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+    assert!(
+        !baseline.status.success(),
+        "planned items should fail without override"
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--allow-planned")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_override_can_forbid_planned_items() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_planned_workspace(tempdir.path(), true);
+
+    let baseline = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+    assert!(
+        baseline.status.success(),
+        "planned items should pass with config"
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--allow-planned=false")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "CLI override should tighten planned items"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-delivery-planned-001"));
+}
+
+#[test]
+fn validate_cli_override_can_disable_orphan_checks() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_orphan_workspace(tempdir.path());
+
+    let baseline = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+    assert!(
+        !baseline.status.success(),
+        "orphaned items should fail without override"
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--require-non-orphaned-items=false")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_override_can_disable_reciprocal_checks() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_missing_backlink_workspace(tempdir.path());
+
+    let baseline = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+    assert!(
+        !baseline.status.success(),
+        "missing backlinks should fail without override"
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--require-reciprocal-links=false")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn validate_cli_override_can_enable_symbol_trace_coverage() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_coverage_workspace(tempdir.path());
+
+    let baseline = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+    assert!(
+        baseline.status.success(),
+        "coverage should stay off without override\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&baseline.stdout),
+        String::from_utf8_lossy(&baseline.stderr)
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--require-symbol-trace-coverage")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "override should enable strict coverage"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-coverage-public-001"));
+}


### PR DESCRIPTION
## Summary
- add temporary CLI overrides for the config-driven validate strictness switches
- cover the new override behavior in parse/help/integration tests and trace the new tests in the self-hosted spec
- update README, guides, self-hosted spec docs, and regenerated docs artifacts

Closes #177