### PR TITLE
Add terminal-first syu search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ syu validate . --fix
 syu browse .
 syu list requirement
 syu show REQ-001
+syu search traceability --kind requirement
 syu app .
 syu report . --output reports/syu.md
 ```
@@ -236,6 +237,16 @@ Show one definition by ID:
 ```bash
 syu show REQ-001
 syu show FEAT-BROWSE-001 path/to/workspace --format json
+```
+
+### `syu search`
+
+Search definitions by ID, title, summary, or description:
+
+```bash
+syu search audit
+syu search traceability --kind requirement
+syu search FEAT-CHECK-001 --format json
 ```
 
 ### `syu app`

--- a/docs/generated/site-spec/features/cli/search.md
+++ b/docs/generated/site-spec/features/cli/search.md
@@ -1,0 +1,66 @@
+---
+title: "Lookup Search CLI / Search"
+description: "Generated reference for docs/syu/features/cli/search.yaml"
+---
+
+> Generated from `docs/syu/features/cli/search.yaml`.
+
+## Parsed content
+
+### Category
+
+- Lookup Search CLI
+
+### Version
+
+- 1
+
+### Features
+
+- **id**: FEAT-SEARCH-001
+  - **title**: Terminal-first definition search
+  - **summary**: Match spec items by ID, title, summary, or description from the CLI with optional kind scoping and JSON output.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-019
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/search.rs
+        - **symbols**:
+          - run_search_command
+      - **file**: src/command/lookup.rs
+        - **symbols**:
+          - search
+          - extend_search_results
+          - field_matches_query
+      - **file**: src/cli.rs
+        - **symbols**:
+          - SearchArgs
+
+## Source YAML
+
+```yaml
+category: Lookup Search CLI
+version: 1
+
+features:
+  - id: FEAT-SEARCH-001
+    title: Terminal-first definition search
+    summary: Match spec items by ID, title, summary, or description from the CLI with optional kind scoping and JSON output.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-019
+    implementations:
+      rust:
+        - file: src/command/search.rs
+          symbols:
+            - run_search_command
+        - file: src/command/lookup.rs
+          symbols:
+            - search
+            - extend_search_results
+            - field_matches_query
+        - file: src/cli.rs
+          symbols:
+            - SearchArgs
+```

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -13,7 +13,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ### Updated
 
-- 2026-03
+- 2026-04
 
 ### Files
 
@@ -23,6 +23,8 @@ description: "Generated reference for docs/syu/features/features.yaml"
   - **file**: cli/browse.yaml
 - **kind**: show-list
   - **file**: cli/show-list.yaml
+- **kind**: search
+  - **file**: cli/search.yaml
 - **kind**: check
   - **file**: cli/check.yaml
 - **kind**: init
@@ -46,7 +48,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ```yaml
 version: "0.0.1-alpha.7"
-updated: "2026-03"
+updated: "2026-04"
 
 files:
   - kind: app
@@ -55,6 +57,8 @@ files:
     file: cli/browse.yaml
   - kind: show-list
     file: cli/show-list.yaml
+  - kind: search
+    file: cli/search.yaml
   - kind: check
     file: cli/check.yaml
   - kind: init

--- a/docs/generated/site-spec/index.md
+++ b/docs/generated/site-spec/index.md
@@ -18,6 +18,7 @@ This section is generated from the YAML source under `docs/syu/`.
 - [Validate Command / Check](/docs/generated/site-spec/features/cli/check)
 - [Init Command / Init](/docs/generated/site-spec/features/cli/init)
 - [Report Command / Report](/docs/generated/site-spec/features/cli/report)
+- [Lookup Search CLI / Search](/docs/generated/site-spec/features/cli/search)
 - [Lookup CLI / Show List](/docs/generated/site-spec/features/cli/show-list)
 - [Documentation / Docs](/docs/generated/site-spec/features/documentation/docs)
 - [Agent Skills / Skills](/docs/generated/site-spec/features/documentation/skills)

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -38,6 +38,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-009
     - REQ-CORE-015
     - REQ-CORE-018
+    - REQ-CORE-019
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -57,6 +58,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-015
     - REQ-CORE-017
     - REQ-CORE-018
+    - REQ-CORE-019
 - **id**: POL-003
   - **title**: Traceability should prove ownership from specification to code and tests
   - **summary**: Declared traces should map to real files, real symbols, and optional full-file ownership.
@@ -91,6 +93,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-015
     - REQ-CORE-017
     - REQ-CORE-018
+    - REQ-CORE-019
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -170,6 +173,7 @@ policies:
       - REQ-CORE-009
       - REQ-CORE-015
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -189,6 +193,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -223,6 +228,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -170,6 +170,43 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: src/command/lookup.rs
         - **symbols**:
           - *
+- **id**: REQ-CORE-019
+  - **title**: Provide a terminal-first search CLI command
+  - **description**:
+    - |
+      The CLI MUST provide a lightweight `search` command that matches
+      philosophies, policies, requirements, and features by ID, title, summary,
+      or description without requiring the browser app. The command SHOULD
+      support optional kind scoping, SHOULD offer JSON output for automation,
+      and SHOULD continue working when validation issues exist so long as the
+      workspace itself still loads.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-002
+    - POL-004
+  - **linked_features**:
+    - FEAT-SEARCH-001
+  - **tests**:
+    - **rust**:
+      - **file**: tests/search_command.rs
+        - **symbols**:
+          - *
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - search_help_mentions_kind_scoping_and_json_output
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatches_search_subcommands_without_rewriting_them
+      - **file**: src/command/search.rs
+        - **symbols**:
+          - *
+      - **file**: src/command/lookup.rs
+        - **symbols**:
+          - search
+          - extend_search_results
+          - field_matches_query
 
 ## Source YAML
 
@@ -326,4 +363,40 @@ requirements:
         - file: src/command/lookup.rs
           symbols:
             - '*'
+  - id: REQ-CORE-019
+    title: Provide a terminal-first search CLI command
+    description: |
+      The CLI MUST provide a lightweight `search` command that matches
+      philosophies, policies, requirements, and features by ID, title, summary,
+      or description without requiring the browser app. The command SHOULD
+      support optional kind scoping, SHOULD offer JSON output for automation,
+      and SHOULD continue working when validation issues exist so long as the
+      workspace itself still loads.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-SEARCH-001
+    tests:
+      rust:
+        - file: tests/search_command.rs
+          symbols:
+            - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - search_help_mentions_kind_scoping_and_json_output
+        - file: src/lib.rs
+          symbols:
+            - dispatches_search_subcommands_without_rewriting_them
+        - file: src/command/search.rs
+          symbols:
+            - '*'
+        - file: src/command/lookup.rs
+          symbols:
+            - search
+            - extend_search_results
+            - field_matches_query
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 7
-- Requirements: 18
-- Features: 22
+- Requirements: 19
+- Features: 23
 
 ## Traceability
 
-- Requirement-to-test traceability: 59/59
-- Feature-to-implementation traceability: 83/83
+- Requirement-to-test traceability: 64/64
+- Feature-to-implementation traceability: 86/86
 
 ## Issues
 

--- a/docs/syu/features/cli/search.yaml
+++ b/docs/syu/features/cli/search.yaml
@@ -1,0 +1,23 @@
+category: Lookup Search CLI
+version: 1
+
+features:
+  - id: FEAT-SEARCH-001
+    title: Terminal-first definition search
+    summary: Match spec items by ID, title, summary, or description from the CLI with optional kind scoping and JSON output.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-019
+    implementations:
+      rust:
+        - file: src/command/search.rs
+          symbols:
+            - run_search_command
+        - file: src/command/lookup.rs
+          symbols:
+            - search
+            - extend_search_results
+            - field_matches_query
+        - file: src/cli.rs
+          symbols:
+            - SearchArgs

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -1,5 +1,5 @@
 version: "0.0.1-alpha.7"
-updated: "2026-03"
+updated: "2026-04"
 
 files:
   - kind: app
@@ -8,6 +8,8 @@ files:
     file: cli/browse.yaml
   - kind: show-list
     file: cli/show-list.yaml
+  - kind: search
+    file: cli/search.yaml
   - kind: check
     file: cli/check.yaml
   - kind: init

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -19,6 +19,7 @@ policies:
       - REQ-CORE-009
       - REQ-CORE-015
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -38,6 +39,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -72,6 +74,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-019
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -150,3 +150,39 @@ requirements:
         - file: src/command/lookup.rs
           symbols:
             - '*'
+  - id: REQ-CORE-019
+    title: Provide a terminal-first search CLI command
+    description: |
+      The CLI MUST provide a lightweight `search` command that matches
+      philosophies, policies, requirements, and features by ID, title, summary,
+      or description without requiring the browser app. The command SHOULD
+      support optional kind scoping, SHOULD offer JSON output for automation,
+      and SHOULD continue working when validation issues exist so long as the
+      workspace itself still loads.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-SEARCH-001
+    tests:
+      rust:
+        - file: tests/search_command.rs
+          symbols:
+            - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - search_help_mentions_kind_scoping_and_json_output
+        - file: src/lib.rs
+          symbols:
+            - dispatches_search_subcommands_without_rewriting_them
+        - file: src/command/search.rs
+          symbols:
+            - '*'
+        - file: src/command/lookup.rs
+          symbols:
+            - search
+            - extend_search_results
+            - field_matches_query

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 // FEAT-DOCS-001
 // FEAT-APP-001
+// FEAT-SEARCH-001
 // FEAT-BROWSE-001
 // FEAT-BROWSE-002
 // FEAT-INIT-005
@@ -44,6 +45,12 @@ Examples:
   syu list requirement docs/syu
   syu list docs/syu requirement";
 
+const SEARCH_AFTER_HELP: &str = "\
+Examples:
+  syu search audit
+  syu search traceability --kind requirement
+  syu search FEAT-CHECK-001 --format json";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "syu",
@@ -71,6 +78,11 @@ pub enum Commands {
     List(ListArgs),
     #[command(about = "Show one philosophy, policy, requirement, or feature by ID")]
     Show(ShowArgs),
+    #[command(
+        about = "Search spec items by ID, title, summary, or description",
+        after_help = SEARCH_AFTER_HELP
+    )]
+    Search(SearchArgs),
     #[command(
         about = "Start a local HTTP server and browser UI for workspace exploration, then print the URL to open in your browser",
         after_help = APP_AFTER_HELP
@@ -165,6 +177,26 @@ pub struct ShowArgs {
     pub workspace: PathBuf,
 
     #[arg(help = "Output format for the selected item")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct SearchArgs {
+    #[arg(
+        help = "Case-insensitive search query matched against IDs, titles, summaries, and descriptions"
+    )]
+    pub query: String,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Limit matches to one layer kind")]
+    #[arg(long, value_enum)]
+    pub kind: Option<LookupKind>,
+
+    #[arg(help = "Output format for matched items")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
 }
@@ -454,6 +486,28 @@ mod tests {
         let rendered = format!("{cli:?}");
         assert!(rendered.contains("command: Some(Init("));
         assert!(rendered.contains("spec_root: Some(\"docs/spec\")"));
+    }
+
+    #[test]
+    fn search_args_accept_kind_filters_and_json_output() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "search",
+            "traceability",
+            ".",
+            "--kind",
+            "feature",
+            "--format",
+            "json",
+        ])
+        .expect("search args should parse");
+
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Search("));
+        assert!(rendered.contains("query: \"traceability\""));
+        assert!(rendered.contains("workspace: \".\""));
+        assert!(rendered.contains("kind: Some(Feature)"));
+        assert!(rendered.contains("format: Json"));
     }
 
     #[test]

--- a/src/command/lookup.rs
+++ b/src/command/lookup.rs
@@ -1,3 +1,5 @@
+// FEAT-SEARCH-001
+// REQ-CORE-019
 // REQ-CORE-018
 
 use std::path::Path;
@@ -21,6 +23,13 @@ pub(crate) struct EntitySummary {
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub document_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct SearchResult {
+    pub id: String,
+    pub kind: &'static str,
+    pub title: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -158,6 +167,27 @@ impl<'a> WorkspaceLookup<'a> {
         None
     }
 
+    pub(crate) fn search(self, query: &str, kind: Option<LookupKind>) -> Vec<SearchResult> {
+        let query = query.trim().to_lowercase();
+        let mut results = Vec::new();
+
+        match kind {
+            Some(kind) => self.extend_search_results(kind, &query, &mut results),
+            None => {
+                for kind in [
+                    LookupKind::Philosophy,
+                    LookupKind::Policy,
+                    LookupKind::Feature,
+                    LookupKind::Requirement,
+                ] {
+                    self.extend_search_results(kind, &query, &mut results);
+                }
+            }
+        }
+
+        results
+    }
+
     fn document_paths(self, kind: LookupKind) -> Result<Vec<String>> {
         match kind {
             LookupKind::Philosophy => Ok(load_philosophy_documents_with_paths(
@@ -214,6 +244,67 @@ impl<'a> WorkspaceLookup<'a> {
             .collect()),
         }
     }
+
+    fn extend_search_results(self, kind: LookupKind, query: &str, results: &mut Vec<SearchResult>) {
+        match kind {
+            LookupKind::Philosophy => {
+                for item in &self.workspace.philosophies {
+                    if field_matches_query(&item.id, query)
+                        || field_matches_query(&item.title, query)
+                    {
+                        results.push(SearchResult {
+                            id: item.id.clone(),
+                            kind: kind.label(),
+                            title: item.title.clone(),
+                        });
+                    }
+                }
+            }
+            LookupKind::Policy => {
+                for item in &self.workspace.policies {
+                    if field_matches_query(&item.id, query)
+                        || field_matches_query(&item.title, query)
+                        || field_matches_query(&item.summary, query)
+                        || field_matches_query(&item.description, query)
+                    {
+                        results.push(SearchResult {
+                            id: item.id.clone(),
+                            kind: kind.label(),
+                            title: item.title.clone(),
+                        });
+                    }
+                }
+            }
+            LookupKind::Requirement => {
+                for item in &self.workspace.requirements {
+                    if field_matches_query(&item.id, query)
+                        || field_matches_query(&item.title, query)
+                        || field_matches_query(&item.description, query)
+                    {
+                        results.push(SearchResult {
+                            id: item.id.clone(),
+                            kind: kind.label(),
+                            title: item.title.clone(),
+                        });
+                    }
+                }
+            }
+            LookupKind::Feature => {
+                for item in &self.workspace.features {
+                    if field_matches_query(&item.id, query)
+                        || field_matches_query(&item.title, query)
+                        || field_matches_query(&item.summary, query)
+                    {
+                        results.push(SearchResult {
+                            id: item.id.clone(),
+                            kind: kind.label(),
+                            title: item.title.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn workspace_relative_display(workspace: &Workspace, path: &Path) -> String {
@@ -221,6 +312,10 @@ fn workspace_relative_display(workspace: &Workspace, path: &Path) -> String {
         .unwrap_or(path)
         .display()
         .to_string()
+}
+
+fn field_matches_query(value: &str, query: &str) -> bool {
+    value.to_lowercase().contains(query)
 }
 
 #[cfg(test)]
@@ -475,5 +570,53 @@ mod tests {
                 .to_string()
                 .contains("workspace requirement entries changed while collecting document paths")
         );
+    }
+
+    #[test]
+    fn search_matches_browser_search_fields_only() {
+        let workspace = Workspace {
+            root: std::path::PathBuf::from("."),
+            spec_root: std::path::PathBuf::from("./docs/syu"),
+            config: SyuConfig::default(),
+            philosophies: vec![crate::model::Philosophy {
+                id: "PHIL-001".to_string(),
+                title: "Trace everything".to_string(),
+                product_design_principle: "Long-form principle text".to_string(),
+                coding_guideline: "Long-form coding text".to_string(),
+                linked_policies: Vec::new(),
+            }],
+            policies: vec![Policy {
+                id: "POL-001".to_string(),
+                title: "Policy title".to_string(),
+                summary: "Summary field".to_string(),
+                description: "Description field".to_string(),
+                linked_philosophies: Vec::new(),
+                linked_requirements: Vec::new(),
+            }],
+            requirements: vec![Requirement {
+                id: "REQ-001".to_string(),
+                title: "Requirement title".to_string(),
+                description: "Requirement description".to_string(),
+                priority: "high".to_string(),
+                status: "planned".to_string(),
+                linked_policies: Vec::new(),
+                linked_features: Vec::new(),
+                tests: BTreeMap::new(),
+            }],
+            features: vec![Feature {
+                id: "FEAT-001".to_string(),
+                title: "Feature title".to_string(),
+                summary: "Feature summary".to_string(),
+                status: "planned".to_string(),
+                linked_requirements: Vec::new(),
+                implementations: BTreeMap::new(),
+            }],
+        };
+
+        let lookup = WorkspaceLookup::new(&workspace);
+        assert_eq!(lookup.search("summary", None)[0].id, "POL-001");
+        assert_eq!(lookup.search("description", None)[0].id, "POL-001");
+        assert_eq!(lookup.search("feature summary", None)[0].id, "FEAT-001");
+        assert!(lookup.search("Long-form principle", None).is_empty());
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod list;
 mod lookup;
 pub mod report;
+pub mod search;
 pub mod show;
 
 pub(crate) fn shell_quote_path(path: &Path) -> String {

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -1,0 +1,56 @@
+// FEAT-SEARCH-001
+// REQ-CORE-019
+
+use anyhow::{Result, bail};
+use serde::Serialize;
+
+use crate::{
+    cli::{OutputFormat, SearchArgs},
+    workspace::load_workspace,
+};
+
+use super::lookup::{SearchResult, WorkspaceLookup};
+
+#[derive(Debug, Serialize)]
+struct JsonSearchOutput {
+    query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<&'static str>,
+    items: Vec<SearchResult>,
+}
+
+pub fn run_search_command(args: &SearchArgs) -> Result<i32> {
+    let query = args.query.trim();
+    if query.is_empty() {
+        bail!("search query must not be empty or whitespace");
+    }
+
+    let workspace = load_workspace(&args.workspace)?;
+    let items = WorkspaceLookup::new(&workspace).search(query, args.kind);
+
+    match args.format {
+        OutputFormat::Text => print_text_results(query, &items),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&JsonSearchOutput {
+                query: query.to_string(),
+                kind: args.kind.map(|kind| kind.label()),
+                items,
+            })
+            .expect("serializing search output to JSON should succeed")
+        ),
+    }
+
+    Ok(0)
+}
+
+fn print_text_results(query: &str, items: &[SearchResult]) {
+    if items.is_empty() {
+        println!("no matches for `{query}`");
+        return;
+    }
+
+    for item in items {
+        println!("{}\t{}\t{}", item.id, item.kind, item.title);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// FEAT-SEARCH-001
 // FEAT-BROWSE-001
 
 pub mod cli;
@@ -20,6 +21,7 @@ enum Dispatch {
     Browse(cli::BrowseArgs),
     List(cli::ListArgs),
     Show(cli::ShowArgs),
+    Search(cli::SearchArgs),
     App(cli::AppArgs),
     PrintHelp,
     Validate(cli::ValidateArgs),
@@ -32,6 +34,7 @@ fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) ->
         Some(cli::Commands::Browse(args)) => Dispatch::Browse(args),
         Some(cli::Commands::List(args)) => Dispatch::List(args),
         Some(cli::Commands::Show(args)) => Dispatch::Show(args),
+        Some(cli::Commands::Search(args)) => Dispatch::Search(args),
         Some(cli::Commands::App(args)) => Dispatch::App(args),
         None if stdin_is_terminal && stdout_is_terminal => {
             Dispatch::Browse(cli::BrowseArgs::default())
@@ -48,6 +51,7 @@ fn run_dispatch(dispatch: Dispatch) -> Result<i32> {
         Dispatch::Browse(args) => command::browse::run_browse_command(&args),
         Dispatch::List(args) => command::list::run_list_command(&args),
         Dispatch::Show(args) => command::show::run_show_command(&args),
+        Dispatch::Search(args) => command::search::run_search_command(&args),
         Dispatch::App(args) => command::app::run_app_command(&args),
         Dispatch::PrintHelp => {
             let mut command = cli::Cli::command();
@@ -74,7 +78,9 @@ pub fn run() -> Result<i32> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::cli::{AppArgs, Cli, Commands, ListArgs, OutputFormat, ShowArgs};
+    use crate::cli::{
+        AppArgs, Cli, Commands, ListArgs, LookupKind, OutputFormat, SearchArgs, ShowArgs,
+    };
 
     // REQ-CORE-015
     #[test]
@@ -148,6 +154,32 @@ mod tests {
                 if id == "REQ-CORE-018"
                     && workspace == Path::new("workspace")
                     && format == OutputFormat::Text
+        ));
+    }
+
+    #[test]
+    // REQ-CORE-019
+    fn dispatches_search_subcommands_without_rewriting_them() {
+        let search = super::dispatch(
+            Cli {
+                command: Some(Commands::Search(SearchArgs {
+                    query: "traceability".to_string(),
+                    workspace: PathBuf::from("workspace"),
+                    kind: Some(LookupKind::Feature),
+                    format: OutputFormat::Json,
+                })),
+            },
+            true,
+            true,
+        );
+
+        assert!(matches!(
+            search,
+            super::Dispatch::Search(crate::cli::SearchArgs { query, workspace, kind, format })
+                if query == "traceability"
+                    && workspace == Path::new("workspace")
+                    && kind == Some(LookupKind::Feature)
+                    && format == OutputFormat::Json
         ));
     }
 }

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -1,3 +1,5 @@
+// REQ-CORE-019
+
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
 
@@ -26,7 +28,9 @@ fn root_help_includes_start_here_guidance() {
 
 #[test]
 fn workspace_help_uses_current_directory_default_consistently() {
-    for command in ["browse", "show", "app", "validate", "check", "report"] {
+    for command in [
+        "browse", "show", "search", "app", "validate", "check", "report",
+    ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
             .args([command, "--help"])
@@ -49,6 +53,22 @@ fn workspace_help_uses_current_directory_default_consistently() {
             "{command} help should not claim docs/syu is the workspace default",
         );
     }
+}
+
+#[test]
+fn search_help_mentions_kind_scoping_and_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["search", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "search help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--kind"));
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("syu search traceability --kind requirement"));
 }
 
 #[test]

--- a/tests/search_command.rs
+++ b/tests/search_command.rs
@@ -26,6 +26,38 @@ fn search_command_matches_ids_and_titles() {
 
 #[test]
 // REQ-CORE-019
+fn search_command_matches_philosophy_ids_and_titles() {
+    let id_output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("PHIL-TRACE-001")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("philosophy id search should run");
+
+    assert!(id_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&id_output.stdout)
+            .contains("PHIL-TRACE-001\tphilosophy\tTrace everything")
+    );
+
+    let title_output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("everything")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("philosophy title search should run");
+
+    assert!(title_output.status.success());
+    assert!(
+        String::from_utf8_lossy(&title_output.stdout)
+            .contains("PHIL-TRACE-001\tphilosophy\tTrace everything")
+    );
+}
+
+#[test]
+// REQ-CORE-019
 fn search_command_matches_summaries_and_descriptions() {
     let summary_output = Command::cargo_bin("syu")
         .expect("binary should build")
@@ -133,4 +165,22 @@ fn search_command_reads_items_from_workspaces_with_validation_errors() {
         "validation issues should not block search"
     );
     assert!(String::from_utf8_lossy(&output.stdout).contains("REQ-FAIL-001"));
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_rejects_whitespace_only_queries() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("   ")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("search query must not be empty or whitespace")
+    );
 }

--- a/tests/search_command.rs
+++ b/tests/search_command.rs
@@ -1,0 +1,136 @@
+use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
+use std::{path::PathBuf, process::Command};
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/workspaces")
+        .join(name)
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_matches_ids_and_titles() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("FEAT-TRACE-002")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("FEAT-TRACE-002\tfeature\tPython implementation trace"));
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_matches_summaries_and_descriptions() {
+    let summary_output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("source")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("summary search should run");
+
+    assert!(summary_output.status.success());
+    let summary_stdout = String::from_utf8_lossy(&summary_output.stdout);
+    assert!(summary_stdout.contains("FEAT-TRACE-001\tfeature\tRust implementation trace"));
+
+    let description_output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("repository")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("description search should run");
+
+    assert!(description_output.status.success());
+    let description_stdout = String::from_utf8_lossy(&description_output.stdout);
+    assert!(
+        description_stdout.contains("POL-TRACE-001\tpolicy\tRequirements need executable evidence")
+    );
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_scopes_results_by_kind() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("python")
+        .arg(fixture_path("passing"))
+        .arg("--kind")
+        .arg("requirement")
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("REQ-TRACE-002\trequirement\tPython requirement trace"));
+    assert!(
+        !stdout.contains("FEAT-TRACE-002"),
+        "kind filter should exclude features"
+    );
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_supports_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("trace")
+        .arg(fixture_path("passing"))
+        .arg("--kind")
+        .arg("feature")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(json["query"], "trace");
+    assert_eq!(json["kind"], "feature");
+    assert_eq!(json["items"][0]["kind"], "feature");
+    assert_eq!(json["items"][0]["id"], "FEAT-TRACE-001");
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_matches_browser_search_fields_only() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("machine-readable")
+        .arg(fixture_path("passing"))
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "no matches for `machine-readable`"
+    );
+}
+
+#[test]
+// REQ-CORE-019
+fn search_command_reads_items_from_workspaces_with_validation_errors() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("search")
+        .arg("REQ-FAIL")
+        .arg(fixture_path("failing"))
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "validation issues should not block search"
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("REQ-FAIL-001"));
+}


### PR DESCRIPTION
## Summary\n- add a new `syu search` CLI for terminal-first lookup across IDs, titles, summaries, and descriptions\n- keep search behavior aligned with the browser search fields while supporting optional kind scoping and JSON output\n- document and trace the new command through the checked-in spec, generated docs, README, and tests\n\n## Validation\n- bash scripts/ci/quality-gates.sh\n- cargo run -- search source tests/fixtures/workspaces/passing --kind feature\n- cargo run -- search traceability . --kind requirement\n\nCloses #168