### PR TITLE
feat: allow syu init custom spec roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,14 @@ are attached to a terminal.
 `syu init` creates:
 
 - `syu.yaml`
-- `docs/syu/philosophy/`
-- `docs/syu/policies/`
-- `docs/syu/requirements/`
-- `docs/syu/features/`
+- `docs/syu/philosophy/` by default
+- `docs/syu/policies/` by default
+- `docs/syu/requirements/` by default
+- `docs/syu/features/` by default
+
+Prefer another repository layout such as `docs/spec` or `spec/contracts`?
+Use `syu init . --spec-root docs/spec` to scaffold the same starter tree there
+and write the matching `spec.root` value into `syu.yaml`.
 
 ## Commands
 
@@ -139,9 +143,11 @@ Bootstrap a new workspace:
 ```bash
 syu init .
 syu init path/to/workspace --name my-project
+syu init . --spec-root docs/spec
 ```
 
-Use `--force` to overwrite generated files.
+Use `--force` to overwrite generated files. Use `--spec-root` to scaffold into a
+repository-relative spec tree without moving the generated files by hand later.
 
 ### `syu validate`
 

--- a/docs/generated/site-spec/config/spec.md
+++ b/docs/generated/site-spec/config/spec.md
@@ -30,6 +30,9 @@ description: "Generated reference for docs/syu/config/spec.yaml"
       Relative paths are resolved from the workspace root. Absolute paths are
       also supported so generated docs or external specification trees can live
       outside the repository when needed. New workspaces default to `docs/syu`.
+      Use `syu init --spec-root ...` when you want the initial scaffold to start
+      in another repository-relative location such as `docs/spec` or
+      `spec/contracts`.
   - **accepts**:
     - relative paths from the workspace root
     - absolute paths outside the repository
@@ -49,6 +52,9 @@ items:
       Relative paths are resolved from the workspace root. Absolute paths are
       also supported so generated docs or external specification trees can live
       outside the repository when needed. New workspaces default to `docs/syu`.
+      Use `syu init --spec-root ...` when you want the initial scaffold to start
+      in another repository-relative location such as `docs/spec` or
+      `spec/contracts`.
     accepts:
       - relative paths from the workspace root
       - absolute paths outside the repository

--- a/docs/generated/site-spec/features/cli/init.md
+++ b/docs/generated/site-spec/features/cli/init.md
@@ -47,6 +47,22 @@ description: "Generated reference for docs/syu/features/cli/init.yaml"
       - **file**: src/cli.rs
         - **symbols**:
           - InitArgs
+- **id**: FEAT-INIT-003
+  - **title**: Custom spec.root bootstrap
+  - **summary**: Allow `syu init --spec-root` to scaffold the starter workspace into another repository-relative specification tree and emit the matching `spec.root` in `syu.yaml`.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-009
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/init.rs
+        - **symbols**:
+          - run_init_command
+          - resolve_init_spec_root
+          - scaffold_files
+      - **file**: src/cli.rs
+        - **symbols**:
+          - InitArgs
 
 ## Source YAML
 
@@ -82,6 +98,22 @@ features:
         - file: src/command/init.rs
           symbols:
             - run_init_command
+        - file: src/cli.rs
+          symbols:
+            - InitArgs
+  - id: FEAT-INIT-003
+    title: Custom spec.root bootstrap
+    summary: Allow `syu init --spec-root` to scaffold the starter workspace into another repository-relative specification tree and emit the matching `spec.root` in `syu.yaml`.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - resolve_init_spec_root
+            - scaffold_files
         - file: src/cli.rs
           symbols:
             - InitArgs

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -41,6 +41,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
         - **symbols**:
           - root_help_includes_start_here_guidance
           - workspace_help_uses_current_directory_default_consistently
+          - init_help_mentions_custom_spec_roots
           - validate_help_lists_temporary_config_overrides
       - **file**: tests/repository_quality.rs
         - **symbols**:
@@ -100,6 +101,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - init_help_mentions_custom_spec_roots
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -22,10 +22,13 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
   - **description**:
     - |
       The `init` command MUST create a starter `syu.yaml` whose version matches
-      the running CLI and a valid `docs/syu/` tree whose starter requirements
-      and features begin as `planned` so users can begin from a working
-      structure instead of manually creating directories and placeholder YAML
-      files.
+      the running CLI and a valid starter specification tree whose starter
+      requirements and features begin as `planned` so users can begin from a
+      working structure instead of manually creating directories and
+      placeholder YAML files. By default the tree lives under `docs/syu/`, and
+      `syu init --spec-root` MUST also support scaffolding the same layout into
+      another repository-relative specification root while writing the matching
+      `spec.root` value into `syu.yaml`.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -34,6 +37,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
   - **linked_features**:
     - FEAT-INIT-001
     - FEAT-INIT-002
+    - FEAT-INIT-003
   - **tests**:
     - **rust**:
       - **file**: tests/init_command.rs
@@ -168,10 +172,13 @@ requirements:
     title: Bootstrap a workspace with syu init and syu.yaml
     description: |
       The `init` command MUST create a starter `syu.yaml` whose version matches
-      the running CLI and a valid `docs/syu/` tree whose starter requirements
-      and features begin as `planned` so users can begin from a working
-      structure instead of manually creating directories and placeholder YAML
-      files.
+      the running CLI and a valid starter specification tree whose starter
+      requirements and features begin as `planned` so users can begin from a
+      working structure instead of manually creating directories and
+      placeholder YAML files. By default the tree lives under `docs/syu/`, and
+      `syu init --spec-root` MUST also support scaffolding the same layout into
+      another repository-relative specification root while writing the matching
+      `spec.root` value into `syu.yaml`.
     priority: high
     status: implemented
     linked_policies:
@@ -180,6 +187,7 @@ requirements:
     linked_features:
       - FEAT-INIT-001
       - FEAT-INIT-002
+      - FEAT-INIT-003
     tests:
       rust:
         - file: tests/init_command.rs

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 7
 - Requirements: 18
-- Features: 19
+- Features: 20
 
 ## Traceability
 
 - Requirement-to-test traceability: 59/59
-- Feature-to-implementation traceability: 77/77
+- Feature-to-implementation traceability: 79/79
 
 ## Issues
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -94,6 +94,10 @@ spec:
 New workspaces default to `docs/syu`. Existing repositories can keep another
 layout, including `docs/spec`, by setting `spec.root` explicitly.
 
+When you are starting a brand-new workspace, `syu init --spec-root docs/spec`
+scaffolds the starter files into that repository-relative path immediately and
+writes the matching `spec.root` value for you.
+
 ### `validate.default_fix`
 
 When `true`, `syu validate` behaves as if `--fix` was passed unless the user

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -60,14 +60,24 @@ Or scaffold another directory:
 syu init path/to/workspace --name my-project
 ```
 
-This creates `syu.yaml` and a starter `docs/syu/` tree.
+Need another repository layout from the first command? Scaffold a custom spec
+root directly:
+
+```bash
+syu init . --spec-root docs/spec
+```
+
+This creates `syu.yaml` and a starter spec tree. By default the tree lives under
+`docs/syu/`; `--spec-root` writes the same scaffold into another
+repository-relative path and records that location in `syu.yaml`.
 
 Starter requirements and features begin as `status: planned`. Keep them planned
 until you are ready to declare real tests and implementation traces.
 
 ## 2. Fill in the starter spec
 
-Start by editing:
+Start by editing the generated files under your configured `spec.root`
+(default: `docs/syu`):
 
 - `docs/syu/philosophy/foundation.yaml`
 - `docs/syu/policies/policies.yaml`

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -15,6 +15,13 @@ mkdir filestore && cd filestore
 syu init .
 ```
 
+If the repository already uses another documentation layout, initialize there
+instead:
+
+```bash
+syu init . --spec-root docs/spec
+```
+
 `syu init` creates:
 
 ```
@@ -35,6 +42,9 @@ The relevant part of `syu.yaml` points the validator at that tree:
 spec:
   root: docs/syu
 ```
+
+`--spec-root` changes both the generated directory and this `spec.root` value, so
+you do not need to move the scaffold by hand after bootstrap.
 
 ---
 

--- a/docs/syu/config/spec.yaml
+++ b/docs/syu/config/spec.yaml
@@ -10,6 +10,9 @@ items:
       Relative paths are resolved from the workspace root. Absolute paths are
       also supported so generated docs or external specification trees can live
       outside the repository when needed. New workspaces default to `docs/syu`.
+      Use `syu init --spec-root ...` when you want the initial scaffold to start
+      in another repository-relative location such as `docs/spec` or
+      `spec/contracts`.
     accepts:
       - relative paths from the workspace root
       - absolute paths outside the repository

--- a/docs/syu/features/cli/init.yaml
+++ b/docs/syu/features/cli/init.yaml
@@ -32,3 +32,19 @@ features:
         - file: src/cli.rs
           symbols:
             - InitArgs
+  - id: FEAT-INIT-003
+    title: Custom spec.root bootstrap
+    summary: Allow `syu init --spec-root` to scaffold the starter workspace into another repository-relative specification tree and emit the matching `spec.root` in `syu.yaml`.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - resolve_init_spec_root
+            - scaffold_files
+        - file: src/cli.rs
+          symbols:
+            - InitArgs

--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -24,6 +24,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - init_help_mentions_custom_spec_roots
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -5,10 +5,13 @@ requirements:
     title: Bootstrap a workspace with syu init and syu.yaml
     description: |
       The `init` command MUST create a starter `syu.yaml` whose version matches
-      the running CLI and a valid `docs/syu/` tree whose starter requirements
-      and features begin as `planned` so users can begin from a working
-      structure instead of manually creating directories and placeholder YAML
-      files.
+      the running CLI and a valid starter specification tree whose starter
+      requirements and features begin as `planned` so users can begin from a
+      working structure instead of manually creating directories and
+      placeholder YAML files. By default the tree lives under `docs/syu/`, and
+      `syu init --spec-root` MUST also support scaffolding the same layout into
+      another repository-relative specification root while writing the matching
+      `spec.root` value into `syu.yaml`.
     priority: high
     status: implemented
     linked_policies:
@@ -17,6 +20,7 @@ requirements:
     linked_features:
       - FEAT-INIT-001
       - FEAT-INIT-002
+      - FEAT-INIT-003
     tests:
       rust:
         - file: tests/init_command.rs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 // FEAT-APP-001
 // FEAT-BROWSE-001
 // FEAT-BROWSE-002
+// FEAT-INIT-003
 // FEAT-LIST-002
 // FEAT-REPORT-001
 // FEAT-INIT-002
@@ -280,6 +281,12 @@ pub struct InitArgs {
     #[arg(long)]
     pub name: Option<String>,
 
+    #[arg(
+        help = "Repository-relative spec.root to scaffold (for example docs/spec or spec/contracts)"
+    )]
+    #[arg(long)]
+    pub spec_root: Option<PathBuf>,
+
     #[arg(help = "Overwrite generated files when they already exist")]
     #[arg(long)]
     pub force: bool,
@@ -334,8 +341,9 @@ impl ValidationGenreFilter {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use std::path::PathBuf;
 
-    use super::{Cli, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
+    use super::{Cli, Commands, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -380,5 +388,16 @@ mod tests {
 
         let message = error.to_string();
         assert!(message.contains("--allow-planned"));
+    }
+
+    #[test]
+    fn init_args_accept_custom_spec_root() {
+        let cli = Cli::try_parse_from(["syu", "init", ".", "--spec-root", "docs/spec"])
+            .expect("init args should parse");
+
+        let Some(Commands::Init(args)) = cli.command else {
+            panic!("expected init command");
+        };
+        assert_eq!(args.spec_root, Some(PathBuf::from("docs/spec")));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -340,10 +340,8 @@ impl ValidationGenreFilter {
 
 #[cfg(test)]
 mod tests {
+    use super::{Cli, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
     use clap::Parser;
-    use std::path::PathBuf;
-
-    use super::{Cli, Commands, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -395,9 +393,8 @@ mod tests {
         let cli = Cli::try_parse_from(["syu", "init", ".", "--spec-root", "docs/spec"])
             .expect("init args should parse");
 
-        let Some(Commands::Init(args)) = cli.command else {
-            panic!("expected init command");
-        };
-        assert_eq!(args.spec_root, Some(PathBuf::from("docs/spec")));
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Init("));
+        assert!(rendered.contains("spec_root: Some(\"docs/spec\")"));
     }
 }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,17 +1,21 @@
 // REQ-CORE-009
+// FEAT-INIT-003
 // FEAT-INIT-002
 
 use anyhow::{Result, bail};
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use crate::{
     cli::{InitArgs, OutputFormat},
     command::shell_quote_path,
     config::{SyuConfig, render_config},
+    coverage::normalize_relative_path,
 };
+
+const DEFAULT_SPEC_ROOT: &str = "docs/syu";
 
 #[cfg(test)]
 const GENERATED_PATHS: &[&str] = &[
@@ -30,8 +34,9 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
         .name
         .clone()
         .unwrap_or_else(|| infer_project_name(&workspace));
+    let spec_root = resolve_init_spec_root(args.spec_root.as_deref())?;
 
-    let files = scaffold_files(&project_name);
+    let files = scaffold_files(&project_name, &spec_root);
     ensure_writable_targets(
         &workspace,
         files.iter().map(|(path, _)| PathBuf::from(path)),
@@ -61,7 +66,7 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
         }
         OutputFormat::Text => {
             let workspace_arg = shell_quote_path(&workspace);
-            let spec_root = workspace.join("docs/syu");
+            let absolute_spec_root = workspace.join(&spec_root);
             println!("initialized syu workspace at {}", workspace.display());
             println!();
             println!("Created files:");
@@ -72,12 +77,24 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
             println!("What to do next:");
             println!(
                 "  1. Edit the spec files in {}/ to describe your project",
-                spec_root.display()
+                absolute_spec_root.display()
             );
-            println!("     - docs/syu/philosophy/foundation.yaml  (core principles)");
-            println!("     - docs/syu/policies/policies.yaml       (governance rules)");
-            println!("     - docs/syu/requirements/core/core.yaml  (concrete requirements)");
-            println!("     - docs/syu/features/core/core.yaml      (feature definitions)");
+            println!(
+                "     - {}  (core principles)",
+                path_label(&spec_root.join("philosophy/foundation.yaml"))
+            );
+            println!(
+                "     - {}  (governance rules)",
+                path_label(&spec_root.join("policies/policies.yaml"))
+            );
+            println!(
+                "     - {}  (concrete requirements)",
+                path_label(&spec_root.join("requirements/core/core.yaml"))
+            );
+            println!(
+                "     - {}  (feature definitions)",
+                path_label(&spec_root.join("features/core/core.yaml"))
+            );
             println!("  2. Run `syu validate {workspace_arg}` to check your spec for consistency");
             println!(
                 "  3. Run `syu browse {workspace_arg}` for terminal exploration, or `syu app {workspace_arg}` for the browser UI"
@@ -96,6 +113,25 @@ fn prepare_workspace_root(path: &Path) -> Result<PathBuf> {
 
     fs::create_dir_all(path)?;
     path.canonicalize().map_err(Into::into)
+}
+
+fn resolve_init_spec_root(spec_root: Option<&Path>) -> Result<PathBuf> {
+    let raw = spec_root.unwrap_or_else(|| Path::new(DEFAULT_SPEC_ROOT));
+    let normalized = normalize_relative_path(raw);
+
+    if normalized.as_os_str().is_empty()
+        || normalized.is_absolute()
+        || normalized
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!(
+            "`--spec-root` must stay within the workspace root as a relative path: `{}`",
+            raw.display()
+        );
+    }
+
+    Ok(PathBuf::from(path_label(&normalized)))
 }
 
 fn infer_project_name(workspace: &Path) -> String {
@@ -133,37 +169,43 @@ fn ensure_writable_targets(
     bail!("refusing to overwrite existing files without --force: {paths}");
 }
 
-fn scaffold_files(project_name: &str) -> Vec<(String, String)> {
+fn scaffold_files(project_name: &str, spec_root: &Path) -> Vec<(String, String)> {
     vec![
         (
             "syu.yaml".to_string(),
-            render_default_config().expect("config template should render"),
+            render_default_config(spec_root).expect("config template should render"),
         ),
         (
-            "docs/syu/philosophy/foundation.yaml".to_string(),
+            path_label(&spec_root.join("philosophy/foundation.yaml")),
             philosophy_template(project_name),
         ),
         (
-            "docs/syu/policies/policies.yaml".to_string(),
+            path_label(&spec_root.join("policies/policies.yaml")),
             policy_template(project_name),
         ),
         (
-            "docs/syu/requirements/core/core.yaml".to_string(),
+            path_label(&spec_root.join("requirements/core/core.yaml")),
             requirement_template(project_name),
         ),
         (
-            "docs/syu/features/features.yaml".to_string(),
+            path_label(&spec_root.join("features/features.yaml")),
             feature_registry_template(),
         ),
         (
-            "docs/syu/features/core/core.yaml".to_string(),
+            path_label(&spec_root.join("features/core/core.yaml")),
             feature_template(project_name),
         ),
     ]
 }
 
-fn render_default_config() -> Result<String> {
-    render_config(&SyuConfig::default())
+fn render_default_config(spec_root: &Path) -> Result<String> {
+    let mut config = SyuConfig::default();
+    config.spec.root = spec_root.to_path_buf();
+    render_config(&config)
+}
+
+fn path_label(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn philosophy_template(project_name: &str) -> String {
@@ -206,8 +248,8 @@ mod tests {
     use crate::cli::InitArgs;
 
     use super::{
-        GENERATED_PATHS, ensure_writable_targets, infer_project_name, run_init_command,
-        scaffold_files,
+        DEFAULT_SPEC_ROOT, GENERATED_PATHS, ensure_writable_targets, infer_project_name,
+        resolve_init_spec_root, run_init_command, scaffold_files,
     };
 
     #[test]
@@ -220,7 +262,7 @@ mod tests {
 
     #[test]
     fn scaffold_files_include_all_expected_templates() {
-        let files = scaffold_files("demo");
+        let files = scaffold_files("demo", std::path::Path::new(DEFAULT_SPEC_ROOT));
         let paths: Vec<_> = files.into_iter().map(|(path, _)| path).collect();
         assert_eq!(paths.len(), GENERATED_PATHS.len());
         for expected in GENERATED_PATHS {
@@ -250,6 +292,7 @@ mod tests {
         let args = InitArgs {
             workspace: workspace.clone(),
             name: Some("demo".to_string()),
+            spec_root: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         };
@@ -274,6 +317,7 @@ mod tests {
         let args = InitArgs {
             workspace: tempdir.path().to_path_buf(),
             name: Some("forced".to_string()),
+            spec_root: None,
             force: true,
             format: crate::cli::OutputFormat::Text,
         };
@@ -288,7 +332,7 @@ mod tests {
 
     #[test]
     fn scaffold_files_default_to_planned_status() {
-        let files = scaffold_files("demo");
+        let files = scaffold_files("demo", std::path::Path::new(DEFAULT_SPEC_ROOT));
         let requirement = files
             .iter()
             .find(|(path, _)| path == "docs/syu/requirements/core/core.yaml")
@@ -311,6 +355,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace: file_path.clone(),
             name: None,
+            spec_root: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -332,6 +377,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace,
             name: Some("demo".to_string()),
+            spec_root: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -350,6 +396,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace,
             name: Some("demo".to_string()),
+            spec_root: None,
             force: true,
             format: crate::cli::OutputFormat::Text,
         })
@@ -365,6 +412,7 @@ mod tests {
         let args = InitArgs {
             workspace: workspace.clone(),
             name: Some("demo".to_string()),
+            spec_root: None,
             force: false,
             format: crate::cli::OutputFormat::Json,
         };
@@ -378,5 +426,29 @@ mod tests {
                 "missing generated file: {path}"
             );
         }
+    }
+
+    #[test]
+    fn resolve_init_spec_root_normalizes_relative_paths() {
+        assert_eq!(
+            resolve_init_spec_root(Some(std::path::Path::new("./spec/./contracts")))
+                .expect("spec root should normalize"),
+            std::path::PathBuf::from("spec/contracts")
+        );
+        assert_eq!(
+            resolve_init_spec_root(None).expect("default spec root should resolve"),
+            std::path::PathBuf::from(DEFAULT_SPEC_ROOT)
+        );
+    }
+
+    #[test]
+    fn resolve_init_spec_root_rejects_paths_outside_workspace() {
+        let parent = resolve_init_spec_root(Some(std::path::Path::new("../spec")))
+            .expect_err("parent paths should fail");
+        assert!(parent.to_string().contains("--spec-root"));
+
+        let absolute = resolve_init_spec_root(Some(std::path::Path::new("/tmp/spec")))
+            .expect_err("absolute paths should fail");
+        assert!(absolute.to_string().contains("--spec-root"));
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -159,7 +159,7 @@ impl CheckResult {
                 None,
                 message.into(),
                 Some(
-                    "New workspace? Run `syu init .` in the repository root. Otherwise make sure `syu.yaml` and `docs/syu/` exist under the selected workspace."
+                    "New workspace? Run `syu init .` in the repository root. Otherwise make sure `syu.yaml` exists and `spec.root` points at a scaffolded tree under the selected workspace."
                         .to_string(),
                 ),
             )],

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -52,6 +52,21 @@ fn workspace_help_uses_current_directory_default_consistently() {
 }
 
 #[test]
+fn init_help_mentions_custom_spec_roots() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["init", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "init help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--spec-root"));
+    assert!(stdout.contains("docs/spec"));
+}
+
+#[test]
 fn validate_help_lists_temporary_config_overrides() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -62,6 +62,63 @@ fn init_command_bootstraps_a_workspace_that_validate_accepts() {
 
 #[test]
 // REQ-CORE-009
+fn init_command_bootstraps_a_custom_spec_root_that_validate_accepts() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .arg("--name")
+        .arg("demo")
+        .arg("--spec-root")
+        .arg("spec/contracts")
+        .output()
+        .expect("init should run");
+
+    assert!(
+        init.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    assert!(workspace.join("syu.yaml").exists());
+    assert!(
+        workspace
+            .join("spec/contracts/features/core/core.yaml")
+            .exists()
+    );
+
+    let config = fs::read_to_string(workspace.join("syu.yaml")).expect("config should exist");
+    let parsed_config: Value = serde_yaml::from_str(&config).expect("config should be valid yaml");
+    assert_eq!(
+        parsed_config["spec"]["root"].as_str(),
+        Some("spec/contracts")
+    );
+
+    let stdout = String::from_utf8_lossy(&init.stdout);
+    assert!(stdout.contains(&format!("{}/", workspace.join("spec/contracts").display())));
+    assert!(stdout.contains("spec/contracts/philosophy/foundation.yaml"));
+
+    let validate = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(&workspace)
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        validate.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+    assert!(String::from_utf8_lossy(&validate.stdout).contains("syu validate passed"));
+}
+
+#[test]
+// REQ-CORE-009
 fn init_command_requires_force_when_generated_files_exist() {
     let tempdir = tempdir().expect("tempdir should exist");
     fs::write(
@@ -107,4 +164,26 @@ fn init_command_prints_workspace_aware_next_steps_for_explicit_paths() {
     assert!(stdout.contains(&format!("Run `syu browse {workspace_arg}`")));
     assert!(stdout.contains(&format!("`syu app {workspace_arg}`")));
     assert!(stdout.contains(&format!("{}/", workspace.join("docs/syu").display())));
+}
+
+#[test]
+// REQ-CORE-009
+fn init_command_rejects_spec_roots_outside_the_workspace() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .arg("--spec-root")
+        .arg("../spec")
+        .output()
+        .expect("init should run");
+
+    assert!(
+        !init.status.success(),
+        "init should reject invalid spec roots"
+    );
+    assert!(String::from_utf8_lossy(&init.stderr).contains("--spec-root"));
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -249,6 +249,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("scripts/install-precommit.sh"));
     assert!(readme.contains("https://ugoite.github.io/syu/"));
     assert!(readme.contains("docs/syu/config/"));
+    assert!(readme.contains("--spec-root"));
     assert!(!readme.contains("cargo run -- init ."));
 
     assert!(concepts.contains("philosophy"));
@@ -273,6 +274,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu app ."));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
+    assert!(getting_started.contains("--spec-root"));
     assert!(getting_started.contains("Requirements are discovered"));
     assert!(getting_started.contains("implementation claims should stay deliberate"));
     assert!(getting_started.contains(&format!("version: {current_version}")));
@@ -295,6 +297,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("Understand the model first?"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("validate.allow_planned"));
+    assert!(configuration.contains("--spec-root"));
     assert!(configuration.contains(&format!("version: {current_version}")));
     assert!(configuration.contains("docs/syu/config/overview.yaml"));
     assert!(configuration.contains("docs/syu/config/validate.yaml"));


### PR DESCRIPTION
## Summary
- add `syu init --spec-root` for repository-relative starter layouts
- validate custom roots in the CLI and update next-step guidance
- document and trace the new bootstrap flow across tests and self-hosted spec

Closes #176