### PR TITLE
feat: add syu init starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ are attached to a terminal.
 - `docs/syu/requirements/`
 - `docs/syu/features/`
 
+Want a closer starting point for a repository that is already clearly
+Rust-first, Python-first, or polyglot? Start with a lightweight template:
+
+```bash
+syu init . --template rust-only
+syu init . --template python-only
+syu init . --template polyglot
+```
+
 ## Commands
 
 ### `syu init`
@@ -139,9 +148,12 @@ Bootstrap a new workspace:
 ```bash
 syu init .
 syu init path/to/workspace --name my-project
+syu init . --template rust-only
 ```
 
-Use `--force` to overwrite generated files.
+Use `--force` to overwrite generated files. Use `--template` when you want the
+starter IDs, file layout, and scaffold copy to start closer to the repository
+style you already expect.
 
 ### `syu validate`
 

--- a/docs/generated/site-spec/features/cli/init.md
+++ b/docs/generated/site-spec/features/cli/init.md
@@ -47,6 +47,24 @@ description: "Generated reference for docs/syu/features/cli/init.yaml"
       - **file**: src/cli.rs
         - **symbols**:
           - InitArgs
+- **id**: FEAT-INIT-004
+  - **title**: Language-oriented starter templates
+  - **summary**: Allow `syu init --template` to scaffold small rust-only, python-only, and polyglot starter layouts that better match the repository style from the first commit.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-009
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/init.rs
+        - **symbols**:
+          - run_init_command
+          - scaffold_files
+          - requirement_document_path
+          - feature_document_path
+      - **file**: src/cli.rs
+        - **symbols**:
+          - InitArgs
+          - StarterTemplate
 
 ## Source YAML
 
@@ -85,4 +103,22 @@ features:
         - file: src/cli.rs
           symbols:
             - InitArgs
+  - id: FEAT-INIT-004
+    title: Language-oriented starter templates
+    summary: Allow `syu init --template` to scaffold small rust-only, python-only, and polyglot starter layouts that better match the repository style from the first commit.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - scaffold_files
+            - requirement_document_path
+            - feature_document_path
+        - file: src/cli.rs
+          symbols:
+            - InitArgs
+            - StarterTemplate
 ```

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -41,6 +41,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
         - **symbols**:
           - root_help_includes_start_here_guidance
           - workspace_help_uses_current_directory_default_consistently
+          - init_help_lists_starter_templates
           - validate_help_lists_temporary_config_overrides
       - **file**: tests/repository_quality.rs
         - **symbols**:
@@ -100,6 +101,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - init_help_lists_starter_templates
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -25,7 +25,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       the running CLI and a valid `docs/syu/` tree whose starter requirements
       and features begin as `planned` so users can begin from a working
       structure instead of manually creating directories and placeholder YAML
-      files.
+      files. `syu init --template` MUST also support small `rust-only`,
+      `python-only`, and `polyglot` starter layouts so adopters can begin
+      closer to their repository style without copying example files by hand.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -34,6 +36,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
   - **linked_features**:
     - FEAT-INIT-001
     - FEAT-INIT-002
+    - FEAT-INIT-004
   - **tests**:
     - **rust**:
       - **file**: tests/init_command.rs
@@ -171,7 +174,9 @@ requirements:
       the running CLI and a valid `docs/syu/` tree whose starter requirements
       and features begin as `planned` so users can begin from a working
       structure instead of manually creating directories and placeholder YAML
-      files.
+      files. `syu init --template` MUST also support small `rust-only`,
+      `python-only`, and `polyglot` starter layouts so adopters can begin
+      closer to their repository style without copying example files by hand.
     priority: high
     status: implemented
     linked_policies:
@@ -180,6 +185,7 @@ requirements:
     linked_features:
       - FEAT-INIT-001
       - FEAT-INIT-002
+      - FEAT-INIT-004
     tests:
       rust:
         - file: tests/init_command.rs

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 7
 - Requirements: 18
-- Features: 19
+- Features: 20
 
 ## Traceability
 
 - Requirement-to-test traceability: 59/59
-- Feature-to-implementation traceability: 77/77
+- Feature-to-implementation traceability: 79/79
 
 ## Issues
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -60,14 +60,23 @@ Or scaffold another directory:
 syu init path/to/workspace --name my-project
 ```
 
-This creates `syu.yaml` and a starter `docs/syu/` tree.
+Need a closer starting point for a repository that is already Rust-first,
+Python-first, or polyglot?
+
+```bash
+syu init . --template rust-only
+```
+
+This creates `syu.yaml` and a starter `docs/syu/` tree. `--template` keeps the
+same four layers but swaps the starter IDs, file layout, and copy so the first
+edit looks more like the repository style you already expect.
 
 Starter requirements and features begin as `status: planned`. Keep them planned
 until you are ready to declare real tests and implementation traces.
 
 ## 2. Fill in the starter spec
 
-Start by editing:
+Start by editing the generated files:
 
 - `docs/syu/philosophy/foundation.yaml`
 - `docs/syu/policies/policies.yaml`
@@ -223,6 +232,10 @@ The repository includes complete examples:
 - `examples/rust-only`
 - `examples/python-only`
 - `examples/polyglot`
+
+If one of those examples is already close to your repository, use the matching
+`syu init --template ...` option so the starter scaffold begins nearer to that
+shape.
 
 ## Keep exploring
 

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -15,6 +15,13 @@ mkdir filestore && cd filestore
 syu init .
 ```
 
+For a repository that is already clearly Rust-first, Python-first, or
+polyglot, you can start from a closer scaffold instead:
+
+```bash
+syu init . --template rust-only
+```
+
 `syu init` creates:
 
 ```

--- a/docs/syu/features/cli/init.yaml
+++ b/docs/syu/features/cli/init.yaml
@@ -32,3 +32,21 @@ features:
         - file: src/cli.rs
           symbols:
             - InitArgs
+  - id: FEAT-INIT-004
+    title: Language-oriented starter templates
+    summary: Allow `syu init --template` to scaffold small rust-only, python-only, and polyglot starter layouts that better match the repository style from the first commit.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - scaffold_files
+            - requirement_document_path
+            - feature_document_path
+        - file: src/cli.rs
+          symbols:
+            - InitArgs
+            - StarterTemplate

--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -24,6 +24,7 @@ requirements:
           symbols:
             - root_help_includes_start_here_guidance
             - workspace_help_uses_current_directory_default_consistently
+            - init_help_lists_starter_templates
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -8,7 +8,9 @@ requirements:
       the running CLI and a valid `docs/syu/` tree whose starter requirements
       and features begin as `planned` so users can begin from a working
       structure instead of manually creating directories and placeholder YAML
-      files.
+      files. `syu init --template` MUST also support small `rust-only`,
+      `python-only`, and `polyglot` starter layouts so adopters can begin
+      closer to their repository style without copying example files by hand.
     priority: high
     status: implemented
     linked_policies:
@@ -17,6 +19,7 @@ requirements:
     linked_features:
       - FEAT-INIT-001
       - FEAT-INIT-002
+      - FEAT-INIT-004
     tests:
       rust:
         - file: tests/init_command.rs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 // FEAT-APP-001
 // FEAT-BROWSE-001
 // FEAT-BROWSE-002
+// FEAT-INIT-004
 // FEAT-LIST-002
 // FEAT-REPORT-001
 // FEAT-INIT-002
@@ -22,6 +23,12 @@ const APP_AFTER_HELP: &str = concat!(
     "Use GET /health for readiness checks once the app is serving.\n",
     "Press Ctrl-C to stop the local app server."
 );
+
+const INIT_AFTER_HELP: &str = "\
+Examples:
+  syu init .
+  syu init . --template rust-only
+  syu init path/to/workspace --name my-project --template polyglot";
 
 const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
 
@@ -72,7 +79,10 @@ pub enum Commands {
     Validate(ValidateArgs),
     #[command(about = "Render a Markdown report from the same validation engine")]
     Report(ReportArgs),
-    #[command(about = "Scaffold a version-matched syu workspace")]
+    #[command(
+        about = "Scaffold a version-matched syu workspace",
+        after_help = INIT_AFTER_HELP
+    )]
     Init(InitArgs),
 }
 
@@ -280,6 +290,10 @@ pub struct InitArgs {
     #[arg(long)]
     pub name: Option<String>,
 
+    #[arg(help = "Starter layout to scaffold (generic, rust-only, python-only, or polyglot)")]
+    #[arg(long, value_enum, default_value_t = StarterTemplate::Generic)]
+    pub template: StarterTemplate,
+
     #[arg(help = "Overwrite generated files when they already exist")]
     #[arg(long)]
     pub force: bool,
@@ -287,6 +301,15 @@ pub struct InitArgs {
     #[arg(help = "Output format (text shows next-step guidance; json returns created file paths)")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+pub enum StarterTemplate {
+    #[default]
+    Generic,
+    RustOnly,
+    PythonOnly,
+    Polyglot,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -335,7 +358,9 @@ impl ValidationGenreFilter {
 mod tests {
     use clap::Parser;
 
-    use super::{Cli, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
+    use super::{
+        Cli, Commands, LookupKind, StarterTemplate, ValidationGenreFilter, ValidationSeverityFilter,
+    };
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -380,5 +405,16 @@ mod tests {
 
         let message = error.to_string();
         assert!(message.contains("--allow-planned"));
+    }
+
+    #[test]
+    fn init_args_accept_template_values() {
+        let cli = Cli::try_parse_from(["syu", "init", ".", "--template", "rust-only"])
+            .expect("init args should parse");
+
+        let Some(Commands::Init(args)) = cli.command else {
+            panic!("expected init command");
+        };
+        assert_eq!(args.template, StarterTemplate::RustOnly);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,11 +356,8 @@ impl ValidationGenreFilter {
 
 #[cfg(test)]
 mod tests {
+    use super::{Cli, LookupKind, ValidationGenreFilter, ValidationSeverityFilter};
     use clap::Parser;
-
-    use super::{
-        Cli, Commands, LookupKind, StarterTemplate, ValidationGenreFilter, ValidationSeverityFilter,
-    };
 
     #[test]
     fn cli_enums_expose_expected_labels() {
@@ -412,9 +409,8 @@ mod tests {
         let cli = Cli::try_parse_from(["syu", "init", ".", "--template", "rust-only"])
             .expect("init args should parse");
 
-        let Some(Commands::Init(args)) = cli.command else {
-            panic!("expected init command");
-        };
-        assert_eq!(args.template, StarterTemplate::RustOnly);
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Init("));
+        assert!(rendered.contains("template: RustOnly"));
     }
 }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,4 +1,5 @@
 // REQ-CORE-009
+// FEAT-INIT-004
 // FEAT-INIT-002
 
 use anyhow::{Result, bail};
@@ -8,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    cli::{InitArgs, OutputFormat},
+    cli::{InitArgs, OutputFormat, StarterTemplate},
     command::shell_quote_path,
     config::{SyuConfig, render_config},
 };
@@ -31,7 +32,7 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
         .clone()
         .unwrap_or_else(|| infer_project_name(&workspace));
 
-    let files = scaffold_files(&project_name);
+    let files = scaffold_files(&project_name, args.template);
     ensure_writable_targets(
         &workspace,
         files.iter().map(|(path, _)| PathBuf::from(path)),
@@ -62,6 +63,8 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
         OutputFormat::Text => {
             let workspace_arg = shell_quote_path(&workspace);
             let spec_root = workspace.join("docs/syu");
+            let requirement_path = workspace.join(requirement_document_path(args.template));
+            let feature_path = workspace.join(feature_document_path(args.template));
             println!("initialized syu workspace at {}", workspace.display());
             println!();
             println!("Created files:");
@@ -76,8 +79,22 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
             );
             println!("     - docs/syu/philosophy/foundation.yaml  (core principles)");
             println!("     - docs/syu/policies/policies.yaml       (governance rules)");
-            println!("     - docs/syu/requirements/core/core.yaml  (concrete requirements)");
-            println!("     - docs/syu/features/core/core.yaml      (feature definitions)");
+            println!(
+                "     - {}  (concrete requirements)",
+                path_label(
+                    requirement_path
+                        .strip_prefix(&workspace)
+                        .expect("workspace-relative requirement path")
+                )
+            );
+            println!(
+                "     - {}  (feature definitions)",
+                path_label(
+                    feature_path
+                        .strip_prefix(&workspace)
+                        .expect("workspace-relative feature path")
+                )
+            );
             println!("  2. Run `syu validate {workspace_arg}` to check your spec for consistency");
             println!(
                 "  3. Run `syu browse {workspace_arg}` for terminal exploration, or `syu app {workspace_arg}` for the browser UI"
@@ -133,7 +150,7 @@ fn ensure_writable_targets(
     bail!("refusing to overwrite existing files without --force: {paths}");
 }
 
-fn scaffold_files(project_name: &str) -> Vec<(String, String)> {
+fn scaffold_files(project_name: &str, template: StarterTemplate) -> Vec<(String, String)> {
     vec![
         (
             "syu.yaml".to_string(),
@@ -141,23 +158,23 @@ fn scaffold_files(project_name: &str) -> Vec<(String, String)> {
         ),
         (
             "docs/syu/philosophy/foundation.yaml".to_string(),
-            philosophy_template(project_name),
+            philosophy_template(project_name, template),
         ),
         (
             "docs/syu/policies/policies.yaml".to_string(),
-            policy_template(project_name),
+            policy_template(project_name, template),
         ),
         (
-            "docs/syu/requirements/core/core.yaml".to_string(),
-            requirement_template(project_name),
+            requirement_document_path(template).to_string(),
+            requirement_template(project_name, template),
         ),
         (
             "docs/syu/features/features.yaml".to_string(),
-            feature_registry_template(),
+            feature_registry_template(template),
         ),
         (
-            "docs/syu/features/core/core.yaml".to_string(),
-            feature_template(project_name),
+            feature_document_path(template).to_string(),
+            feature_template(project_name, template),
         ),
     ]
 }
@@ -166,35 +183,114 @@ fn render_default_config() -> Result<String> {
     render_config(&SyuConfig::default())
 }
 
-fn philosophy_template(project_name: &str) -> String {
+fn philosophy_template(project_name: &str, template: StarterTemplate) -> String {
+    match template {
+        StarterTemplate::Generic => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: {project_name} should turn intent into executable agreements\n    product_design_principle: |\n      The project should keep philosophy, policy, requirements, and features\n      explicit enough that contributors can validate changes mechanically.\n    coding_guideline: |\n      Prefer stable IDs, typed data, and explicit traceability over conventions\n      that live only in contributor memory.\n    linked_policies:\n      - POL-001\n"
+        ),
+        StarterTemplate::RustOnly => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-RUST-001\n    title: {project_name} should keep Rust traces explicit\n    product_design_principle: |\n      The project should keep Rust-first traceability small, reviewable, and\n      obvious to contributors reading the code.\n    coding_guideline: |\n      Prefer stable IDs and Rust doc comments on traced symbols from the first\n      requirement onward.\n    linked_policies:\n      - POL-RUST-001\n"
+        ),
+        StarterTemplate::PythonOnly => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-PY-001\n    title: {project_name} should keep Python traces explicit\n    product_design_principle: |\n      The project should keep Python traceability small, reviewable, and easy\n      to understand from docstrings alone.\n    coding_guideline: |\n      Prefer stable IDs and clear docstrings on traced Python symbols from the\n      first requirement onward.\n    linked_policies:\n      - POL-PY-001\n"
+        ),
+        StarterTemplate::Polyglot => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-MIX-001\n    title: {project_name} should keep polyglot traces coherent\n    product_design_principle: |\n      The project should prove that one specification can stay understandable\n      even when implementation and tests span multiple languages.\n    coding_guideline: |\n      Prefer stable IDs and short language-native docs on every traced symbol.\n    linked_policies:\n      - POL-MIX-001\n"
+        ),
+    }
+}
+
+fn policy_template(project_name: &str, template: StarterTemplate) -> String {
+    match template {
+        StarterTemplate::Generic => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Every change in {project_name} should remain traceable\n    summary: Define rules that turn philosophy into a verifiable workflow.\n    description: |\n      A specification entry is only useful when contributors can trace it to\n      concrete requirements, features, code, and tests inside the repository.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n"
+        ),
+        StarterTemplate::RustOnly => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-RUST-001\n    title: Rust requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Rust-first workflow that stays explicit in code review.\n    description: |\n      Rust requirement and feature traces should point to symbols whose doc\n      comments carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - PHIL-RUST-001\n    linked_requirements:\n      - REQ-RUST-001\n"
+        ),
+        StarterTemplate::PythonOnly => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-PY-001\n    title: Python requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Python-first workflow that stays explicit in docstrings.\n    description: |\n      Python requirement and feature traces should point to symbols whose\n      docstrings carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - PHIL-PY-001\n    linked_requirements:\n      - REQ-PY-001\n"
+        ),
+        StarterTemplate::Polyglot => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-MIX-001\n    title: Polyglot requirement and feature traces must stay verifiable in {project_name}\n    summary: Start with one specification flow that can grow across languages.\n    description: |\n      The starter workspace should make it obvious how one requirement and one\n      feature can stay linked even when implementation later spans Rust,\n      Python, and TypeScript.\n    linked_philosophies:\n      - PHIL-MIX-001\n    linked_requirements:\n      - REQ-MIX-001\n"
+        ),
+    }
+}
+
+fn requirement_template(project_name: &str, template: StarterTemplate) -> String {
+    match template {
+        StarterTemplate::Generic => format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Bootstrap {project_name} with a four-layer specification\n    description: |\n      The project should keep philosophy, policy, requirements, and features in\n      YAML so contributors can evolve behavior deliberately.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {{}}\n"
+        ),
+        StarterTemplate::RustOnly => format!(
+            "category: Rust Requirements\nprefix: REQ-RUST\n\nrequirements:\n  - id: REQ-RUST-001\n    title: Bootstrap {project_name} with Rust-first trace conventions\n    description: |\n      The project should start with a Rust-oriented requirement that can later\n      claim documented Rust test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-RUST-001\n    linked_features:\n      - FEAT-RUST-001\n    tests: {{}}\n"
+        ),
+        StarterTemplate::PythonOnly => format!(
+            "category: Python Requirements\nprefix: REQ-PY\n\nrequirements:\n  - id: REQ-PY-001\n    title: Bootstrap {project_name} with Python-first trace conventions\n    description: |\n      The project should start with a Python-oriented requirement that can later\n      claim documented Python test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-PY-001\n    linked_features:\n      - FEAT-PY-001\n    tests: {{}}\n"
+        ),
+        StarterTemplate::Polyglot => format!(
+            "category: Polyglot Requirements\nprefix: REQ-MIX\n\nrequirements:\n  - id: REQ-MIX-001\n    title: Bootstrap {project_name} with polyglot trace conventions\n    description: |\n      The project should start with one requirement that can later trace into\n      Rust, Python, and TypeScript without changing the layered layout.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-MIX-001\n    linked_features:\n      - FEAT-MIX-001\n    tests: {{}}\n"
+        ),
+    }
+}
+
+fn feature_registry_template(template: StarterTemplate) -> String {
     format!(
-        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: {project_name} should turn intent into executable agreements\n    product_design_principle: |\n      The project should keep philosophy, policy, requirements, and features\n      explicit enough that contributors can validate changes mechanically.\n    coding_guideline: |\n      Prefer stable IDs, typed data, and explicit traceability over conventions\n      that live only in contributor memory.\n    linked_policies:\n      - POL-001\n"
+        "version: \"{}\"\nupdated: \"generated by syu init\"\n\nfiles:\n  - kind: {}\n    file: {}\n",
+        SyuConfig::default().version,
+        feature_kind(template),
+        feature_document_path(template)
+            .strip_prefix("docs/syu/features/")
+            .expect("feature path should stay under docs/syu/features")
     )
 }
 
-fn policy_template(project_name: &str) -> String {
-    format!(
-        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Every change in {project_name} should remain traceable\n    summary: Define rules that turn philosophy into a verifiable workflow.\n    description: |\n      A specification entry is only useful when contributors can trace it to\n      concrete requirements, features, code, and tests inside the repository.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n"
-    )
+fn feature_template(project_name: &str, template: StarterTemplate) -> String {
+    match template {
+        StarterTemplate::Generic => format!(
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Bootstrap the {project_name} spec workspace\n    summary: Provide a starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {{}}\n"
+        ),
+        StarterTemplate::RustOnly => format!(
+            "category: Rust Features\nversion: 1\n\nfeatures:\n  - id: FEAT-RUST-001\n    title: Bootstrap the {project_name} Rust spec workspace\n    summary: Provide a Rust-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-RUST-001\n    implementations: {{}}\n"
+        ),
+        StarterTemplate::PythonOnly => format!(
+            "category: Python Features\nversion: 1\n\nfeatures:\n  - id: FEAT-PY-001\n    title: Bootstrap the {project_name} Python spec workspace\n    summary: Provide a Python-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-PY-001\n    implementations: {{}}\n"
+        ),
+        StarterTemplate::Polyglot => format!(
+            "category: Polyglot Features\nversion: 1\n\nfeatures:\n  - id: FEAT-MIX-001\n    title: Bootstrap the {project_name} polyglot spec workspace\n    summary: Provide a starter structure that can grow across Rust, Python, and TypeScript.\n    status: planned\n    linked_requirements:\n      - REQ-MIX-001\n    implementations: {{}}\n"
+        ),
+    }
 }
 
-fn requirement_template(project_name: &str) -> String {
-    format!(
-        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Bootstrap {project_name} with a four-layer specification\n    description: |\n      The project should keep philosophy, policy, requirements, and features in\n      YAML so contributors can evolve behavior deliberately.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {{}}\n"
-    )
+fn requirement_document_path(template: StarterTemplate) -> &'static str {
+    match template {
+        StarterTemplate::Generic => "docs/syu/requirements/core/core.yaml",
+        StarterTemplate::RustOnly => "docs/syu/requirements/core/rust.yaml",
+        StarterTemplate::PythonOnly => "docs/syu/requirements/core/python.yaml",
+        StarterTemplate::Polyglot => "docs/syu/requirements/core/polyglot.yaml",
+    }
 }
 
-fn feature_registry_template() -> String {
-    format!(
-        "version: \"{}\"\nupdated: \"generated by syu init\"\n\nfiles:\n  - kind: core\n    file: core/core.yaml\n",
-        SyuConfig::default().version
-    )
+fn feature_document_path(template: StarterTemplate) -> &'static str {
+    match template {
+        StarterTemplate::Generic => "docs/syu/features/core/core.yaml",
+        StarterTemplate::RustOnly => "docs/syu/features/languages/rust.yaml",
+        StarterTemplate::PythonOnly => "docs/syu/features/languages/python.yaml",
+        StarterTemplate::Polyglot => "docs/syu/features/languages/polyglot.yaml",
+    }
 }
 
-fn feature_template(project_name: &str) -> String {
-    format!(
-        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Bootstrap the {project_name} spec workspace\n    summary: Provide a starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {{}}\n"
-    )
+fn feature_kind(template: StarterTemplate) -> &'static str {
+    match template {
+        StarterTemplate::Generic => "core",
+        StarterTemplate::RustOnly => "rust",
+        StarterTemplate::PythonOnly => "python",
+        StarterTemplate::Polyglot => "polyglot",
+    }
+}
+
+fn path_label(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 #[cfg(test)]
@@ -203,11 +299,11 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use crate::cli::InitArgs;
+    use crate::cli::{InitArgs, StarterTemplate};
 
     use super::{
-        GENERATED_PATHS, ensure_writable_targets, infer_project_name, run_init_command,
-        scaffold_files,
+        GENERATED_PATHS, ensure_writable_targets, feature_document_path, feature_kind,
+        infer_project_name, requirement_document_path, run_init_command, scaffold_files,
     };
 
     #[test]
@@ -220,7 +316,7 @@ mod tests {
 
     #[test]
     fn scaffold_files_include_all_expected_templates() {
-        let files = scaffold_files("demo");
+        let files = scaffold_files("demo", StarterTemplate::Generic);
         let paths: Vec<_> = files.into_iter().map(|(path, _)| path).collect();
         assert_eq!(paths.len(), GENERATED_PATHS.len());
         for expected in GENERATED_PATHS {
@@ -250,6 +346,7 @@ mod tests {
         let args = InitArgs {
             workspace: workspace.clone(),
             name: Some("demo".to_string()),
+            template: StarterTemplate::Generic,
             force: false,
             format: crate::cli::OutputFormat::Text,
         };
@@ -274,6 +371,7 @@ mod tests {
         let args = InitArgs {
             workspace: tempdir.path().to_path_buf(),
             name: Some("forced".to_string()),
+            template: StarterTemplate::Generic,
             force: true,
             format: crate::cli::OutputFormat::Text,
         };
@@ -288,7 +386,7 @@ mod tests {
 
     #[test]
     fn scaffold_files_default_to_planned_status() {
-        let files = scaffold_files("demo");
+        let files = scaffold_files("demo", StarterTemplate::Generic);
         let requirement = files
             .iter()
             .find(|(path, _)| path == "docs/syu/requirements/core/core.yaml")
@@ -311,6 +409,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace: file_path.clone(),
             name: None,
+            template: StarterTemplate::Generic,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -332,6 +431,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace,
             name: Some("demo".to_string()),
+            template: StarterTemplate::Generic,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -350,6 +450,7 @@ mod tests {
         let error = run_init_command(&InitArgs {
             workspace,
             name: Some("demo".to_string()),
+            template: StarterTemplate::Generic,
             force: true,
             format: crate::cli::OutputFormat::Text,
         })
@@ -365,6 +466,7 @@ mod tests {
         let args = InitArgs {
             workspace: workspace.clone(),
             name: Some("demo".to_string()),
+            template: StarterTemplate::Generic,
             force: false,
             format: crate::cli::OutputFormat::Json,
         };
@@ -377,6 +479,29 @@ mod tests {
                 workspace.join(path).exists(),
                 "missing generated file: {path}"
             );
+        }
+    }
+
+    #[test]
+    fn scaffold_files_support_language_oriented_templates() {
+        for template in [
+            StarterTemplate::RustOnly,
+            StarterTemplate::PythonOnly,
+            StarterTemplate::Polyglot,
+        ] {
+            let files = scaffold_files("demo", template);
+            let paths: Vec<_> = files.iter().map(|(path, _)| path.as_str()).collect();
+            assert!(paths.contains(&"syu.yaml"));
+            assert!(paths.contains(&"docs/syu/philosophy/foundation.yaml"));
+            assert!(paths.contains(&"docs/syu/policies/policies.yaml"));
+            assert!(paths.contains(&requirement_document_path(template)));
+            assert!(paths.contains(&feature_document_path(template)));
+
+            let registry = files
+                .iter()
+                .find(|(path, _)| path == "docs/syu/features/features.yaml")
+                .expect("feature registry should exist");
+            assert!(registry.1.contains(feature_kind(template)));
         }
     }
 }

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -52,6 +52,23 @@ fn workspace_help_uses_current_directory_default_consistently() {
 }
 
 #[test]
+fn init_help_lists_starter_templates() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["init", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "init help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--template"));
+    assert!(stdout.contains("rust-only"));
+    assert!(stdout.contains("python-only"));
+    assert!(stdout.contains("polyglot"));
+}
+
+#[test]
 fn validate_help_lists_temporary_config_overrides() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -62,6 +62,87 @@ fn init_command_bootstraps_a_workspace_that_validate_accepts() {
 
 #[test]
 // REQ-CORE-009
+fn init_command_bootstraps_language_templates_that_validate_accept() {
+    for (template, requirement_path, feature_path, requirement_id, feature_id) in [
+        (
+            "rust-only",
+            "docs/syu/requirements/core/rust.yaml",
+            "docs/syu/features/languages/rust.yaml",
+            "REQ-RUST-001",
+            "FEAT-RUST-001",
+        ),
+        (
+            "python-only",
+            "docs/syu/requirements/core/python.yaml",
+            "docs/syu/features/languages/python.yaml",
+            "REQ-PY-001",
+            "FEAT-PY-001",
+        ),
+        (
+            "polyglot",
+            "docs/syu/requirements/core/polyglot.yaml",
+            "docs/syu/features/languages/polyglot.yaml",
+            "REQ-MIX-001",
+            "FEAT-MIX-001",
+        ),
+    ] {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path().join(template);
+
+        let init = Command::cargo_bin("syu")
+            .expect("binary should build")
+            .arg("init")
+            .arg(&workspace)
+            .arg("--template")
+            .arg(template)
+            .output()
+            .expect("init should run");
+
+        assert!(
+            init.status.success(),
+            "template={template}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&init.stdout),
+            String::from_utf8_lossy(&init.stderr)
+        );
+        assert!(
+            workspace.join(requirement_path).exists(),
+            "missing {requirement_path}"
+        );
+        assert!(
+            workspace.join(feature_path).exists(),
+            "missing {feature_path}"
+        );
+
+        let requirement =
+            fs::read_to_string(workspace.join(requirement_path)).expect("requirement should exist");
+        let feature =
+            fs::read_to_string(workspace.join(feature_path)).expect("feature should exist");
+        assert!(
+            requirement.contains(requirement_id),
+            "missing {requirement_id}"
+        );
+        assert!(feature.contains(feature_id), "missing {feature_id}");
+        assert!(requirement.contains("status: planned"));
+        assert!(feature.contains("status: planned"));
+
+        let validate = Command::cargo_bin("syu")
+            .expect("binary should build")
+            .arg("validate")
+            .arg(&workspace)
+            .output()
+            .expect("validate should run");
+
+        assert!(
+            validate.status.success(),
+            "template={template}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&validate.stdout),
+            String::from_utf8_lossy(&validate.stderr)
+        );
+    }
+}
+
+#[test]
+// REQ-CORE-009
 fn init_command_requires_force_when_generated_files_exist() {
     let tempdir = tempdir().expect("tempdir should exist");
     fs::write(

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -234,6 +234,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("# 2. Add your spec items"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
+    assert!(readme.contains("--template rust-only"));
     assert!(readme.contains("syu validate"));
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
@@ -266,6 +267,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains(&format!(
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
     )));
+    assert!(getting_started.contains("--template rust-only"));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("syu list feature"));
@@ -285,6 +287,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/syu-report"));
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
+    assert!(getting_started.contains("examples/rust-only"));
+    assert!(getting_started.contains("examples/python-only"));
+    assert!(getting_started.contains("examples/polyglot"));
     assert_eq!(
         getting_started
             .matches("Follow the [end-to-end tutorial](./tutorial.md)")


### PR DESCRIPTION
## Summary
- add `syu init --template` with generic, rust-only, python-only, and polyglot layouts
- tailor starter IDs, file locations, and next-step guidance to the selected template
- document and trace the new bootstrap flow across tests and self-hosted spec

Closes #175