### PR TITLE
Add syu add authoring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ before you begin editing YAML.
 
 ```bash
 syu init .          # 1. Create spec scaffold
-# edit docs/syu/... # 2. Add your spec items
+syu add requirement REQ-AUTH-001  # 2. Add spec items with generated YAML stubs
 syu validate .      # 3. Check everything is linked
 syu app .           # 4. Browse in the browser
 ```
@@ -113,6 +113,7 @@ syu init .
 syu validate .
 syu validate . --fix
 syu browse .
+syu add feature FEAT-AUTH-LOGIN-001 --kind auth
 syu list requirement
 syu show REQ-001
 syu app .
@@ -183,6 +184,23 @@ style you already expect. Use `--id-prefix` when you want stable project-wide
 starter IDs from the first command, and the per-layer `--*-prefix` flags when a
 single shared stem is not enough. Use `--spec-root` to scaffold into a
 repository-relative spec tree without moving the generated files by hand later.
+
+### `syu add`
+
+Scaffold a new YAML stub after the initial workspace exists:
+
+```bash
+syu add philosophy PHIL-002
+syu add requirement REQ-AUTH-001
+syu add feature FEAT-AUTH-LOGIN-001 --kind auth
+syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.yaml
+```
+
+`syu add` keeps the command intentionally small. It derives a default title and
+document path from the ID, uses the configured `spec.root`, and updates
+`features/features.yaml` automatically when you scaffold a new feature document.
+Edit the generated stub fields and reciprocal links before you expect
+`syu validate` to pass cleanly.
 
 ### `syu validate`
 

--- a/docs/generated/site-spec/features/cli/add.md
+++ b/docs/generated/site-spec/features/cli/add.md
@@ -1,0 +1,56 @@
+---
+title: "Authoring Add CLI / Add"
+description: "Generated reference for docs/syu/features/cli/add.yaml"
+---
+
+> Generated from `docs/syu/features/cli/add.yaml`.
+
+## Parsed content
+
+### Category
+
+- Authoring Add CLI
+
+### Version
+
+- 1
+
+### Features
+
+- **id**: FEAT-ADD-001
+  - **title**: Follow-up spec authoring scaffold
+  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-020
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/add.rs
+        - **symbols**:
+          - run_add_command
+      - **file**: src/cli.rs
+        - **symbols**:
+          - AddArgs
+
+## Source YAML
+
+```yaml
+category: Authoring Add CLI
+version: 1
+
+features:
+  - id: FEAT-ADD-001
+    title: Follow-up spec authoring scaffold
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-020
+    implementations:
+      rust:
+        - file: src/command/add.rs
+          symbols:
+            - run_add_command
+        - file: src/cli.rs
+          symbols:
+            - AddArgs
+```

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -13,7 +13,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ### Updated
 
-- 2026-03
+- 2026-04
 
 ### Files
 
@@ -27,6 +27,8 @@ description: "Generated reference for docs/syu/features/features.yaml"
   - **file**: cli/check.yaml
 - **kind**: init
   - **file**: cli/init.yaml
+- **kind**: add
+  - **file**: cli/add.yaml
 - **kind**: report
   - **file**: cli/report.yaml
 - **kind**: docs
@@ -46,7 +48,7 @@ description: "Generated reference for docs/syu/features/features.yaml"
 
 ```yaml
 version: "0.0.1-alpha.7"
-updated: "2026-03"
+updated: "2026-04"
 
 files:
   - kind: app
@@ -59,6 +61,8 @@ files:
     file: cli/check.yaml
   - kind: init
     file: cli/init.yaml
+  - kind: add
+    file: cli/add.yaml
   - kind: report
     file: cli/report.yaml
   - kind: docs

--- a/docs/generated/site-spec/index.md
+++ b/docs/generated/site-spec/index.md
@@ -14,6 +14,7 @@ This section is generated from the YAML source under `docs/syu/`.
 - [Configuration / Spec](/docs/generated/site-spec/config/spec)
 - [Configuration / Validate](/docs/generated/site-spec/config/validate)
 - [Browser App / App](/docs/generated/site-spec/features/browser/app)
+- [Authoring Add CLI / Add](/docs/generated/site-spec/features/cli/add)
 - [Interactive CLI / Browse](/docs/generated/site-spec/features/cli/browse)
 - [Validate Command / Check](/docs/generated/site-spec/features/cli/check)
 - [Init Command / Init](/docs/generated/site-spec/features/cli/init)

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -38,6 +38,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-009
     - REQ-CORE-015
     - REQ-CORE-018
+    - REQ-CORE-020
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -91,6 +92,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-015
     - REQ-CORE-017
     - REQ-CORE-018
+    - REQ-CORE-020
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -170,6 +172,7 @@ policies:
       - REQ-CORE-009
       - REQ-CORE-015
       - REQ-CORE-018
+      - REQ-CORE-020
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -223,6 +226,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-020
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -170,6 +170,38 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: src/command/lookup.rs
         - **symbols**:
           - *
+- **id**: REQ-CORE-020
+  - **title**: Provide a follow-up authoring scaffold command after syu init
+  - **description**:
+    - |
+      The CLI MUST provide an `add` command that scaffolds a new philosophy,
+      policy, requirement, or feature stub after a workspace already exists.
+      The command SHOULD infer a sensible default title and document path from
+      the requested ID, MUST honor the configured `spec.root`, and MUST update
+      the explicit feature registry when creating a new feature document. Output
+      SHOULD stay concise enough for normal code review and hand-edited follow-up
+      work.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-004
+  - **linked_features**:
+    - FEAT-ADD-001
+  - **tests**:
+    - **rust**:
+      - **file**: tests/add_command.rs
+        - **symbols**:
+          - *
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - add_help_mentions_explicit_file_and_feature_kind
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatches_add_subcommands_without_rewriting_them
+      - **file**: src/command/add.rs
+        - **symbols**:
+          - *
 
 ## Source YAML
 
@@ -324,6 +356,37 @@ requirements:
           symbols:
             - '*'
         - file: src/command/lookup.rs
+          symbols:
+            - '*'
+  - id: REQ-CORE-020
+    title: Provide a follow-up authoring scaffold command after syu init
+    description: |
+      The CLI MUST provide an `add` command that scaffolds a new philosophy,
+      policy, requirement, or feature stub after a workspace already exists.
+      The command SHOULD infer a sensible default title and document path from
+      the requested ID, MUST honor the configured `spec.root`, and MUST update
+      the explicit feature registry when creating a new feature document. Output
+      SHOULD stay concise enough for normal code review and hand-edited follow-up
+      work.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-004
+    linked_features:
+      - FEAT-ADD-001
+    tests:
+      rust:
+        - file: tests/add_command.rs
+          symbols:
+            - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - add_help_mentions_explicit_file_and_feature_kind
+        - file: src/lib.rs
+          symbols:
+            - dispatches_add_subcommands_without_rewriting_them
+        - file: src/command/add.rs
           symbols:
             - '*'
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 7
-- Requirements: 18
-- Features: 22
+- Requirements: 19
+- Features: 23
 
 ## Traceability
 
-- Requirement-to-test traceability: 59/59
-- Feature-to-implementation traceability: 83/83
+- Requirement-to-test traceability: 63/63
+- Feature-to-implementation traceability: 85/85
 
 ## Issues
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@ Start here once `syu` is installed:
 
 ```bash
 syu init .          # 1. Create spec scaffold
-# edit docs/syu/... # 2. Add your spec items
+syu add requirement REQ-AUTH-001  # 2. Add your next spec item
 syu validate .      # 3. Check everything is linked
 syu app .           # 4. Browse in the browser
 ```
@@ -100,10 +100,28 @@ different prefix, use `--philosophy-prefix`, `--policy-prefix`,
 Starter requirements and features begin as `status: planned`. Keep them planned
 until you are ready to declare real tests and implementation traces.
 
-## 2. Fill in the starter spec
+## 2. Add and refine spec items
 
-Start by editing the generated files under your configured `spec.root`
-(default: `docs/syu`):
+Start with the generated files under your configured `spec.root`
+(default: `docs/syu`), then scaffold new items as the workspace grows:
+
+```bash
+syu add philosophy PHIL-002
+syu add policy POL-002
+syu add requirement REQ-AUTH-001
+syu add feature FEAT-AUTH-LOGIN-001 --kind auth
+```
+
+These commands generate correctly shaped YAML stubs, infer a default document
+path from the ID, and keep feature discovery explicit by updating the feature
+registry automatically when a new feature document is created. You can override
+the target file when you want a more specific layout:
+
+```bash
+syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.yaml
+```
+
+Direct YAML editing is still supported. The default scaffolded files are:
 
 - `<spec.root>/philosophy/foundation.yaml`
 - `<spec.root>/policies/policies.yaml`
@@ -115,11 +133,12 @@ Start by editing the generated files under your configured `spec.root`
   `features/languages/polyglot.yaml`)
 
 As the workspace grows, you can group requirement and feature files into nested
-folders. Keep feature discovery explicit by updating
-`<spec.root>/features/features.yaml` (default:
-`docs/syu/features/features.yaml`) whenever you add or move a feature document.
-`syu validate` reports feature YAML files on disk that are missing from that
-registry.
+folders. `syu add` chooses a default folder from the ID or feature `--kind`,
+but you can still move documents later if another layout reads better in your
+repository. When you move a feature document by hand, keep feature discovery
+explicit by updating `<spec.root>/features/features.yaml` (default:
+`docs/syu/features/features.yaml`). `syu validate` reports feature YAML files on
+disk that are missing from that registry.
 
 Requirements are discovered by walking the `requirements/` tree, but features use
 an explicit registry because implementation claims should stay deliberate and

--- a/docs/syu/features/cli/add.yaml
+++ b/docs/syu/features/cli/add.yaml
@@ -1,0 +1,18 @@
+category: Authoring Add CLI
+version: 1
+
+features:
+  - id: FEAT-ADD-001
+    title: Follow-up spec authoring scaffold
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-020
+    implementations:
+      rust:
+        - file: src/command/add.rs
+          symbols:
+            - run_add_command
+        - file: src/cli.rs
+          symbols:
+            - AddArgs

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -1,5 +1,5 @@
 version: "0.0.1-alpha.7"
-updated: "2026-03"
+updated: "2026-04"
 
 files:
   - kind: app
@@ -12,6 +12,8 @@ files:
     file: cli/check.yaml
   - kind: init
     file: cli/init.yaml
+  - kind: add
+    file: cli/add.yaml
   - kind: report
     file: cli/report.yaml
   - kind: docs

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -19,6 +19,7 @@ policies:
       - REQ-CORE-009
       - REQ-CORE-015
       - REQ-CORE-018
+      - REQ-CORE-020
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -72,6 +73,7 @@ policies:
       - REQ-CORE-015
       - REQ-CORE-017
       - REQ-CORE-018
+      - REQ-CORE-020
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -150,3 +150,34 @@ requirements:
         - file: src/command/lookup.rs
           symbols:
             - '*'
+  - id: REQ-CORE-020
+    title: Provide a follow-up authoring scaffold command after syu init
+    description: |
+      The CLI MUST provide an `add` command that scaffolds a new philosophy,
+      policy, requirement, or feature stub after a workspace already exists.
+      The command SHOULD infer a sensible default title and document path from
+      the requested ID, MUST honor the configured `spec.root`, and MUST update
+      the explicit feature registry when creating a new feature document. Output
+      SHOULD stay concise enough for normal code review and hand-edited follow-up
+      work.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-004
+    linked_features:
+      - FEAT-ADD-001
+    tests:
+      rust:
+        - file: tests/add_command.rs
+          symbols:
+            - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - add_help_mentions_explicit_file_and_feature_kind
+        - file: src/lib.rs
+          symbols:
+            - dispatches_add_subcommands_without_rewriting_them
+        - file: src/command/add.rs
+          symbols:
+            - '*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 // FEAT-DOCS-001
 // FEAT-APP-001
+// FEAT-ADD-001
 // FEAT-BROWSE-001
 // FEAT-BROWSE-002
 // FEAT-INIT-005
@@ -33,6 +34,14 @@ Examples:
   syu init . --template rust-only
   syu init . --spec-root docs/spec
   syu init path/to/workspace --name my-project --spec-root spec/contracts --template polyglot --id-prefix store";
+
+const ADD_AFTER_HELP: &str = "\
+Examples:
+  syu add philosophy PHIL-002
+  syu add policy POL-002 --file docs/syu/policies/policies.yaml
+  syu add requirement REQ-AUTH-001
+  syu add feature FEAT-AUTH-LOGIN-001 --kind auth
+  syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.yaml";
 
 const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
 
@@ -88,6 +97,11 @@ pub enum Commands {
         after_help = INIT_AFTER_HELP
     )]
     Init(InitArgs),
+    #[command(
+        about = "Scaffold a new philosophy, policy, requirement, or feature stub",
+        after_help = ADD_AFTER_HELP
+    )]
+    Add(AddArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -335,6 +349,35 @@ pub struct InitArgs {
     pub format: OutputFormat,
 }
 
+#[derive(Debug, Clone, Args)]
+pub struct AddArgs {
+    #[arg(help = "Layer kind to scaffold (philosophy, policy, requirement, or feature)")]
+    pub layer: LookupKind,
+
+    #[arg(
+        help = "New definition ID to scaffold (for example REQ-AUTH-001 or FEAT-AUTH-LOGIN-001)"
+    )]
+    pub id: String,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Optional YAML document path, relative to the workspace root or spec.root"
+    )]
+    pub file: Option<PathBuf>,
+
+    #[arg(
+        long,
+        value_name = "NAME",
+        help = "Feature registry kind and default folder name (feature scaffolding only)"
+    )]
+    pub kind: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum StarterTemplate {
     #[default]
@@ -488,5 +531,29 @@ mod tests {
         assert!(rendered.contains("policy_prefix: Some(\"POL-STORE\")"));
         assert!(rendered.contains("requirement_prefix: Some(\"REQ-STORE\")"));
         assert!(rendered.contains("feature_prefix: Some(\"FEAT-STORE\")"));
+    }
+
+    #[test]
+    fn add_args_accept_explicit_files_and_feature_kinds() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "add",
+            "feature",
+            "FEAT-AUTH-001",
+            ".",
+            "--kind",
+            "auth",
+            "--file",
+            "docs/syu/features/auth/login.yaml",
+        ])
+        .expect("add args should parse");
+
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Add("));
+        assert!(rendered.contains("layer: Feature"));
+        assert!(rendered.contains("id: \"FEAT-AUTH-001\""));
+        assert!(rendered.contains("workspace: \".\""));
+        assert!(rendered.contains("file: Some(\"docs/syu/features/auth/login.yaml\")"));
+        assert!(rendered.contains("kind: Some(\"auth\")"));
     }
 }

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -1,0 +1,673 @@
+// FEAT-ADD-001
+// REQ-CORE-020
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::{
+    cli::{AddArgs, LookupKind},
+    coverage::normalize_relative_path,
+    model::{
+        FeatureDocument, FeatureRegistryDocument, PhilosophyDocument, PolicyDocument,
+        RequirementDocument,
+    },
+    workspace::{Workspace, load_workspace},
+};
+
+use super::{lookup::WorkspaceLookup, shell_quote_path};
+
+pub fn run_add_command(args: &AddArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let parsed_id = ParsedId::parse(args.layer, &args.id)?;
+
+    if args.layer != LookupKind::Feature && args.kind.is_some() {
+        bail!("`--kind` is only supported when scaffolding features");
+    }
+    if WorkspaceLookup::new(&workspace)
+        .find(&parsed_id.normalized)
+        .is_some()
+    {
+        bail!(
+            "{} `{}` already exists in `{}`",
+            args.layer.label(),
+            parsed_id.normalized,
+            workspace.root.display()
+        );
+    }
+
+    let feature_kind = match args.layer {
+        LookupKind::Feature => Some(normalize_feature_kind(
+            args.kind
+                .as_deref()
+                .unwrap_or(parsed_id.folder_slug.as_str()),
+        )?),
+        _ => None,
+    };
+    let target = resolve_target_path(
+        &workspace,
+        args.layer,
+        args.file.as_deref(),
+        &parsed_id,
+        feature_kind.as_deref(),
+    )?;
+    let created_target_file = !target.absolute.exists();
+
+    write_stub_document(args.layer, &parsed_id, feature_kind.as_deref(), &target)?;
+
+    let registry_updated = if args.layer == LookupKind::Feature {
+        update_feature_registry(
+            &workspace,
+            &target.absolute,
+            feature_kind
+                .as_deref()
+                .expect("features require a registry kind"),
+        )?
+    } else {
+        false
+    };
+
+    print_add_summary(
+        &workspace,
+        args.layer,
+        &parsed_id.normalized,
+        &target.absolute,
+        created_target_file,
+        registry_updated,
+    );
+    Ok(0)
+}
+
+#[derive(Debug, Clone)]
+struct ParsedId {
+    normalized: String,
+    typed_prefix: String,
+    title: String,
+    folder_slug: String,
+    file_slug: String,
+}
+
+impl ParsedId {
+    fn parse(layer: LookupKind, raw: &str) -> Result<Self> {
+        let normalized = normalize_definition_id(raw, layer)?;
+        let segments: Vec<_> = normalized.split('-').collect();
+        let suffix = &segments[1..segments.len() - 1];
+        let title = if suffix.is_empty() {
+            default_title(layer)
+        } else {
+            title_case_tokens(suffix)
+        };
+        let folder_slug = suffix
+            .first()
+            .map(|segment| segment.to_ascii_lowercase())
+            .unwrap_or_else(|| default_folder_slug(layer));
+        let file_slug = if suffix.len() > 1 {
+            suffix[1..]
+                .iter()
+                .map(|segment| segment.to_ascii_lowercase())
+                .collect::<Vec<_>>()
+                .join("-")
+        } else {
+            folder_slug.clone()
+        };
+
+        Ok(Self {
+            typed_prefix: segments[..segments.len() - 1].join("-"),
+            normalized,
+            title,
+            folder_slug,
+            file_slug,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TargetPath {
+    absolute: PathBuf,
+}
+
+fn normalize_definition_id(raw: &str, layer: LookupKind) -> Result<String> {
+    let normalized = raw.trim().to_ascii_uppercase();
+    if normalized.is_empty()
+        || normalized.split('-').any(|segment| segment.is_empty())
+        || !normalized
+            .chars()
+            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        bail!(
+            "{} IDs must contain only ASCII letters, numbers, and single hyphens: `{}`",
+            layer.label(),
+            raw.trim()
+        );
+    }
+
+    let segments: Vec<_> = normalized.split('-').collect();
+    let expected_prefix = match layer {
+        LookupKind::Philosophy => "PHIL",
+        LookupKind::Policy => "POL",
+        LookupKind::Requirement => "REQ",
+        LookupKind::Feature => "FEAT",
+    };
+    if segments.first().copied() != Some(expected_prefix) {
+        bail!(
+            "{} IDs must start with `{expected_prefix}-`: `{}`",
+            layer.label(),
+            raw.trim()
+        );
+    }
+    if segments.len() < 2
+        || !segments
+            .last()
+            .expect("segments should exist")
+            .chars()
+            .all(|ch| ch.is_ascii_digit())
+    {
+        bail!(
+            "{} IDs must end with a numeric segment like `{expected_prefix}-001`: `{}`",
+            layer.label(),
+            raw.trim()
+        );
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_feature_kind(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty()
+        || trimmed != trimmed.to_ascii_lowercase()
+        || trimmed.split('-').any(|segment| segment.is_empty())
+        || !trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        bail!(
+            "feature `--kind` must contain only lowercase ASCII letters, numbers, and single hyphens: `{}`",
+            raw.trim()
+        );
+    }
+    Ok(trimmed.to_string())
+}
+
+fn resolve_target_path(
+    workspace: &Workspace,
+    layer: LookupKind,
+    explicit_file: Option<&Path>,
+    parsed_id: &ParsedId,
+    feature_kind: Option<&str>,
+) -> Result<TargetPath> {
+    let default_relative = default_document_path(layer, parsed_id, feature_kind);
+    let absolute = if let Some(file) = explicit_file {
+        resolve_explicit_file(workspace, file)?
+    } else {
+        workspace.spec_root.join(default_relative)
+    };
+
+    ensure_target_within_spec_root(workspace, layer, &absolute)?;
+    Ok(TargetPath { absolute })
+}
+
+fn default_document_path(
+    layer: LookupKind,
+    parsed_id: &ParsedId,
+    feature_kind: Option<&str>,
+) -> PathBuf {
+    match layer {
+        LookupKind::Philosophy => PathBuf::from("philosophy/foundation.yaml"),
+        LookupKind::Policy => PathBuf::from("policies/policies.yaml"),
+        LookupKind::Requirement => PathBuf::from(format!(
+            "requirements/{}/{}.yaml",
+            parsed_id.folder_slug, parsed_id.file_slug
+        )),
+        LookupKind::Feature => {
+            let kind = feature_kind.expect("feature default paths require a kind");
+            PathBuf::from(format!("features/{kind}/{}.yaml", parsed_id.file_slug))
+        }
+    }
+}
+
+fn resolve_explicit_file(workspace: &Workspace, raw: &Path) -> Result<PathBuf> {
+    if raw.is_absolute() {
+        bail!(
+            "`--file` must stay inside `{}` as a relative path",
+            workspace.spec_root.display()
+        );
+    }
+
+    let normalized = normalize_relative_path(raw);
+    if normalized.as_os_str().is_empty()
+        || normalized.is_absolute()
+        || normalized
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!(
+            "`--file` must stay within the workspace or configured spec root: `{}`",
+            raw.display()
+        );
+    }
+
+    let workspace_relative = workspace.root.join(&normalized);
+    if workspace_relative.starts_with(&workspace.spec_root) {
+        return Ok(workspace_relative);
+    }
+
+    let spec_relative = workspace.spec_root.join(&normalized);
+    if spec_relative.starts_with(&workspace.spec_root) {
+        return Ok(spec_relative);
+    }
+
+    bail!(
+        "`--file` must point inside `{}` or be relative to that spec root: `{}`",
+        workspace.spec_root.display(),
+        raw.display()
+    );
+}
+
+fn ensure_target_within_spec_root(
+    workspace: &Workspace,
+    layer: LookupKind,
+    path: &Path,
+) -> Result<()> {
+    if !path.starts_with(&workspace.spec_root) {
+        bail!(
+            "target path `{}` must stay within `{}`",
+            path.display(),
+            workspace.spec_root.display()
+        );
+    }
+    if !matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("yaml" | "yml")
+    ) {
+        bail!(
+            "target path must point to a YAML document: `{}`",
+            path.display()
+        );
+    }
+
+    let layer_root = match layer {
+        LookupKind::Philosophy => workspace.spec_root.join("philosophy"),
+        LookupKind::Policy => workspace.spec_root.join("policies"),
+        LookupKind::Requirement => workspace.spec_root.join("requirements"),
+        LookupKind::Feature => workspace.spec_root.join("features"),
+    };
+    if !path.starts_with(&layer_root) {
+        bail!(
+            "{} stubs must stay under `{}`",
+            layer.label(),
+            layer_root.display()
+        );
+    }
+    if layer == LookupKind::Feature && path == workspace.spec_root.join("features/features.yaml") {
+        bail!("feature stubs must use a feature document path, not `features/features.yaml`");
+    }
+
+    Ok(())
+}
+
+fn write_stub_document(
+    layer: LookupKind,
+    parsed_id: &ParsedId,
+    feature_kind: Option<&str>,
+    target: &TargetPath,
+) -> Result<()> {
+    if let Some(parent) = target.absolute.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    if target.absolute.exists() {
+        validate_existing_document(layer, &target.absolute, parsed_id)?;
+        append_yaml_list_item(&target.absolute, render_item_block(layer, parsed_id))?;
+    } else {
+        let document = render_new_document(layer, parsed_id, feature_kind);
+        fs::write(&target.absolute, document)?;
+    }
+
+    Ok(())
+}
+
+fn validate_existing_document(layer: LookupKind, path: &Path, parsed_id: &ParsedId) -> Result<()> {
+    let raw = fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read {} document `{}`",
+            layer.label(),
+            path.display()
+        )
+    })?;
+
+    match layer {
+        LookupKind::Philosophy => {
+            let _: PhilosophyDocument = serde_yaml::from_str(&raw).with_context(|| {
+                format!(
+                    "failed to parse philosophy document from `{}`",
+                    path.display()
+                )
+            })?;
+        }
+        LookupKind::Policy => {
+            let _: PolicyDocument = serde_yaml::from_str(&raw).with_context(|| {
+                format!("failed to parse policy document from `{}`", path.display())
+            })?;
+        }
+        LookupKind::Requirement => {
+            let document: RequirementDocument = serde_yaml::from_str(&raw).with_context(|| {
+                format!(
+                    "failed to parse requirement document from `{}`",
+                    path.display()
+                )
+            })?;
+            if document.prefix.trim() != parsed_id.typed_prefix {
+                bail!(
+                    "requirement document `{}` uses prefix `{}`, which does not match `{}`",
+                    path.display(),
+                    document.prefix,
+                    parsed_id.typed_prefix
+                );
+            }
+        }
+        LookupKind::Feature => {
+            let _: FeatureDocument = serde_yaml::from_str(&raw).with_context(|| {
+                format!("failed to parse feature document from `{}`", path.display())
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn append_yaml_list_item(path: &Path, item_block: String) -> Result<()> {
+    let mut existing = fs::read_to_string(path)
+        .with_context(|| format!("failed to read YAML document `{}`", path.display()))?;
+    while existing.ends_with('\n') {
+        existing.pop();
+    }
+    existing.push_str("\n\n");
+    existing.push_str(&item_block);
+    existing.push('\n');
+    fs::write(path, existing)
+        .with_context(|| format!("failed to update YAML document `{}`", path.display()))
+}
+
+fn render_new_document(
+    layer: LookupKind,
+    parsed_id: &ParsedId,
+    feature_kind: Option<&str>,
+) -> String {
+    match layer {
+        LookupKind::Philosophy => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n{}\n",
+            render_item_block(layer, parsed_id)
+        ),
+        LookupKind::Policy => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n{}\n",
+            render_item_block(layer, parsed_id)
+        ),
+        LookupKind::Requirement => format!(
+            "category: {} Requirements\nprefix: {}\n\nrequirements:\n{}\n",
+            title_case_slug(&parsed_id.folder_slug),
+            parsed_id.typed_prefix,
+            render_item_block(layer, parsed_id)
+        ),
+        LookupKind::Feature => format!(
+            "category: {} Features\nversion: 1\n\nfeatures:\n{}\n",
+            title_case_slug(feature_kind.unwrap_or(parsed_id.folder_slug.as_str())),
+            render_item_block(layer, parsed_id)
+        ),
+    }
+}
+
+fn render_item_block(layer: LookupKind, parsed_id: &ParsedId) -> String {
+    match layer {
+        LookupKind::Philosophy => format!(
+            "  - id: {}\n    title: {}\n    product_design_principle: |\n      Describe the durable product design principle for {}.\n    coding_guideline: |\n      Describe the coding guideline that keeps {} actionable in day-to-day work.\n    linked_policies: []",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized, parsed_id.normalized
+        ),
+        LookupKind::Policy => format!(
+            "  - id: {}\n    title: {}\n    summary: Document the rule enforced by {}.\n    description: |\n      Describe how this policy turns philosophy into a concrete contributor rule.\n    linked_philosophies: []\n    linked_requirements: []",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+        ),
+        LookupKind::Requirement => format!(
+            "  - id: {}\n    title: {}\n    description: |\n      Describe the concrete requirement that {} adds to the repository.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features: []\n    tests: {{}}",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+        ),
+        LookupKind::Feature => format!(
+            "  - id: {}\n    title: {}\n    summary: Describe the shipped capability that {} represents.\n    status: planned\n    linked_requirements: []\n    implementations: {{}}",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+        ),
+    }
+}
+
+fn update_feature_registry(
+    workspace: &Workspace,
+    feature_document: &Path,
+    kind: &str,
+) -> Result<bool> {
+    let registry_path = workspace.spec_root.join("features/features.yaml");
+    let raw = fs::read_to_string(&registry_path).with_context(|| {
+        format!(
+            "failed to read feature registry `{}`",
+            registry_path.display()
+        )
+    })?;
+    let registry: FeatureRegistryDocument = serde_yaml::from_str(&raw).with_context(|| {
+        format!(
+            "failed to parse feature registry from `{}`",
+            registry_path.display()
+        )
+    })?;
+    let relative = feature_document
+        .strip_prefix(workspace.spec_root.join("features"))
+        .with_context(|| {
+            format!(
+                "feature document `{}` must stay under `{}`",
+                feature_document.display(),
+                workspace.spec_root.join("features").display()
+            )
+        })?;
+    let portable = path_label(relative);
+
+    if let Some(existing) = registry
+        .files
+        .iter()
+        .find(|entry| path_label(&entry.file) == portable)
+    {
+        if existing.kind != kind {
+            bail!(
+                "feature registry already tracks `{portable}` under kind `{}`",
+                existing.kind
+            );
+        }
+        return Ok(false);
+    }
+
+    let mut updated = raw;
+    while updated.ends_with('\n') {
+        updated.pop();
+    }
+    updated.push_str(&format!("\n  - kind: {kind}\n    file: {portable}\n"));
+    fs::write(&registry_path, updated).with_context(|| {
+        format!(
+            "failed to update feature registry `{}`",
+            registry_path.display()
+        )
+    })?;
+    Ok(true)
+}
+
+fn print_add_summary(
+    workspace: &Workspace,
+    layer: LookupKind,
+    id: &str,
+    target: &Path,
+    created_target_file: bool,
+    registry_updated: bool,
+) {
+    let action = if created_target_file {
+        "created"
+    } else {
+        "updated"
+    };
+    println!(
+        "{action} {} stub `{id}` in {}",
+        layer.label(),
+        display_workspace_path(workspace, target)
+    );
+    if registry_updated {
+        println!(
+            "updated {}",
+            display_workspace_path(
+                workspace,
+                &workspace.spec_root.join("features/features.yaml")
+            )
+        );
+    }
+    println!();
+    println!("Next steps:");
+    println!("  1. Edit the generated stub fields and reciprocal links");
+    println!(
+        "  2. Run `syu validate {}` once the new item is linked",
+        shell_quote_path(&workspace.root)
+    );
+}
+
+fn display_workspace_path(workspace: &Workspace, path: &Path) -> String {
+    path.strip_prefix(&workspace.root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn path_label(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn default_title(layer: LookupKind) -> String {
+    match layer {
+        LookupKind::Philosophy => "New philosophy".to_string(),
+        LookupKind::Policy => "New policy".to_string(),
+        LookupKind::Requirement => "New requirement".to_string(),
+        LookupKind::Feature => "New feature".to_string(),
+    }
+}
+
+fn default_folder_slug(layer: LookupKind) -> String {
+    match layer {
+        LookupKind::Philosophy => "philosophy".to_string(),
+        LookupKind::Policy => "policies".to_string(),
+        LookupKind::Requirement | LookupKind::Feature => "core".to_string(),
+    }
+}
+
+fn title_case_tokens(tokens: &[&str]) -> String {
+    tokens
+        .iter()
+        .map(|segment| title_case_slug(&segment.to_ascii_lowercase()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn title_case_slug(slug: &str) -> String {
+    slug.split('-')
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let mut chars = segment.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            format!("{}{}", first.to_ascii_uppercase(), chars.as_str())
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use crate::{cli::LookupKind, config::SyuConfig, workspace::Workspace};
+
+    use super::{
+        ParsedId, default_document_path, normalize_definition_id, normalize_feature_kind,
+        resolve_explicit_file, title_case_slug,
+    };
+
+    #[test]
+    fn normalize_definition_id_enforces_expected_prefixes() {
+        assert_eq!(
+            normalize_definition_id("req-auth-001", LookupKind::Requirement)
+                .expect("requirement ids should normalize"),
+            "REQ-AUTH-001"
+        );
+        assert!(normalize_definition_id("FEAT-AUTH-001", LookupKind::Requirement).is_err());
+        assert!(normalize_definition_id("REQ-AUTH", LookupKind::Requirement).is_err());
+    }
+
+    #[test]
+    fn parsed_ids_infer_title_folder_and_file_slugs() {
+        let parsed = ParsedId::parse(LookupKind::Feature, "FEAT-AUTH-LOGIN-001")
+            .expect("feature ids should parse");
+        assert_eq!(parsed.typed_prefix, "FEAT-AUTH-LOGIN");
+        assert_eq!(parsed.title, "Auth Login");
+        assert_eq!(parsed.folder_slug, "auth");
+        assert_eq!(parsed.file_slug, "login");
+    }
+
+    #[test]
+    fn default_document_path_uses_kind_folder_for_features() {
+        let parsed =
+            ParsedId::parse(LookupKind::Feature, "FEAT-AUTH-LOGIN-001").expect("feature id");
+        assert_eq!(
+            default_document_path(LookupKind::Feature, &parsed, Some("auth")),
+            PathBuf::from("features/auth/login.yaml")
+        );
+    }
+
+    #[test]
+    fn resolve_explicit_file_accepts_workspace_and_spec_relative_paths() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = Workspace {
+            root: tempdir.path().join("workspace"),
+            spec_root: tempdir.path().join("workspace/docs/spec"),
+            config: SyuConfig::default(),
+            philosophies: Vec::new(),
+            policies: Vec::new(),
+            requirements: Vec::new(),
+            features: Vec::new(),
+        };
+
+        assert_eq!(
+            resolve_explicit_file(
+                &workspace,
+                std::path::Path::new("docs/spec/features/auth/login.yaml")
+            )
+            .expect("workspace-relative paths should work"),
+            workspace.spec_root.join("features/auth/login.yaml")
+        );
+        assert_eq!(
+            resolve_explicit_file(&workspace, std::path::Path::new("features/auth/login.yaml"))
+                .expect("spec-relative paths should work"),
+            workspace.spec_root.join("features/auth/login.yaml")
+        );
+    }
+
+    #[test]
+    fn normalize_feature_kind_rejects_invalid_values() {
+        assert_eq!(
+            normalize_feature_kind("auth-login").expect("valid kind"),
+            "auth-login"
+        );
+        assert!(normalize_feature_kind("Auth").is_err());
+        assert!(normalize_feature_kind("auth login").is_err());
+    }
+
+    #[test]
+    fn title_case_slug_expands_hyphenated_names() {
+        assert_eq!(title_case_slug("auth-login"), "Auth Login");
+    }
+}

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -40,11 +40,13 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
     }
 
     let feature_kind = match args.layer {
-        LookupKind::Feature => Some(normalize_feature_kind(
-            args.kind
+        LookupKind::Feature => {
+            let kind = args
+                .kind
                 .as_deref()
-                .unwrap_or(parsed_id.folder_slug.as_str()),
-        )?),
+                .unwrap_or(parsed_id.folder_slug.as_str());
+            Some(normalize_feature_kind(kind)?)
+        }
         _ => None,
     };
     let target = resolve_target_path(
@@ -55,17 +57,22 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
         feature_kind.as_deref(),
     )?;
     let created_target_file = !target.absolute.exists();
-
-    write_stub_document(args.layer, &parsed_id, feature_kind.as_deref(), &target)?;
-
-    let registry_updated = if args.layer == LookupKind::Feature {
-        update_feature_registry(
+    let feature_registry_update = if args.layer == LookupKind::Feature {
+        Some(prepare_feature_registry_update(
             &workspace,
             &target.absolute,
             feature_kind
                 .as_deref()
                 .expect("features require a registry kind"),
-        )?
+        )?)
+    } else {
+        None
+    };
+
+    write_stub_document(args.layer, &parsed_id, feature_kind.as_deref(), &target)?;
+
+    let registry_updated = if let Some(update) = feature_registry_update {
+        write_feature_registry_update(update)?
     } else {
         false
     };
@@ -127,6 +134,11 @@ impl ParsedId {
 #[derive(Debug, Clone)]
 struct TargetPath {
     absolute: PathBuf,
+}
+
+struct FeatureRegistryUpdate {
+    path: PathBuf,
+    updated_contents: Option<String>,
 }
 
 fn normalize_definition_id(raw: &str, layer: LookupKind) -> Result<String> {
@@ -255,16 +267,7 @@ fn resolve_explicit_file(workspace: &Workspace, raw: &Path) -> Result<PathBuf> {
         return Ok(workspace_relative);
     }
 
-    let spec_relative = workspace.spec_root.join(&normalized);
-    if spec_relative.starts_with(&workspace.spec_root) {
-        return Ok(spec_relative);
-    }
-
-    bail!(
-        "`--file` must point inside `{}` or be relative to that spec root: `{}`",
-        workspace.spec_root.display(),
-        raw.display()
-    );
+    Ok(workspace.spec_root.join(normalized))
 }
 
 fn ensure_target_within_spec_root(
@@ -315,9 +318,11 @@ fn write_stub_document(
     feature_kind: Option<&str>,
     target: &TargetPath,
 ) -> Result<()> {
-    if let Some(parent) = target.absolute.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    target
+        .absolute
+        .parent()
+        .map(fs::create_dir_all)
+        .transpose()?;
 
     if target.absolute.exists() {
         validate_existing_document(layer, &target.absolute, parsed_id)?;
@@ -441,11 +446,11 @@ fn render_item_block(layer: LookupKind, parsed_id: &ParsedId) -> String {
     }
 }
 
-fn update_feature_registry(
+fn prepare_feature_registry_update(
     workspace: &Workspace,
     feature_document: &Path,
     kind: &str,
-) -> Result<bool> {
+) -> Result<FeatureRegistryUpdate> {
     let registry_path = workspace.spec_root.join("features/features.yaml");
     let raw = fs::read_to_string(&registry_path).with_context(|| {
         format!(
@@ -481,7 +486,10 @@ fn update_feature_registry(
                 existing.kind
             );
         }
-        return Ok(false);
+        return Ok(FeatureRegistryUpdate {
+            path: registry_path,
+            updated_contents: None,
+        });
     }
 
     let mut updated = raw;
@@ -489,10 +497,20 @@ fn update_feature_registry(
         updated.pop();
     }
     updated.push_str(&format!("\n  - kind: {kind}\n    file: {portable}\n"));
-    fs::write(&registry_path, updated).with_context(|| {
+    Ok(FeatureRegistryUpdate {
+        path: registry_path,
+        updated_contents: Some(updated),
+    })
+}
+
+fn write_feature_registry_update(update: FeatureRegistryUpdate) -> Result<bool> {
+    let Some(updated) = update.updated_contents else {
+        return Ok(false);
+    };
+    fs::write(&update.path, updated).with_context(|| {
         format!(
             "failed to update feature registry `{}`",
-            registry_path.display()
+            update.path.display()
         )
     })?;
     Ok(true)
@@ -575,9 +593,7 @@ fn title_case_slug(slug: &str) -> String {
         .filter(|segment| !segment.is_empty())
         .map(|segment| {
             let mut chars = segment.chars();
-            let Some(first) = chars.next() else {
-                return String::new();
-            };
+            let first = chars.next().expect("empty segments are filtered out");
             format!("{}{}", first.to_ascii_uppercase(), chars.as_str())
         })
         .collect::<Vec<_>>()
@@ -586,16 +602,48 @@ fn title_case_slug(slug: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
 
-    use tempfile::tempdir;
+    use tempfile::{TempDir, tempdir};
 
     use crate::{cli::LookupKind, config::SyuConfig, workspace::Workspace};
 
     use super::{
-        ParsedId, default_document_path, normalize_definition_id, normalize_feature_kind,
-        resolve_explicit_file, title_case_slug,
+        FeatureRegistryUpdate, ParsedId, TargetPath, default_document_path, default_folder_slug,
+        default_title, ensure_target_within_spec_root, normalize_definition_id,
+        normalize_feature_kind, prepare_feature_registry_update, render_item_block,
+        render_new_document, resolve_explicit_file, title_case_slug, validate_existing_document,
+        write_feature_registry_update, write_stub_document,
     };
+
+    fn test_workspace() -> (TempDir, Workspace) {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let root = tempdir.path().join("workspace");
+        let spec_root = root.join("docs/spec");
+        fs::create_dir_all(&spec_root).expect("spec root should be created");
+        (
+            tempdir,
+            Workspace {
+                root,
+                spec_root,
+                config: SyuConfig::default(),
+                philosophies: Vec::new(),
+                policies: Vec::new(),
+                requirements: Vec::new(),
+                features: Vec::new(),
+            },
+        )
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("parent directory should exist");
+        }
+        fs::write(path, contents).expect("test fixture file should be written");
+    }
 
     #[test]
     fn normalize_definition_id_enforces_expected_prefixes() {
@@ -606,6 +654,16 @@ mod tests {
         );
         assert!(normalize_definition_id("FEAT-AUTH-001", LookupKind::Requirement).is_err());
         assert!(normalize_definition_id("REQ-AUTH", LookupKind::Requirement).is_err());
+    }
+
+    #[test]
+    fn normalize_definition_id_covers_policy_and_invalid_character_cases() {
+        assert_eq!(
+            normalize_definition_id("pol-001", LookupKind::Policy)
+                .expect("policy ids should normalize"),
+            "POL-001"
+        );
+        assert!(normalize_definition_id("POL 001", LookupKind::Policy).is_err());
     }
 
     #[test]
@@ -629,17 +687,21 @@ mod tests {
     }
 
     #[test]
+    fn helper_defaults_cover_policy_and_feature_layers() {
+        let parsed = ParsedId::parse(LookupKind::Policy, "POL-001").expect("policy id");
+
+        assert_eq!(
+            default_document_path(LookupKind::Policy, &parsed, None),
+            PathBuf::from("policies/policies.yaml")
+        );
+        assert_eq!(default_title(LookupKind::Policy), "New policy");
+        assert_eq!(default_title(LookupKind::Feature), "New feature");
+        assert_eq!(default_folder_slug(LookupKind::Policy), "policies");
+    }
+
+    #[test]
     fn resolve_explicit_file_accepts_workspace_and_spec_relative_paths() {
-        let tempdir = tempdir().expect("tempdir should exist");
-        let workspace = Workspace {
-            root: tempdir.path().join("workspace"),
-            spec_root: tempdir.path().join("workspace/docs/spec"),
-            config: SyuConfig::default(),
-            philosophies: Vec::new(),
-            policies: Vec::new(),
-            requirements: Vec::new(),
-            features: Vec::new(),
-        };
+        let (_tempdir, workspace) = test_workspace();
 
         assert_eq!(
             resolve_explicit_file(
@@ -657,6 +719,14 @@ mod tests {
     }
 
     #[test]
+    fn resolve_explicit_file_rejects_absolute_and_invalid_paths() {
+        let (_tempdir, workspace) = test_workspace();
+
+        assert!(resolve_explicit_file(&workspace, Path::new("/tmp/escape.yaml")).is_err());
+        assert!(resolve_explicit_file(&workspace, Path::new("../escape.yaml")).is_err());
+    }
+
+    #[test]
     fn normalize_feature_kind_rejects_invalid_values() {
         assert_eq!(
             normalize_feature_kind("auth-login").expect("valid kind"),
@@ -669,5 +739,214 @@ mod tests {
     #[test]
     fn title_case_slug_expands_hyphenated_names() {
         assert_eq!(title_case_slug("auth-login"), "Auth Login");
+    }
+
+    #[test]
+    fn ensure_target_within_spec_root_rejects_invalid_targets() {
+        let (_tempdir, workspace) = test_workspace();
+
+        assert!(
+            ensure_target_within_spec_root(
+                &workspace,
+                LookupKind::Requirement,
+                &workspace.root.join("outside.yaml")
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_target_within_spec_root(
+                &workspace,
+                LookupKind::Requirement,
+                &workspace.spec_root.join("requirements/core.txt")
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_target_within_spec_root(
+                &workspace,
+                LookupKind::Policy,
+                &workspace.spec_root.join("requirements/core.yaml")
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_target_within_spec_root(
+                &workspace,
+                LookupKind::Policy,
+                &workspace.spec_root.join("policies/policies.yaml")
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn write_stub_document_creates_new_parent_directories() {
+        let (_tempdir, workspace) = test_workspace();
+        let parsed = ParsedId::parse(LookupKind::Requirement, "REQ-AUTH-001").expect("id");
+        let target = TargetPath {
+            absolute: workspace.spec_root.join("requirements/auth/auth.yaml"),
+        };
+
+        write_stub_document(LookupKind::Requirement, &parsed, None, &target)
+            .expect("stub write should succeed");
+
+        assert!(target.absolute.exists());
+    }
+
+    #[test]
+    fn validate_existing_document_reports_read_errors() {
+        let (_tempdir, workspace) = test_workspace();
+        let parsed = ParsedId::parse(LookupKind::Philosophy, "PHIL-001").expect("id");
+
+        assert!(
+            validate_existing_document(
+                LookupKind::Philosophy,
+                &workspace.spec_root.join("philosophy/missing.yaml"),
+                &parsed
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_existing_document_rejects_invalid_yaml_for_all_layers() {
+        let (_tempdir, workspace) = test_workspace();
+        let invalid = "not: [valid";
+
+        let philosophy_path = workspace.spec_root.join("philosophy/foundation.yaml");
+        write_file(&philosophy_path, invalid);
+        assert!(
+            validate_existing_document(
+                LookupKind::Philosophy,
+                &philosophy_path,
+                &ParsedId::parse(LookupKind::Philosophy, "PHIL-001").expect("philosophy id")
+            )
+            .is_err()
+        );
+
+        let policy_path = workspace.spec_root.join("policies/policies.yaml");
+        write_file(&policy_path, invalid);
+        assert!(
+            validate_existing_document(
+                LookupKind::Policy,
+                &policy_path,
+                &ParsedId::parse(LookupKind::Policy, "POL-001").expect("policy id")
+            )
+            .is_err()
+        );
+
+        let requirement_path = workspace.spec_root.join("requirements/core/core.yaml");
+        write_file(&requirement_path, invalid);
+        assert!(
+            validate_existing_document(
+                LookupKind::Requirement,
+                &requirement_path,
+                &ParsedId::parse(LookupKind::Requirement, "REQ-CORE-001").expect("requirement id")
+            )
+            .is_err()
+        );
+
+        let feature_path = workspace.spec_root.join("features/core/core.yaml");
+        write_file(&feature_path, invalid);
+        assert!(
+            validate_existing_document(
+                LookupKind::Feature,
+                &feature_path,
+                &ParsedId::parse(LookupKind::Feature, "FEAT-CORE-001").expect("feature id")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_existing_document_rejects_requirement_prefix_mismatches() {
+        let (_tempdir, workspace) = test_workspace();
+        let path = workspace.spec_root.join("requirements/core/core.yaml");
+        write_file(
+            &path,
+            "category: Core Requirements\nprefix: REQ-OTHER\n\nrequirements:\n  - id: REQ-OTHER-001\n    title: Other\n    description: |\n      Example.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features: []\n    tests: {}\n",
+        );
+
+        assert!(
+            validate_existing_document(
+                LookupKind::Requirement,
+                &path,
+                &ParsedId::parse(LookupKind::Requirement, "REQ-CORE-001").expect("requirement id")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_existing_document_accepts_matching_requirement_prefixes() {
+        let (_tempdir, workspace) = test_workspace();
+        let path = workspace.spec_root.join("requirements/core/core.yaml");
+        write_file(
+            &path,
+            "category: Core Requirements\nprefix: REQ-CORE\n\nrequirements:\n  - id: REQ-CORE-001\n    title: Core\n    description: |\n      Example.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features: []\n    tests: {}\n",
+        );
+
+        validate_existing_document(
+            LookupKind::Requirement,
+            &path,
+            &ParsedId::parse(LookupKind::Requirement, "REQ-CORE-001").expect("requirement id"),
+        )
+        .expect("matching prefixes should validate");
+    }
+
+    #[test]
+    fn render_helpers_cover_non_requirement_layers() {
+        let philosophy = ParsedId::parse(LookupKind::Philosophy, "PHIL-001").expect("id");
+        let policy = ParsedId::parse(LookupKind::Policy, "POL-001").expect("id");
+        let feature = ParsedId::parse(LookupKind::Feature, "FEAT-AUTH-LOGIN-001").expect("id");
+
+        assert!(
+            render_new_document(LookupKind::Philosophy, &philosophy, None)
+                .contains("category: Philosophy")
+        );
+        assert!(
+            render_new_document(LookupKind::Policy, &policy, None).contains("category: Policies")
+        );
+        assert!(render_item_block(LookupKind::Policy, &policy).contains("linked_requirements"));
+        assert!(
+            render_new_document(LookupKind::Feature, &feature, Some("auth"))
+                .contains("category: Auth Features")
+        );
+    }
+
+    #[test]
+    fn prepare_feature_registry_update_reports_read_parse_and_root_errors() {
+        let (_tempdir, workspace) = test_workspace();
+        let feature_path = workspace.spec_root.join("features/auth/login.yaml");
+
+        assert!(prepare_feature_registry_update(&workspace, &feature_path, "auth").is_err());
+
+        let registry_path = workspace.spec_root.join("features/features.yaml");
+        write_file(&registry_path, "version: 1\nfiles: [");
+        assert!(prepare_feature_registry_update(&workspace, &feature_path, "auth").is_err());
+
+        write_file(
+            &registry_path,
+            "version: \"1\"\nfiles:\n  - kind: core\n    file: core/core.yaml\n",
+        );
+        assert!(
+            prepare_feature_registry_update(
+                &workspace,
+                &workspace.spec_root.join("requirements/core/core.yaml"),
+                "auth"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn write_feature_registry_update_reports_write_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let update = FeatureRegistryUpdate {
+            path: tempdir.path().to_path_buf(),
+            updated_contents: Some("version: \"1\"\nfiles: []\n".to_string()),
+        };
+
+        assert!(write_feature_registry_update(update).is_err());
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 // FEAT-BROWSE-001
 
+pub mod add;
 pub mod app;
 pub mod browse;
 pub mod check;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+// FEAT-ADD-001
 // FEAT-BROWSE-001
 
 pub mod cli;
@@ -25,6 +26,7 @@ enum Dispatch {
     Validate(cli::ValidateArgs),
     Report(cli::ReportArgs),
     Init(cli::InitArgs),
+    Add(cli::AddArgs),
 }
 
 fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) -> Dispatch {
@@ -40,6 +42,7 @@ fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) ->
         Some(cli::Commands::Validate(args)) => Dispatch::Validate(args),
         Some(cli::Commands::Report(args)) => Dispatch::Report(args),
         Some(cli::Commands::Init(args)) => Dispatch::Init(args),
+        Some(cli::Commands::Add(args)) => Dispatch::Add(args),
     }
 }
 
@@ -58,6 +61,7 @@ fn run_dispatch(dispatch: Dispatch) -> Result<i32> {
         Dispatch::Validate(args) => command::check::run_check_command(&args),
         Dispatch::Report(args) => command::report::run_report_command(&args),
         Dispatch::Init(args) => command::init::run_init_command(&args),
+        Dispatch::Add(args) => command::add::run_add_command(&args),
     }
 }
 
@@ -74,7 +78,9 @@ pub fn run() -> Result<i32> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::cli::{AppArgs, Cli, Commands, ListArgs, OutputFormat, ShowArgs};
+    use crate::cli::{
+        AddArgs, AppArgs, Cli, Commands, ListArgs, LookupKind, OutputFormat, ShowArgs,
+    };
 
     // REQ-CORE-015
     #[test]
@@ -148,6 +154,34 @@ mod tests {
                 if id == "REQ-CORE-018"
                     && workspace == Path::new("workspace")
                     && format == OutputFormat::Text
+        ));
+    }
+
+    #[test]
+    // REQ-CORE-020
+    fn dispatches_add_subcommands_without_rewriting_them() {
+        let add = super::dispatch(
+            Cli {
+                command: Some(Commands::Add(AddArgs {
+                    layer: LookupKind::Feature,
+                    id: "FEAT-AUTH-001".to_string(),
+                    workspace: PathBuf::from("workspace"),
+                    file: Some(PathBuf::from("docs/syu/features/auth/login.yaml")),
+                    kind: Some("auth".to_string()),
+                })),
+            },
+            true,
+            true,
+        );
+
+        assert!(matches!(
+            add,
+            super::Dispatch::Add(crate::cli::AddArgs { layer, id, workspace, file, kind })
+                if layer == LookupKind::Feature
+                    && id == "FEAT-AUTH-001"
+                    && workspace == Path::new("workspace")
+                    && file == Some(PathBuf::from("docs/syu/features/auth/login.yaml"))
+                    && kind.as_deref() == Some("auth")
         ));
     }
 }

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -84,6 +84,142 @@ fn add_command_updates_the_feature_registry_for_new_feature_files() {
 
 #[test]
 // REQ-CORE-020
+fn add_command_defaults_feature_kind_from_the_feature_id_prefix() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "feature", "FEAT-AUTH-LOGIN-001"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let feature_file = workspace.join("docs/syu/features/auth/login.yaml");
+    let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(feature_file.exists(), "feature file should be created");
+    assert!(registry.contains("kind: auth"));
+    assert!(registry.contains("file: auth/login.yaml"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_reuses_existing_feature_registry_entries_for_shared_files() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let first = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "add",
+            "feature",
+            "FEAT-AUTH-LOGIN-001",
+            "--kind",
+            "auth",
+            "--file",
+            "features/auth/shared.yaml",
+        ])
+        .arg(&workspace)
+        .output()
+        .expect("first command should run");
+    assert!(first.status.success());
+
+    let second = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "add",
+            "feature",
+            "FEAT-AUTH-RESET-001",
+            "--kind",
+            "auth",
+            "--file",
+            "features/auth/shared.yaml",
+        ])
+        .arg(&workspace)
+        .output()
+        .expect("second command should run");
+    assert!(second.status.success());
+
+    let feature_file = fs::read_to_string(workspace.join("docs/syu/features/auth/shared.yaml"))
+        .expect("shared feature file should exist");
+    let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(feature_file.contains("id: FEAT-AUTH-LOGIN-001"));
+    assert!(feature_file.contains("id: FEAT-AUTH-RESET-001"));
+    assert_eq!(registry.matches("file: auth/shared.yaml").count(), 1);
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_does_not_mutate_feature_files_when_registry_kind_conflicts() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let feature_path = workspace.join("docs/syu/features/core/core.yaml");
+    let before = fs::read_to_string(&feature_path).expect("core feature file should exist");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "add",
+            "feature",
+            "FEAT-AUTH-NEW-001",
+            "--kind",
+            "auth",
+            "--file",
+            "features/core/core.yaml",
+        ])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("feature registry already tracks `core/core.yaml` under kind `core`")
+    );
+    assert_eq!(
+        fs::read_to_string(&feature_path).expect("core feature file should remain readable"),
+        before
+    );
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_rejects_feature_registry_paths_as_targets() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "add",
+            "feature",
+            "FEAT-AUTH-001",
+            "--kind",
+            "auth",
+            "--file",
+            "features/features.yaml",
+        ])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("feature stubs must use a feature document path")
+    );
+}
+
+#[test]
+// REQ-CORE-020
 fn add_command_honors_explicit_files_in_custom_spec_roots() {
     let tempdir = tempdir().expect("tempdir should exist");
     let workspace = tempdir.path().join("workspace");

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -1,0 +1,155 @@
+use assert_cmd::cargo::CommandCargoExt;
+use std::{fs, path::Path, process::Command};
+use tempfile::tempdir;
+
+fn init_workspace(workspace: &Path, extra_args: &[&str]) {
+    let mut command = Command::cargo_bin("syu").expect("binary should build");
+    command.arg("init").arg(workspace);
+    command.args(extra_args);
+    let output = command.output().expect("init should run");
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_appends_philosophy_to_the_default_file() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "philosophy", "PHIL-002"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let file = fs::read_to_string(workspace.join("docs/syu/philosophy/foundation.yaml"))
+        .expect("philosophy file should exist");
+    assert!(file.contains("- id: PHIL-002"));
+    assert!(file.contains("title: New philosophy"));
+    assert!(file.contains("linked_policies: []"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_creates_requirement_files_from_the_id_prefix() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "requirement", "REQ-AUTH-001"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let file = workspace.join("docs/syu/requirements/auth/auth.yaml");
+    let contents = fs::read_to_string(&file).expect("requirement file should exist");
+    assert!(contents.contains("prefix: REQ-AUTH"));
+    assert!(contents.contains("id: REQ-AUTH-001"));
+    assert!(contents.contains("status: planned"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_updates_the_feature_registry_for_new_feature_files() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "feature", "FEAT-AUTH-LOGIN-001", "--kind", "auth"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let feature_file = workspace.join("docs/syu/features/auth/login.yaml");
+    let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(feature_file.exists(), "feature file should be created");
+    assert!(registry.contains("kind: auth"));
+    assert!(registry.contains("file: auth/login.yaml"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_honors_explicit_files_in_custom_spec_roots() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &["--spec-root", "docs/spec"]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "add",
+            "feature",
+            "FEAT-AUTH-001",
+            "--kind",
+            "auth",
+            "--file",
+            "docs/spec/features/auth/flows.yaml",
+        ])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let feature_file = workspace.join("docs/spec/features/auth/flows.yaml");
+    let registry = fs::read_to_string(workspace.join("docs/spec/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(
+        feature_file.exists(),
+        "explicit feature file should be created"
+    );
+    assert!(registry.contains("file: auth/flows.yaml"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_rejects_duplicate_ids() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "requirement", "REQ-001"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("already exists"));
+}
+
+#[test]
+// REQ-CORE-020
+fn add_command_rejects_feature_kind_for_non_feature_layers() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "requirement", "REQ-AUTH-001", "--kind", "auth"])
+        .arg(&workspace)
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("only supported when scaffolding features")
+    );
+}

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -1,3 +1,5 @@
+// REQ-CORE-020
+
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
 
@@ -26,7 +28,9 @@ fn root_help_includes_start_here_guidance() {
 
 #[test]
 fn workspace_help_uses_current_directory_default_consistently() {
-    for command in ["browse", "show", "app", "validate", "check", "report"] {
+    for command in [
+        "browse", "show", "app", "validate", "check", "report", "add",
+    ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
             .args([command, "--help"])
@@ -49,6 +53,22 @@ fn workspace_help_uses_current_directory_default_consistently() {
             "{command} help should not claim docs/syu is the workspace default",
         );
     }
+}
+
+#[test]
+fn add_help_mentions_explicit_file_and_feature_kind() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "add help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--file"));
+    assert!(stdout.contains("--kind"));
+    assert!(stdout.contains("FEAT-AUTH-LOGIN-001 --kind auth"));
 }
 
 #[test]

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -231,9 +231,10 @@ fn repository_declares_documentation_guides() {
 
     assert!(readme.contains("docs/guide/concepts.md"));
     assert!(readme.contains("Step 0: required"));
-    assert!(readme.contains("# 2. Add your spec items"));
+    assert!(readme.contains("Add spec items with generated YAML stubs"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
+    assert!(readme.contains("syu add"));
     assert!(readme.contains("--id-prefix"));
     assert!(readme.contains("--template rust-only"));
     assert!(readme.contains("syu validate"));


### PR DESCRIPTION
## Summary\n- add a new `syu add` command that scaffolds philosophy, policy, requirement, and feature YAML stubs after init\n- infer default document paths from IDs, honor custom `spec.root` layouts, and update the feature registry when new feature files are created\n- update guides, README, checked-in spec docs, generated docs, and tests around the new authoring workflow\n\n## Validation\n- bash scripts/ci/quality-gates.sh\n- cargo run -- add requirement REQ-AUTH-001 <temp workspace>\n- cargo run -- add feature FEAT-AUTH-LOGIN-001 <temp workspace> --kind auth\n\nCloses #148