### PR TITLE
feat: add init id prefix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ Prefer another repository layout such as `docs/spec` or `spec/contracts`?
 Use `syu init . --spec-root docs/spec` to scaffold the same starter tree there
 and write the matching `spec.root` value into `syu.yaml`.
 
+Want stable project-specific starter IDs from the first commit? Seed a shared
+stem directly into the scaffold:
+
+```bash
+syu init . --id-prefix store
+```
+
+That renders `PHIL-STORE-001`, `POL-STORE-001`, `REQ-STORE-001`, and
+`FEAT-STORE-001`. If one layer should keep a different prefix, override it with
+`--philosophy-prefix`, `--policy-prefix`, `--requirement-prefix`, or
+`--feature-prefix`.
+
 Want a closer starting point for a repository that is already clearly
 Rust-first, Python-first, or polyglot? Start with a lightweight template:
 
@@ -159,13 +171,17 @@ Bootstrap a new workspace:
 ```bash
 syu init .
 syu init path/to/workspace --name my-project
+syu init . --id-prefix store
 syu init . --template rust-only
 syu init . --spec-root docs/spec
+syu init . --requirement-prefix REQ-STORE --feature-prefix FEAT-STORE
 ```
 
 Use `--force` to overwrite generated files. Use `--template` when you want the
 starter IDs, file layout, and scaffold copy to start closer to the repository
-style you already expect. Use `--spec-root` to scaffold into a
+style you already expect. Use `--id-prefix` when you want stable project-wide
+starter IDs from the first command, and the per-layer `--*-prefix` flags when a
+single shared stem is not enough. Use `--spec-root` to scaffold into a
 repository-relative spec tree without moving the generated files by hand later.
 
 ### `syu validate`

--- a/docs/generated/site-spec/features/cli/init.md
+++ b/docs/generated/site-spec/features/cli/init.md
@@ -82,6 +82,22 @@ description: "Generated reference for docs/syu/features/cli/init.yaml"
         - **symbols**:
           - InitArgs
           - StarterTemplate
+- **id**: FEAT-INIT-005
+  - **title**: Project-specific starter ID prefixes
+  - **summary**: Allow `syu init --id-prefix` to seed stable starter IDs across all four layers and support per-layer prefix overrides when one shared stem is not enough.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-009
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/init.rs
+        - **symbols**:
+          - run_init_command
+          - resolve_init_id_prefixes
+          - scaffold_files
+      - **file**: src/cli.rs
+        - **symbols**:
+          - InitArgs
 
 ## Source YAML
 
@@ -155,4 +171,20 @@ features:
           symbols:
             - InitArgs
             - StarterTemplate
+  - id: FEAT-INIT-005
+    title: Project-specific starter ID prefixes
+    summary: Allow `syu init --id-prefix` to seed stable starter IDs across all four layers and support per-layer prefix overrides when one shared stem is not enough.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - resolve_init_id_prefixes
+            - scaffold_files
+        - file: src/cli.rs
+          symbols:
+            - InitArgs
 ```

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -43,6 +43,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
           - workspace_help_uses_current_directory_default_consistently
           - init_help_lists_starter_templates
           - init_help_mentions_custom_spec_roots
+          - init_help_mentions_id_prefix_options
           - validate_help_lists_temporary_config_overrides
       - **file**: tests/repository_quality.rs
         - **symbols**:
@@ -104,6 +105,7 @@ requirements:
             - workspace_help_uses_current_directory_default_consistently
             - init_help_lists_starter_templates
             - init_help_mentions_custom_spec_roots
+            - init_help_mentions_id_prefix_options
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -31,7 +31,11 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       `spec.root` value into `syu.yaml`, and `syu init --template` MUST support
       small `rust-only`, `python-only`, and `polyglot` starter layouts so
       adopters can begin closer to their repository style without copying
-      example files by hand.
+      example files by hand. `syu init --id-prefix` MUST support seeding a
+      shared project-specific stem into the starter philosophy, policy,
+      requirement, and feature IDs, and the per-layer `--philosophy-prefix`,
+      `--policy-prefix`, `--requirement-prefix`, and `--feature-prefix` flags
+      MUST allow narrower overrides when one shared stem is not enough.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -42,6 +46,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - FEAT-INIT-002
     - FEAT-INIT-003
     - FEAT-INIT-004
+    - FEAT-INIT-005
   - **tests**:
     - **rust**:
       - **file**: tests/init_command.rs
@@ -185,7 +190,11 @@ requirements:
       `spec.root` value into `syu.yaml`, and `syu init --template` MUST support
       small `rust-only`, `python-only`, and `polyglot` starter layouts so
       adopters can begin closer to their repository style without copying
-      example files by hand.
+      example files by hand. `syu init --id-prefix` MUST support seeding a
+      shared project-specific stem into the starter philosophy, policy,
+      requirement, and feature IDs, and the per-layer `--philosophy-prefix`,
+      `--policy-prefix`, `--requirement-prefix`, and `--feature-prefix` flags
+      MUST allow narrower overrides when one shared stem is not enough.
     priority: high
     status: implemented
     linked_policies:
@@ -196,6 +205,7 @@ requirements:
       - FEAT-INIT-002
       - FEAT-INIT-003
       - FEAT-INIT-004
+      - FEAT-INIT-005
     tests:
       rust:
         - file: tests/init_command.rs

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 7
 - Requirements: 18
-- Features: 21
+- Features: 22
 
 ## Traceability
 
 - Requirement-to-test traceability: 59/59
-- Feature-to-implementation traceability: 81/81
+- Feature-to-implementation traceability: 83/83
 
 ## Issues
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -67,6 +67,12 @@ root directly:
 syu init . --spec-root docs/spec
 ```
 
+Need stable project-specific starter IDs from the first command?
+
+```bash
+syu init . --id-prefix store
+```
+
 Need a closer starting point for a repository that is already Rust-first,
 Python-first, or polyglot?
 
@@ -85,7 +91,11 @@ under `docs/syu/`; `--spec-root` writes the same scaffold into another
 repository-relative path and records that location in `syu.yaml`. `--template`
 keeps the same four layers but swaps the starter IDs, requirement/feature file
 names, and copy so the first edit looks more like the repository style you
-already expect.
+already expect. `--id-prefix` seeds a shared stem into all four starter IDs so
+the scaffold begins with `PHIL-STORE-001`, `POL-STORE-001`, `REQ-STORE-001`,
+and `FEAT-STORE-001` instead of the generic defaults. When one layer needs a
+different prefix, use `--philosophy-prefix`, `--policy-prefix`,
+`--requirement-prefix`, or `--feature-prefix`.
 
 Starter requirements and features begin as `status: planned`. Keep them planned
 until you are ready to declare real tests and implementation traces.

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -22,6 +22,13 @@ instead:
 syu init . --spec-root docs/spec
 ```
 
+If you already know the stable project stem you want to keep long-term, seed it
+into the starter IDs immediately:
+
+```bash
+syu init . --id-prefix store
+```
+
 For a repository that is already clearly Rust-first, Python-first, or
 polyglot, you can start from a closer scaffold instead:
 
@@ -57,6 +64,11 @@ spec:
 so you do not need to move the scaffold by hand after bootstrap. `--template`
 keeps the same four layers but may swap the starter IDs and the initial
 requirement/feature file names to better match the repository style.
+`--id-prefix` replaces the generic starter IDs with project-specific IDs such
+as `PHIL-STORE-001`, `POL-STORE-001`, `REQ-STORE-001`, and `FEAT-STORE-001`.
+If only one layer needs a different prefix, use the corresponding
+`--philosophy-prefix`, `--policy-prefix`, `--requirement-prefix`, or
+`--feature-prefix` flag instead.
 
 ---
 

--- a/docs/syu/features/cli/init.yaml
+++ b/docs/syu/features/cli/init.yaml
@@ -67,3 +67,19 @@ features:
           symbols:
             - InitArgs
             - StarterTemplate
+  - id: FEAT-INIT-005
+    title: Project-specific starter ID prefixes
+    summary: Allow `syu init --id-prefix` to seed stable starter IDs across all four layers and support per-layer prefix overrides when one shared stem is not enough.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-009
+    implementations:
+      rust:
+        - file: src/command/init.rs
+          symbols:
+            - run_init_command
+            - resolve_init_id_prefixes
+            - scaffold_files
+        - file: src/cli.rs
+          symbols:
+            - InitArgs

--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -26,6 +26,7 @@ requirements:
             - workspace_help_uses_current_directory_default_consistently
             - init_help_lists_starter_templates
             - init_help_mentions_custom_spec_roots
+            - init_help_mentions_id_prefix_options
             - validate_help_lists_temporary_config_overrides
         - file: tests/repository_quality.rs
           symbols:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -14,7 +14,11 @@ requirements:
       `spec.root` value into `syu.yaml`, and `syu init --template` MUST support
       small `rust-only`, `python-only`, and `polyglot` starter layouts so
       adopters can begin closer to their repository style without copying
-      example files by hand.
+      example files by hand. `syu init --id-prefix` MUST support seeding a
+      shared project-specific stem into the starter philosophy, policy,
+      requirement, and feature IDs, and the per-layer `--philosophy-prefix`,
+      `--policy-prefix`, `--requirement-prefix`, and `--feature-prefix` flags
+      MUST allow narrower overrides when one shared stem is not enough.
     priority: high
     status: implemented
     linked_policies:
@@ -25,6 +29,7 @@ requirements:
       - FEAT-INIT-002
       - FEAT-INIT-003
       - FEAT-INIT-004
+      - FEAT-INIT-005
     tests:
       rust:
         - file: tests/init_command.rs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 // FEAT-APP-001
 // FEAT-BROWSE-001
 // FEAT-BROWSE-002
+// FEAT-INIT-005
 // FEAT-INIT-004
 // FEAT-INIT-003
 // FEAT-LIST-002
@@ -28,9 +29,10 @@ const APP_AFTER_HELP: &str = concat!(
 const INIT_AFTER_HELP: &str = "\
 Examples:
   syu init .
+  syu init . --id-prefix store
   syu init . --template rust-only
   syu init . --spec-root docs/spec
-  syu init path/to/workspace --name my-project --spec-root spec/contracts --template polyglot";
+  syu init path/to/workspace --name my-project --spec-root spec/contracts --template polyglot --id-prefix store";
 
 const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
 
@@ -302,6 +304,28 @@ pub struct InitArgs {
     #[arg(long, value_enum, default_value_t = StarterTemplate::Generic)]
     pub template: StarterTemplate,
 
+    #[arg(
+        help = "Shared ID stem to render as PHIL-<stem>, POL-<stem>, REQ-<stem>, and FEAT-<stem>"
+    )]
+    #[arg(long, value_name = "STEM")]
+    pub id_prefix: Option<String>,
+
+    #[arg(help = "Override the philosophy ID prefix (for example PHIL-STORE)")]
+    #[arg(long, value_name = "PREFIX")]
+    pub philosophy_prefix: Option<String>,
+
+    #[arg(help = "Override the policy ID prefix (for example POL-STORE)")]
+    #[arg(long, value_name = "PREFIX")]
+    pub policy_prefix: Option<String>,
+
+    #[arg(help = "Override the requirement ID prefix (for example REQ-STORE)")]
+    #[arg(long, value_name = "PREFIX")]
+    pub requirement_prefix: Option<String>,
+
+    #[arg(help = "Override the feature ID prefix (for example FEAT-STORE)")]
+    #[arg(long, value_name = "PREFIX")]
+    pub feature_prefix: Option<String>,
+
     #[arg(help = "Overwrite generated files when they already exist")]
     #[arg(long)]
     pub force: bool,
@@ -430,5 +454,39 @@ mod tests {
         let rendered = format!("{cli:?}");
         assert!(rendered.contains("command: Some(Init("));
         assert!(rendered.contains("spec_root: Some(\"docs/spec\")"));
+    }
+
+    #[test]
+    fn init_args_accept_shared_id_prefix_stems() {
+        let cli = Cli::try_parse_from(["syu", "init", ".", "--id-prefix", "store"])
+            .expect("init args should parse");
+
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Init("));
+        assert!(rendered.contains("id_prefix: Some(\"store\")"));
+    }
+
+    #[test]
+    fn init_args_accept_individual_id_prefix_overrides() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "init",
+            ".",
+            "--philosophy-prefix",
+            "PHIL-STORE",
+            "--policy-prefix",
+            "POL-STORE",
+            "--requirement-prefix",
+            "REQ-STORE",
+            "--feature-prefix",
+            "FEAT-STORE",
+        ])
+        .expect("init args should parse");
+
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("philosophy_prefix: Some(\"PHIL-STORE\")"));
+        assert!(rendered.contains("policy_prefix: Some(\"POL-STORE\")"));
+        assert!(rendered.contains("requirement_prefix: Some(\"REQ-STORE\")"));
+        assert!(rendered.contains("feature_prefix: Some(\"FEAT-STORE\")"));
     }
 }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -523,8 +523,8 @@ mod tests {
             spec_root: None,
             template: StarterTemplate::RustOnly,
             id_prefix: Some("store".to_string()),
-            philosophy_prefix: None,
-            policy_prefix: None,
+            philosophy_prefix: Some("phil-guiding".to_string()),
+            policy_prefix: Some("pol-governance".to_string()),
             requirement_prefix: Some("req-auth".to_string()),
             feature_prefix: Some("feat-auth".to_string()),
             force: false,
@@ -532,8 +532,8 @@ mod tests {
         };
 
         let prefixes = resolve_init_id_prefixes(&args).expect("prefixes should resolve");
-        assert_eq!(prefixes.philosophy, "PHIL-STORE");
-        assert_eq!(prefixes.policy, "POL-STORE");
+        assert_eq!(prefixes.philosophy, "PHIL-GUIDING");
+        assert_eq!(prefixes.policy, "POL-GOVERNANCE");
         assert_eq!(prefixes.requirement, "REQ-AUTH");
         assert_eq!(prefixes.feature, "FEAT-AUTH");
     }
@@ -556,6 +556,52 @@ mod tests {
 
         let error = resolve_init_id_prefixes(&args).expect_err("typed stems should be rejected");
         assert!(error.to_string().contains("--id-prefix"));
+    }
+
+    #[test]
+    fn resolve_init_id_prefixes_rejects_typed_overrides_without_expected_prefix() {
+        let args = InitArgs {
+            workspace: std::path::PathBuf::from("."),
+            name: None,
+            spec_root: None,
+            template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: Some("store".to_string()),
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
+            force: false,
+            format: crate::cli::OutputFormat::Text,
+        };
+
+        let error =
+            resolve_init_id_prefixes(&args).expect_err("typed overrides should require a prefix");
+        let message = error.to_string();
+        assert!(message.contains("--philosophy-prefix"));
+        assert!(message.contains("PHIL"));
+    }
+
+    #[test]
+    fn resolve_init_id_prefixes_rejects_invalid_override_tokens() {
+        let args = InitArgs {
+            workspace: std::path::PathBuf::from("."),
+            name: None,
+            spec_root: None,
+            template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: Some("feat_store".to_string()),
+            force: false,
+            format: crate::cli::OutputFormat::Text,
+        };
+
+        let error = resolve_init_id_prefixes(&args)
+            .expect_err("invalid override tokens should be rejected");
+        let message = error.to_string();
+        assert!(message.contains("--feature-prefix"));
+        assert!(message.contains("single hyphens"));
     }
 
     #[test]

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,4 +1,5 @@
 // REQ-CORE-009
+// FEAT-INIT-005
 // FEAT-INIT-004
 // FEAT-INIT-003
 // FEAT-INIT-002
@@ -28,6 +29,32 @@ const GENERATED_PATHS: &[&str] = &[
     "docs/syu/features/core/core.yaml",
 ];
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StarterIdPrefixes {
+    philosophy: String,
+    policy: String,
+    requirement: String,
+    feature: String,
+}
+
+impl StarterIdPrefixes {
+    fn philosophy_id(&self) -> String {
+        format!("{}-001", self.philosophy)
+    }
+
+    fn policy_id(&self) -> String {
+        format!("{}-001", self.policy)
+    }
+
+    fn requirement_id(&self) -> String {
+        format!("{}-001", self.requirement)
+    }
+
+    fn feature_id(&self) -> String {
+        format!("{}-001", self.feature)
+    }
+}
+
 // FEAT-INIT-001
 pub fn run_init_command(args: &InitArgs) -> Result<i32> {
     let workspace = prepare_workspace_root(&args.workspace)?;
@@ -36,8 +63,9 @@ pub fn run_init_command(args: &InitArgs) -> Result<i32> {
         .clone()
         .unwrap_or_else(|| infer_project_name(&workspace));
     let spec_root = resolve_init_spec_root(args.spec_root.as_deref())?;
+    let id_prefixes = resolve_init_id_prefixes(args)?;
 
-    let files = scaffold_files(&project_name, &spec_root, args.template);
+    let files = scaffold_files(&project_name, &spec_root, args.template, &id_prefixes);
     ensure_writable_targets(
         &workspace,
         files.iter().map(|(path, _)| PathBuf::from(path)),
@@ -168,10 +196,111 @@ fn ensure_writable_targets(
     bail!("refusing to overwrite existing files without --force: {paths}");
 }
 
+fn resolve_init_id_prefixes(args: &InitArgs) -> Result<StarterIdPrefixes> {
+    let mut prefixes = if let Some(stem) = args.id_prefix.as_deref() {
+        let stem = normalize_shared_id_stem(stem)?;
+        StarterIdPrefixes {
+            philosophy: format!("PHIL-{stem}"),
+            policy: format!("POL-{stem}"),
+            requirement: format!("REQ-{stem}"),
+            feature: format!("FEAT-{stem}"),
+        }
+    } else {
+        default_id_prefixes(args.template)
+    };
+
+    if let Some(prefix) = args.philosophy_prefix.as_deref() {
+        prefixes.philosophy = normalize_typed_prefix(prefix, "PHIL", "--philosophy-prefix")?;
+    }
+    if let Some(prefix) = args.policy_prefix.as_deref() {
+        prefixes.policy = normalize_typed_prefix(prefix, "POL", "--policy-prefix")?;
+    }
+    if let Some(prefix) = args.requirement_prefix.as_deref() {
+        prefixes.requirement = normalize_typed_prefix(prefix, "REQ", "--requirement-prefix")?;
+    }
+    if let Some(prefix) = args.feature_prefix.as_deref() {
+        prefixes.feature = normalize_typed_prefix(prefix, "FEAT", "--feature-prefix")?;
+    }
+
+    Ok(prefixes)
+}
+
+fn default_id_prefixes(template: StarterTemplate) -> StarterIdPrefixes {
+    match template {
+        StarterTemplate::Generic => StarterIdPrefixes {
+            philosophy: "PHIL".to_string(),
+            policy: "POL".to_string(),
+            requirement: "REQ".to_string(),
+            feature: "FEAT".to_string(),
+        },
+        StarterTemplate::RustOnly => StarterIdPrefixes {
+            philosophy: "PHIL-RUST".to_string(),
+            policy: "POL-RUST".to_string(),
+            requirement: "REQ-RUST".to_string(),
+            feature: "FEAT-RUST".to_string(),
+        },
+        StarterTemplate::PythonOnly => StarterIdPrefixes {
+            philosophy: "PHIL-PY".to_string(),
+            policy: "POL-PY".to_string(),
+            requirement: "REQ-PY".to_string(),
+            feature: "FEAT-PY".to_string(),
+        },
+        StarterTemplate::Polyglot => StarterIdPrefixes {
+            philosophy: "PHIL-MIX".to_string(),
+            policy: "POL-MIX".to_string(),
+            requirement: "REQ-MIX".to_string(),
+            feature: "FEAT-MIX".to_string(),
+        },
+    }
+}
+
+fn normalize_shared_id_stem(raw: &str) -> Result<String> {
+    let normalized = normalize_id_token(raw, "--id-prefix")?;
+    if ["PHIL", "POL", "REQ", "FEAT"].contains(&normalized.as_str())
+        || ["PHIL-", "POL-", "REQ-", "FEAT-"]
+            .into_iter()
+            .any(|prefix| normalized.starts_with(prefix))
+    {
+        bail!(
+            "`--id-prefix` expects a shared stem like `STORE`, not a full typed prefix like `{}`",
+            raw.trim()
+        );
+    }
+    Ok(normalized)
+}
+
+fn normalize_typed_prefix(raw: &str, expected: &str, flag: &str) -> Result<String> {
+    let normalized = normalize_id_token(raw, flag)?;
+    if normalized == expected || normalized.starts_with(&format!("{expected}-")) {
+        return Ok(normalized);
+    }
+    bail!(
+        "{flag} must be `{expected}` or start with `{expected}-`: `{}`",
+        raw.trim()
+    );
+}
+
+fn normalize_id_token(raw: &str, flag: &str) -> Result<String> {
+    let normalized = raw.trim().to_ascii_uppercase();
+    if normalized.is_empty()
+        || normalized.split('-').any(|segment| segment.is_empty())
+        || !normalized
+            .chars()
+            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        bail!(
+            "{flag} must contain only ASCII letters, numbers, and single hyphens: `{}`",
+            raw.trim()
+        );
+    }
+    Ok(normalized)
+}
+
 fn scaffold_files(
     project_name: &str,
     spec_root: &Path,
     template: StarterTemplate,
+    id_prefixes: &StarterIdPrefixes,
 ) -> Vec<(String, String)> {
     vec![
         (
@@ -180,15 +309,15 @@ fn scaffold_files(
         ),
         (
             path_label(&spec_root.join("philosophy/foundation.yaml")),
-            philosophy_template(project_name, template),
+            philosophy_template(project_name, template, id_prefixes),
         ),
         (
             path_label(&spec_root.join("policies/policies.yaml")),
-            policy_template(project_name, template),
+            policy_template(project_name, template, id_prefixes),
         ),
         (
             path_label(&spec_root.join(requirement_document_path(template))),
-            requirement_template(project_name, template),
+            requirement_template(project_name, template, id_prefixes),
         ),
         (
             path_label(&spec_root.join("features/features.yaml")),
@@ -196,7 +325,7 @@ fn scaffold_files(
         ),
         (
             path_label(&spec_root.join(feature_document_path(template))),
-            feature_template(project_name, template),
+            feature_template(project_name, template, id_prefixes),
         ),
     ]
 }
@@ -207,53 +336,77 @@ fn render_default_config(spec_root: &Path) -> Result<String> {
     render_config(&config)
 }
 
-fn philosophy_template(project_name: &str, template: StarterTemplate) -> String {
+fn philosophy_template(
+    project_name: &str,
+    template: StarterTemplate,
+    id_prefixes: &StarterIdPrefixes,
+) -> String {
+    let philosophy_id = id_prefixes.philosophy_id();
+    let policy_id = id_prefixes.policy_id();
     match template {
         StarterTemplate::Generic => format!(
-            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: {project_name} should turn intent into executable agreements\n    product_design_principle: |\n      The project should keep philosophy, policy, requirements, and features\n      explicit enough that contributors can validate changes mechanically.\n    coding_guideline: |\n      Prefer stable IDs, typed data, and explicit traceability over conventions\n      that live only in contributor memory.\n    linked_policies:\n      - POL-001\n"
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should turn intent into executable agreements\n    product_design_principle: |\n      The project should keep philosophy, policy, requirements, and features\n      explicit enough that contributors can validate changes mechanically.\n    coding_guideline: |\n      Prefer stable IDs, typed data, and explicit traceability over conventions\n      that live only in contributor memory.\n    linked_policies:\n      - {policy_id}\n"
         ),
         StarterTemplate::RustOnly => format!(
-            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-RUST-001\n    title: {project_name} should keep Rust traces explicit\n    product_design_principle: |\n      The project should keep Rust-first traceability small, reviewable, and\n      obvious to contributors reading the code.\n    coding_guideline: |\n      Prefer stable IDs and Rust doc comments on traced symbols from the first\n      requirement onward.\n    linked_policies:\n      - POL-RUST-001\n"
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should keep Rust traces explicit\n    product_design_principle: |\n      The project should keep Rust-first traceability small, reviewable, and\n      obvious to contributors reading the code.\n    coding_guideline: |\n      Prefer stable IDs and Rust doc comments on traced symbols from the first\n      requirement onward.\n    linked_policies:\n      - {policy_id}\n"
         ),
         StarterTemplate::PythonOnly => format!(
-            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-PY-001\n    title: {project_name} should keep Python traces explicit\n    product_design_principle: |\n      The project should keep Python traceability small, reviewable, and easy\n      to understand from docstrings alone.\n    coding_guideline: |\n      Prefer stable IDs and clear docstrings on traced Python symbols from the\n      first requirement onward.\n    linked_policies:\n      - POL-PY-001\n"
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should keep Python traces explicit\n    product_design_principle: |\n      The project should keep Python traceability small, reviewable, and easy\n      to understand from docstrings alone.\n    coding_guideline: |\n      Prefer stable IDs and clear docstrings on traced Python symbols from the\n      first requirement onward.\n    linked_policies:\n      - {policy_id}\n"
         ),
         StarterTemplate::Polyglot => format!(
-            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-MIX-001\n    title: {project_name} should keep polyglot traces coherent\n    product_design_principle: |\n      The project should prove that one specification can stay understandable\n      even when implementation and tests span multiple languages.\n    coding_guideline: |\n      Prefer stable IDs and short language-native docs on every traced symbol.\n    linked_policies:\n      - POL-MIX-001\n"
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should keep polyglot traces coherent\n    product_design_principle: |\n      The project should prove that one specification can stay understandable\n      even when implementation and tests span multiple languages.\n    coding_guideline: |\n      Prefer stable IDs and short language-native docs on every traced symbol.\n    linked_policies:\n      - {policy_id}\n"
         ),
     }
 }
 
-fn policy_template(project_name: &str, template: StarterTemplate) -> String {
+fn policy_template(
+    project_name: &str,
+    template: StarterTemplate,
+    id_prefixes: &StarterIdPrefixes,
+) -> String {
+    let philosophy_id = id_prefixes.philosophy_id();
+    let policy_id = id_prefixes.policy_id();
+    let requirement_id = id_prefixes.requirement_id();
     match template {
         StarterTemplate::Generic => format!(
-            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Every change in {project_name} should remain traceable\n    summary: Define rules that turn philosophy into a verifiable workflow.\n    description: |\n      A specification entry is only useful when contributors can trace it to\n      concrete requirements, features, code, and tests inside the repository.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n"
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Every change in {project_name} should remain traceable\n    summary: Define rules that turn philosophy into a verifiable workflow.\n    description: |\n      A specification entry is only useful when contributors can trace it to\n      concrete requirements, features, code, and tests inside the repository.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
         ),
         StarterTemplate::RustOnly => format!(
-            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-RUST-001\n    title: Rust requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Rust-first workflow that stays explicit in code review.\n    description: |\n      Rust requirement and feature traces should point to symbols whose doc\n      comments carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - PHIL-RUST-001\n    linked_requirements:\n      - REQ-RUST-001\n"
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Rust requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Rust-first workflow that stays explicit in code review.\n    description: |\n      Rust requirement and feature traces should point to symbols whose doc\n      comments carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
         ),
         StarterTemplate::PythonOnly => format!(
-            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-PY-001\n    title: Python requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Python-first workflow that stays explicit in docstrings.\n    description: |\n      Python requirement and feature traces should point to symbols whose\n      docstrings carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - PHIL-PY-001\n    linked_requirements:\n      - REQ-PY-001\n"
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Python requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Python-first workflow that stays explicit in docstrings.\n    description: |\n      Python requirement and feature traces should point to symbols whose\n      docstrings carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
         ),
         StarterTemplate::Polyglot => format!(
-            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-MIX-001\n    title: Polyglot requirement and feature traces must stay verifiable in {project_name}\n    summary: Start with one specification flow that can grow across languages.\n    description: |\n      The starter workspace should make it obvious how one requirement and one\n      feature can stay linked even when implementation later spans Rust,\n      Python, and TypeScript.\n    linked_philosophies:\n      - PHIL-MIX-001\n    linked_requirements:\n      - REQ-MIX-001\n"
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Polyglot requirement and feature traces must stay verifiable in {project_name}\n    summary: Start with one specification flow that can grow across languages.\n    description: |\n      The starter workspace should make it obvious how one requirement and one\n      feature can stay linked even when implementation later spans Rust,\n      Python, and TypeScript.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
         ),
     }
 }
 
-fn requirement_template(project_name: &str, template: StarterTemplate) -> String {
+fn requirement_template(
+    project_name: &str,
+    template: StarterTemplate,
+    id_prefixes: &StarterIdPrefixes,
+) -> String {
+    let requirement_id = id_prefixes.requirement_id();
+    let policy_id = id_prefixes.policy_id();
+    let feature_id = id_prefixes.feature_id();
     match template {
         StarterTemplate::Generic => format!(
-            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Bootstrap {project_name} with a four-layer specification\n    description: |\n      The project should keep philosophy, policy, requirements, and features in\n      YAML so contributors can evolve behavior deliberately.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests: {{}}\n"
+            "category: Core Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Bootstrap {project_name} with a four-layer specification\n    description: |\n      The project should keep philosophy, policy, requirements, and features in\n      YAML so contributors can evolve behavior deliberately.\n    priority: high\n    status: planned\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests: {{}}\n",
+            id_prefixes.requirement
         ),
         StarterTemplate::RustOnly => format!(
-            "category: Rust Requirements\nprefix: REQ-RUST\n\nrequirements:\n  - id: REQ-RUST-001\n    title: Bootstrap {project_name} with Rust-first trace conventions\n    description: |\n      The project should start with a Rust-oriented requirement that can later\n      claim documented Rust test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-RUST-001\n    linked_features:\n      - FEAT-RUST-001\n    tests: {{}}\n"
+            "category: Rust Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Bootstrap {project_name} with Rust-first trace conventions\n    description: |\n      The project should start with a Rust-oriented requirement that can later\n      claim documented Rust test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests: {{}}\n",
+            id_prefixes.requirement
         ),
         StarterTemplate::PythonOnly => format!(
-            "category: Python Requirements\nprefix: REQ-PY\n\nrequirements:\n  - id: REQ-PY-001\n    title: Bootstrap {project_name} with Python-first trace conventions\n    description: |\n      The project should start with a Python-oriented requirement that can later\n      claim documented Python test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-PY-001\n    linked_features:\n      - FEAT-PY-001\n    tests: {{}}\n"
+            "category: Python Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Bootstrap {project_name} with Python-first trace conventions\n    description: |\n      The project should start with a Python-oriented requirement that can later\n      claim documented Python test symbols without restructuring the workspace.\n    priority: high\n    status: planned\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests: {{}}\n",
+            id_prefixes.requirement
         ),
         StarterTemplate::Polyglot => format!(
-            "category: Polyglot Requirements\nprefix: REQ-MIX\n\nrequirements:\n  - id: REQ-MIX-001\n    title: Bootstrap {project_name} with polyglot trace conventions\n    description: |\n      The project should start with one requirement that can later trace into\n      Rust, Python, and TypeScript without changing the layered layout.\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-MIX-001\n    linked_features:\n      - FEAT-MIX-001\n    tests: {{}}\n"
+            "category: Polyglot Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Bootstrap {project_name} with polyglot trace conventions\n    description: |\n      The project should start with one requirement that can later trace into\n      Rust, Python, and TypeScript without changing the layered layout.\n    priority: high\n    status: planned\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests: {{}}\n",
+            id_prefixes.requirement
         ),
     }
 }
@@ -270,19 +423,25 @@ fn feature_registry_template(template: StarterTemplate) -> String {
     )
 }
 
-fn feature_template(project_name: &str, template: StarterTemplate) -> String {
+fn feature_template(
+    project_name: &str,
+    template: StarterTemplate,
+    id_prefixes: &StarterIdPrefixes,
+) -> String {
+    let feature_id = id_prefixes.feature_id();
+    let requirement_id = id_prefixes.requirement_id();
     match template {
         StarterTemplate::Generic => format!(
-            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Bootstrap the {project_name} spec workspace\n    summary: Provide a starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-001\n    implementations: {{}}\n"
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} spec workspace\n    summary: Provide a starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
         ),
         StarterTemplate::RustOnly => format!(
-            "category: Rust Features\nversion: 1\n\nfeatures:\n  - id: FEAT-RUST-001\n    title: Bootstrap the {project_name} Rust spec workspace\n    summary: Provide a Rust-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-RUST-001\n    implementations: {{}}\n"
+            "category: Rust Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} Rust spec workspace\n    summary: Provide a Rust-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
         ),
         StarterTemplate::PythonOnly => format!(
-            "category: Python Features\nversion: 1\n\nfeatures:\n  - id: FEAT-PY-001\n    title: Bootstrap the {project_name} Python spec workspace\n    summary: Provide a Python-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - REQ-PY-001\n    implementations: {{}}\n"
+            "category: Python Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} Python spec workspace\n    summary: Provide a Python-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
         ),
         StarterTemplate::Polyglot => format!(
-            "category: Polyglot Features\nversion: 1\n\nfeatures:\n  - id: FEAT-MIX-001\n    title: Bootstrap the {project_name} polyglot spec workspace\n    summary: Provide a starter structure that can grow across Rust, Python, and TypeScript.\n    status: planned\n    linked_requirements:\n      - REQ-MIX-001\n    implementations: {{}}\n"
+            "category: Polyglot Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} polyglot spec workspace\n    summary: Provide a starter structure that can grow across Rust, Python, and TypeScript.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
         ),
     }
 }
@@ -327,9 +486,10 @@ mod tests {
     use crate::cli::{InitArgs, StarterTemplate};
 
     use super::{
-        DEFAULT_SPEC_ROOT, GENERATED_PATHS, ensure_writable_targets, feature_document_path,
-        feature_kind, infer_project_name, path_label, requirement_document_path,
-        resolve_init_spec_root, run_init_command, scaffold_files,
+        DEFAULT_SPEC_ROOT, GENERATED_PATHS, default_id_prefixes, ensure_writable_targets,
+        feature_document_path, feature_kind, infer_project_name, path_label,
+        requirement_document_path, resolve_init_id_prefixes, resolve_init_spec_root,
+        run_init_command, scaffold_files,
     };
 
     #[test]
@@ -346,12 +506,56 @@ mod tests {
             "demo",
             std::path::Path::new(DEFAULT_SPEC_ROOT),
             StarterTemplate::Generic,
+            &default_id_prefixes(StarterTemplate::Generic),
         );
         let paths: Vec<_> = files.into_iter().map(|(path, _)| path).collect();
         assert_eq!(paths.len(), GENERATED_PATHS.len());
         for expected in GENERATED_PATHS {
             assert!(paths.iter().any(|path| path == expected));
         }
+    }
+
+    #[test]
+    fn resolve_init_id_prefixes_accepts_shared_stems_and_overrides() {
+        let args = InitArgs {
+            workspace: std::path::PathBuf::from("."),
+            name: None,
+            spec_root: None,
+            template: StarterTemplate::RustOnly,
+            id_prefix: Some("store".to_string()),
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: Some("req-auth".to_string()),
+            feature_prefix: Some("feat-auth".to_string()),
+            force: false,
+            format: crate::cli::OutputFormat::Text,
+        };
+
+        let prefixes = resolve_init_id_prefixes(&args).expect("prefixes should resolve");
+        assert_eq!(prefixes.philosophy, "PHIL-STORE");
+        assert_eq!(prefixes.policy, "POL-STORE");
+        assert_eq!(prefixes.requirement, "REQ-AUTH");
+        assert_eq!(prefixes.feature, "FEAT-AUTH");
+    }
+
+    #[test]
+    fn resolve_init_id_prefixes_rejects_full_prefixes_as_shared_stems() {
+        let args = InitArgs {
+            workspace: std::path::PathBuf::from("."),
+            name: None,
+            spec_root: None,
+            template: StarterTemplate::Generic,
+            id_prefix: Some("REQ-STORE".to_string()),
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
+            force: false,
+            format: crate::cli::OutputFormat::Text,
+        };
+
+        let error = resolve_init_id_prefixes(&args).expect_err("typed stems should be rejected");
+        assert!(error.to_string().contains("--id-prefix"));
     }
 
     #[test]
@@ -378,6 +582,11 @@ mod tests {
             name: Some("demo".to_string()),
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         };
@@ -404,6 +613,11 @@ mod tests {
             name: Some("forced".to_string()),
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: true,
             format: crate::cli::OutputFormat::Text,
         };
@@ -422,6 +636,7 @@ mod tests {
             "demo",
             std::path::Path::new(DEFAULT_SPEC_ROOT),
             StarterTemplate::Generic,
+            &default_id_prefixes(StarterTemplate::Generic),
         );
         let requirement = files
             .iter()
@@ -447,6 +662,11 @@ mod tests {
             name: None,
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -470,6 +690,11 @@ mod tests {
             name: Some("demo".to_string()),
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: false,
             format: crate::cli::OutputFormat::Text,
         })
@@ -490,6 +715,11 @@ mod tests {
             name: Some("demo".to_string()),
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: true,
             format: crate::cli::OutputFormat::Text,
         })
@@ -507,6 +737,11 @@ mod tests {
             name: Some("demo".to_string()),
             spec_root: None,
             template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
             force: false,
             format: crate::cli::OutputFormat::Json,
         };
@@ -530,7 +765,7 @@ mod tests {
             StarterTemplate::PythonOnly,
             StarterTemplate::Polyglot,
         ] {
-            let files = scaffold_files("demo", spec_root, template);
+            let files = scaffold_files("demo", spec_root, template, &default_id_prefixes(template));
             let paths: Vec<_> = files.iter().map(|(path, _)| path.as_str()).collect();
             assert!(paths.contains(&"syu.yaml"));
             assert!(paths.contains(&"docs/syu/philosophy/foundation.yaml"));
@@ -551,7 +786,12 @@ mod tests {
     #[test]
     fn scaffold_files_support_language_templates_in_custom_spec_roots() {
         let spec_root = std::path::Path::new("spec/contracts");
-        let files = scaffold_files("demo", spec_root, StarterTemplate::RustOnly);
+        let files = scaffold_files(
+            "demo",
+            spec_root,
+            StarterTemplate::RustOnly,
+            &default_id_prefixes(StarterTemplate::RustOnly),
+        );
         let paths: Vec<_> = files.iter().map(|(path, _)| path.as_str()).collect();
 
         assert!(paths.contains(&"spec/contracts/philosophy/foundation.yaml"));

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -85,6 +85,23 @@ fn init_help_mentions_custom_spec_roots() {
 }
 
 #[test]
+fn init_help_mentions_id_prefix_options() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["init", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "init help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--id-prefix"));
+    assert!(stdout.contains("--requirement-prefix"));
+    assert!(stdout.contains("PHIL-<stem>"));
+    assert!(stdout.contains("REQ-<stem>"));
+}
+
+#[test]
 fn validate_help_lists_temporary_config_overrides() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -265,6 +265,135 @@ fn init_command_combines_custom_spec_roots_with_language_templates() {
 
 #[test]
 // REQ-CORE-009
+fn init_command_bootstraps_project_specific_id_prefixes_that_validate_accept() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .arg("--id-prefix")
+        .arg("store")
+        .output()
+        .expect("init should run");
+
+    assert!(
+        init.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let philosophy = fs::read_to_string(workspace.join("docs/syu/philosophy/foundation.yaml"))
+        .expect("philosophy should exist");
+    let policy = fs::read_to_string(workspace.join("docs/syu/policies/policies.yaml"))
+        .expect("policy should exist");
+    let requirement = fs::read_to_string(workspace.join("docs/syu/requirements/core/core.yaml"))
+        .expect("requirement should exist");
+    let feature = fs::read_to_string(workspace.join("docs/syu/features/core/core.yaml"))
+        .expect("feature should exist");
+
+    assert!(philosophy.contains("id: PHIL-STORE-001"));
+    assert!(policy.contains("id: POL-STORE-001"));
+    assert!(requirement.contains("prefix: REQ-STORE"));
+    assert!(requirement.contains("id: REQ-STORE-001"));
+    assert!(feature.contains("id: FEAT-STORE-001"));
+
+    let validate = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(&workspace)
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        validate.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+}
+
+#[test]
+// REQ-CORE-009
+fn init_command_allows_layer_specific_id_prefix_overrides() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .arg("--template")
+        .arg("rust-only")
+        .arg("--id-prefix")
+        .arg("store")
+        .arg("--requirement-prefix")
+        .arg("req-auth")
+        .arg("--feature-prefix")
+        .arg("feat-auth")
+        .output()
+        .expect("init should run");
+
+    assert!(
+        init.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let philosophy = fs::read_to_string(workspace.join("docs/syu/philosophy/foundation.yaml"))
+        .expect("philosophy should exist");
+    let requirement = fs::read_to_string(workspace.join("docs/syu/requirements/core/rust.yaml"))
+        .expect("requirement should exist");
+    let feature = fs::read_to_string(workspace.join("docs/syu/features/languages/rust.yaml"))
+        .expect("feature should exist");
+
+    assert!(philosophy.contains("id: PHIL-STORE-001"));
+    assert!(requirement.contains("prefix: REQ-AUTH"));
+    assert!(requirement.contains("id: REQ-AUTH-001"));
+    assert!(feature.contains("id: FEAT-AUTH-001"));
+
+    let validate = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(&workspace)
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        validate.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+}
+
+#[test]
+// REQ-CORE-009
+fn init_command_rejects_full_prefixes_as_shared_stems() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("demo");
+
+    let init = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("init")
+        .arg(&workspace)
+        .arg("--id-prefix")
+        .arg("REQ-STORE")
+        .output()
+        .expect("init should run");
+
+    assert!(
+        !init.status.success(),
+        "init should reject full typed stems"
+    );
+    assert!(String::from_utf8_lossy(&init.stderr).contains("--id-prefix"));
+}
+
+#[test]
+// REQ-CORE-009
 fn init_command_requires_force_when_generated_files_exist() {
     let tempdir = tempdir().expect("tempdir should exist");
     fs::write(

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -329,6 +329,10 @@ fn init_command_allows_layer_specific_id_prefix_overrides() {
         .arg("rust-only")
         .arg("--id-prefix")
         .arg("store")
+        .arg("--philosophy-prefix")
+        .arg("phil-guiding")
+        .arg("--policy-prefix")
+        .arg("pol-governance")
         .arg("--requirement-prefix")
         .arg("req-auth")
         .arg("--feature-prefix")
@@ -345,12 +349,16 @@ fn init_command_allows_layer_specific_id_prefix_overrides() {
 
     let philosophy = fs::read_to_string(workspace.join("docs/syu/philosophy/foundation.yaml"))
         .expect("philosophy should exist");
+    let policy = fs::read_to_string(workspace.join("docs/syu/policies/policies.yaml"))
+        .expect("policy should exist");
     let requirement = fs::read_to_string(workspace.join("docs/syu/requirements/core/rust.yaml"))
         .expect("requirement should exist");
     let feature = fs::read_to_string(workspace.join("docs/syu/features/languages/rust.yaml"))
         .expect("feature should exist");
 
-    assert!(philosophy.contains("id: PHIL-STORE-001"));
+    assert!(philosophy.contains("id: PHIL-GUIDING-001"));
+    assert!(philosophy.contains("linked_policies:\n      - POL-GOVERNANCE-001"));
+    assert!(policy.contains("id: POL-GOVERNANCE-001"));
     assert!(requirement.contains("prefix: REQ-AUTH"));
     assert!(requirement.contains("id: REQ-AUTH-001"));
     assert!(feature.contains("id: FEAT-AUTH-001"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -234,6 +234,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("# 2. Add your spec items"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
+    assert!(readme.contains("--id-prefix"));
     assert!(readme.contains("--template rust-only"));
     assert!(readme.contains("syu validate"));
     assert!(readme.contains("syu browse"));
@@ -269,6 +270,7 @@ fn repository_declares_documentation_guides() {
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
     )));
     assert!(getting_started.contains("--template rust-only"));
+    assert!(getting_started.contains("--id-prefix"));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("syu list feature"));


### PR DESCRIPTION
## Summary
- add `syu init --id-prefix` plus per-layer `--*-prefix` overrides for starter IDs
- update init scaffolding, CLI help, docs, and self-hosted spec coverage
- add CLI and integration tests for shared stems, per-layer overrides, and validation

## Validation
- cargo test
- scripts/ci/quality-gates.sh

Closes #174
