### PR TITLE
Add interactive syu add prompts

### DIFF
--- a/docs/generated/site-spec/features/cli/add.md
+++ b/docs/generated/site-spec/features/cli/add.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/add.yaml"
 
 - **id**: FEAT-ADD-001
   - **title**: Follow-up spec authoring scaffold
-  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-020
@@ -41,7 +41,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -217,7 +217,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work.
+      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
+      for it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -440,7 +442,9 @@ requirements:
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work.
+      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
+      for it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -112,6 +112,17 @@ syu add requirement REQ-AUTH-001
 syu add feature FEAT-AUTH-LOGIN-001 --kind auth
 ```
 
+Prefer a guided terminal flow for the next item?
+
+```bash
+syu add requirement --interactive
+syu add feature path/to/workspace --interactive
+```
+
+When you omit the ID in a terminal, `syu add` prompts for it. With
+`--interactive`, it also lets you confirm the feature kind and override the
+target YAML path before writing the stub.
+
 These commands generate correctly shaped YAML stubs, infer a default document
 path from the ID, and keep feature discovery explicit by updating the feature
 registry automatically when a new feature document is created. You can override

--- a/docs/syu/features/cli/add.yaml
+++ b/docs/syu/features/cli/add.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init while keeping feature registry maintenance explicit.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -195,7 +195,9 @@ requirements:
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work.
+      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
+      for it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,9 @@ Examples:
   syu add philosophy PHIL-002
   syu add policy POL-002 --file docs/syu/policies/policies.yaml
   syu add requirement REQ-AUTH-001
+  syu add requirement --interactive
   syu add feature FEAT-AUTH-LOGIN-001 --kind auth
+  syu add feature path/to/workspace --interactive
   syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.yaml";
 
 const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configured spec tree";
@@ -387,13 +389,19 @@ pub struct AddArgs {
     pub layer: LookupKind,
 
     #[arg(
-        help = "New definition ID to scaffold (for example REQ-AUTH-001 or FEAT-AUTH-LOGIN-001)"
+        help = "New definition ID to scaffold (for example REQ-AUTH-001 or FEAT-AUTH-LOGIN-001). Omit in a terminal to be prompted."
     )]
-    pub id: String,
+    pub id: Option<String>,
 
     #[arg(help = WORKSPACE_HELP)]
     #[arg(default_value = ".")]
     pub workspace: PathBuf,
+
+    #[arg(
+        help = "Prompt for missing values in a terminal; when the ID is omitted, syu also prompts for it"
+    )]
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub interactive: bool,
 
     #[arg(
         long,
@@ -605,9 +613,23 @@ mod tests {
         let rendered = format!("{cli:?}");
         assert!(rendered.contains("command: Some(Add("));
         assert!(rendered.contains("layer: Feature"));
-        assert!(rendered.contains("id: \"FEAT-AUTH-001\""));
+        assert!(rendered.contains("id: Some(\"FEAT-AUTH-001\")"));
         assert!(rendered.contains("workspace: \".\""));
+        assert!(rendered.contains("interactive: false"));
         assert!(rendered.contains("file: Some(\"docs/syu/features/auth/login.yaml\")"));
         assert!(rendered.contains("kind: Some(\"auth\")"));
+    }
+
+    #[test]
+    fn add_args_support_interactive_mode_without_an_id() {
+        let cli = Cli::try_parse_from(["syu", "add", "requirement", "--interactive"])
+            .expect("interactive add args should parse");
+
+        let rendered = format!("{cli:?}");
+        assert!(rendered.contains("command: Some(Add("));
+        assert!(rendered.contains("layer: Requirement"));
+        assert!(rendered.contains("id: None"));
+        assert!(rendered.contains("workspace: \".\""));
+        assert!(rendered.contains("interactive: true"));
     }
 }

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -21,6 +21,12 @@ use crate::{
 
 use super::{lookup::WorkspaceLookup, shell_quote_path};
 
+const ADD_MISSING_ID_NON_TTY_MESSAGE: &str = "`syu add` needs a definition ID when stdin/stdout are not terminals; pass the ID explicitly or rerun in a terminal to be prompted";
+const ADD_INTERACTIVE_KIND_NON_TTY_MESSAGE: &str =
+    "`syu add --interactive` requires a terminal to prompt for a feature kind";
+const ADD_INTERACTIVE_FILE_NON_TTY_MESSAGE: &str =
+    "`syu add --interactive` requires a terminal to prompt for a file path";
+
 pub fn run_add_command(args: &AddArgs) -> Result<i32> {
     if args.layer != LookupKind::Feature && args.kind.is_some() {
         bail!("`--kind` is only supported when scaffolding features");
@@ -59,12 +65,8 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
         None
     };
 
-    write_stub_document(
-        args.layer,
-        &resolved.parsed_id,
-        resolved.feature_kind.as_deref(),
-        &target,
-    )?;
+    let feature_kind = resolved.feature_kind.as_deref();
+    write_stub_document(args.layer, &resolved.parsed_id, feature_kind, &target)?;
 
     let registry_updated = if let Some(update) = feature_registry_update {
         write_feature_registry_update(update)?
@@ -144,17 +146,55 @@ struct FeatureRegistryUpdate {
     updated_contents: Option<String>,
 }
 
+trait AddPromptIo {
+    fn is_terminal(&self) -> bool;
+    fn prompt_line(&mut self, label: &str, default: Option<&str>) -> Result<String>;
+}
+
+struct StdioPromptIo;
+
+impl AddPromptIo for StdioPromptIo {
+    fn is_terminal(&self) -> bool {
+        io::stdin().is_terminal() && io::stdout().is_terminal()
+    }
+
+    fn prompt_line(&mut self, label: &str, default: Option<&str>) -> Result<String> {
+        match default {
+            Some(value) => print!("{label} [{value}]: "),
+            None => print!("{label}: "),
+        }
+        io::stdout()
+            .flush()
+            .context("failed to flush interactive `syu add` prompt")?;
+
+        let mut input = String::new();
+        io::stdin()
+            .read_line(&mut input)
+            .context("failed to read interactive `syu add` input")?;
+        Ok(input.trim().to_string())
+    }
+}
+
 fn resolve_add_invocation(args: &AddArgs) -> Result<ResolvedAddInvocation> {
+    let mut prompt_io = StdioPromptIo;
+    resolve_add_invocation_with_prompt_io(args, &mut prompt_io)
+}
+
+fn resolve_add_invocation_with_prompt_io(
+    args: &AddArgs,
+    prompt_io: &mut impl AddPromptIo,
+) -> Result<ResolvedAddInvocation> {
     let (raw_id, workspace) = resolve_workspace_and_id(args)?;
     let parsed_id = match raw_id {
         Some(id) => ParsedId::parse(args.layer, &id)?,
-        None => prompt_for_parsed_id(args.layer)?,
+        None => prompt_for_parsed_id(args.layer, prompt_io)?,
     };
     let feature_kind = match args.layer {
-        LookupKind::Feature => Some(resolve_feature_kind(args, &parsed_id)?),
+        LookupKind::Feature => Some(resolve_feature_kind(args, &parsed_id, prompt_io)?),
         _ => None,
     };
-    let file = resolve_interactive_file_prompt(args, &parsed_id, feature_kind.as_deref())?;
+    let file =
+        resolve_interactive_file_prompt(args, &parsed_id, feature_kind.as_deref(), prompt_io)?;
 
     Ok(ResolvedAddInvocation {
         workspace,
@@ -183,16 +223,19 @@ fn resolve_workspace_and_id(args: &AddArgs) -> Result<(Option<String>, PathBuf)>
     Ok((id, workspace))
 }
 
-fn resolve_feature_kind(args: &AddArgs, parsed_id: &ParsedId) -> Result<String> {
+fn resolve_feature_kind(
+    args: &AddArgs,
+    parsed_id: &ParsedId,
+    prompt_io: &mut impl AddPromptIo,
+) -> Result<String> {
     if let Some(kind) = args.kind.as_deref() {
         return normalize_feature_kind(kind);
     }
     if args.interactive {
-        ensure_prompt_terminal(
-            "`syu add --interactive` requires a terminal to prompt for a feature kind",
-        )?;
+        ensure_prompt_terminal(prompt_io, ADD_INTERACTIVE_KIND_NON_TTY_MESSAGE)?;
         loop {
-            let raw = prompt_with_default("Feature kind", parsed_id.folder_slug.as_str())?;
+            let raw =
+                prompt_with_default(prompt_io, "Feature kind", parsed_id.folder_slug.as_str())?;
             match normalize_feature_kind(&raw) {
                 Ok(kind) => return Ok(kind),
                 Err(error) => eprintln!("{error:#}"),
@@ -207,6 +250,7 @@ fn resolve_interactive_file_prompt(
     args: &AddArgs,
     parsed_id: &ParsedId,
     feature_kind: Option<&str>,
+    prompt_io: &mut impl AddPromptIo,
 ) -> Result<Option<PathBuf>> {
     if let Some(file) = &args.file {
         return Ok(Some(file.clone()));
@@ -215,23 +259,18 @@ fn resolve_interactive_file_prompt(
         return Ok(None);
     }
 
-    ensure_prompt_terminal(
-        "`syu add --interactive` requires a terminal to prompt for a file path",
-    )?;
+    ensure_prompt_terminal(prompt_io, ADD_INTERACTIVE_FILE_NON_TTY_MESSAGE)?;
     let default_relative = default_document_path(args.layer, parsed_id, feature_kind);
-    Ok(
-        prompt_optional_path("YAML file", &default_relative.display().to_string())?
-            .map(PathBuf::from),
-    )
+    let default_relative_display = default_relative.display().to_string();
+    let prompted_path = prompt_optional_path(prompt_io, "YAML file", &default_relative_display)?;
+    Ok(prompted_path.map(PathBuf::from))
 }
 
-fn prompt_for_parsed_id(layer: LookupKind) -> Result<ParsedId> {
-    ensure_prompt_terminal(
-        "interactive `syu add` prompts require a terminal; provide the ID explicitly when stdin/stdout are not terminals",
-    )?;
+fn prompt_for_parsed_id(layer: LookupKind, prompt_io: &mut impl AddPromptIo) -> Result<ParsedId> {
+    ensure_prompt_terminal(prompt_io, ADD_MISSING_ID_NON_TTY_MESSAGE)?;
 
     loop {
-        let raw = prompt_required("Definition ID")?;
+        let raw = prompt_required(prompt_io, "Definition ID")?;
         match ParsedId::parse(layer, &raw) {
             Ok(parsed) => return Ok(parsed),
             Err(error) => eprintln!("{error:#}"),
@@ -239,17 +278,17 @@ fn prompt_for_parsed_id(layer: LookupKind) -> Result<ParsedId> {
     }
 }
 
-fn ensure_prompt_terminal(message: &str) -> Result<()> {
-    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+fn ensure_prompt_terminal(prompt_io: &impl AddPromptIo, message: &str) -> Result<()> {
+    if prompt_io.is_terminal() {
         return Ok(());
     }
 
     bail!("{message}");
 }
 
-fn prompt_required(label: &str) -> Result<String> {
+fn prompt_required(prompt_io: &mut impl AddPromptIo, label: &str) -> Result<String> {
     loop {
-        let raw = prompt_line(label, None)?;
+        let raw = prompt_io.prompt_line(label, None)?;
         if !raw.is_empty() {
             return Ok(raw);
         }
@@ -257,8 +296,12 @@ fn prompt_required(label: &str) -> Result<String> {
     }
 }
 
-fn prompt_with_default(label: &str, default: &str) -> Result<String> {
-    let raw = prompt_line(label, Some(default))?;
+fn prompt_with_default(
+    prompt_io: &mut impl AddPromptIo,
+    label: &str,
+    default: &str,
+) -> Result<String> {
+    let raw = prompt_io.prompt_line(label, Some(default))?;
     if raw.is_empty() {
         Ok(default.to_string())
     } else {
@@ -266,29 +309,17 @@ fn prompt_with_default(label: &str, default: &str) -> Result<String> {
     }
 }
 
-fn prompt_optional_path(label: &str, default: &str) -> Result<Option<String>> {
-    let raw = prompt_line(label, Some(default))?;
+fn prompt_optional_path(
+    prompt_io: &mut impl AddPromptIo,
+    label: &str,
+    default: &str,
+) -> Result<Option<String>> {
+    let raw = prompt_io.prompt_line(label, Some(default))?;
     if raw.is_empty() {
         Ok(None)
     } else {
         Ok(Some(raw))
     }
-}
-
-fn prompt_line(label: &str, default: Option<&str>) -> Result<String> {
-    match default {
-        Some(value) => print!("{label} [{value}]: "),
-        None => print!("{label}: "),
-    }
-    io::stdout()
-        .flush()
-        .context("failed to flush interactive `syu add` prompt")?;
-
-    let mut input = String::new();
-    io::stdin()
-        .read_line(&mut input)
-        .context("failed to read interactive `syu add` input")?;
-    Ok(input.trim().to_string())
 }
 
 fn normalize_definition_id(raw: &str, layer: LookupKind) -> Result<String> {
@@ -752,22 +783,51 @@ fn title_case_slug(slug: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use std::{
+        collections::VecDeque,
         fs,
         path::{Path, PathBuf},
     };
 
     use tempfile::{TempDir, tempdir};
 
-    use crate::{cli::LookupKind, config::SyuConfig, workspace::Workspace};
+    use crate::{
+        cli::{AddArgs, InitArgs, LookupKind, OutputFormat, StarterTemplate},
+        config::SyuConfig,
+        workspace::Workspace,
+    };
 
     use super::{
-        FeatureRegistryUpdate, ParsedId, TargetPath, default_document_path, default_folder_slug,
-        default_title, ensure_target_within_spec_root, normalize_definition_id,
-        normalize_feature_kind, prepare_feature_registry_update, render_item_block,
-        render_new_document, resolve_explicit_file, title_case_slug, validate_existing_document,
-        write_feature_registry_update, write_stub_document,
+        AddPromptIo, FeatureRegistryUpdate, ParsedId, TargetPath, default_document_path,
+        default_folder_slug, default_title, ensure_target_within_spec_root,
+        normalize_definition_id, normalize_feature_kind, prepare_feature_registry_update,
+        prompt_for_parsed_id, render_item_block, render_new_document,
+        resolve_add_invocation_with_prompt_io, resolve_explicit_file, resolve_feature_kind,
+        resolve_interactive_file_prompt, run_add_command, title_case_slug,
+        validate_existing_document, write_feature_registry_update, write_stub_document,
     };
+
+    #[derive(Default)]
+    struct FakePromptIo {
+        terminal: bool,
+        lines: VecDeque<String>,
+        prompts: Vec<(String, Option<String>)>,
+    }
+
+    impl AddPromptIo for FakePromptIo {
+        fn is_terminal(&self) -> bool {
+            self.terminal
+        }
+
+        fn prompt_line(&mut self, label: &str, default: Option<&str>) -> Result<String> {
+            self.prompts.push((
+                label.to_string(),
+                default.map(std::string::ToString::to_string),
+            ));
+            Ok(self.lines.pop_front().unwrap_or_default())
+        }
+    }
 
     fn test_workspace() -> (TempDir, Workspace) {
         let tempdir = tempdir().expect("tempdir should exist");
@@ -1098,5 +1158,160 @@ mod tests {
         };
 
         assert!(write_feature_registry_update(update).is_err());
+    }
+
+    #[test]
+    fn run_add_command_scaffolds_requirement_stubs_in_initialized_workspaces() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path().join("workspace");
+        crate::command::init::run_init_command(&InitArgs {
+            workspace: workspace.clone(),
+            name: Some("workspace".to_string()),
+            spec_root: None,
+            template: StarterTemplate::Generic,
+            id_prefix: None,
+            philosophy_prefix: None,
+            policy_prefix: None,
+            requirement_prefix: None,
+            feature_prefix: None,
+            force: false,
+            format: OutputFormat::Text,
+        })
+        .expect("workspace init should succeed");
+
+        let code = run_add_command(&AddArgs {
+            layer: LookupKind::Requirement,
+            id: Some("REQ-AUTH-001".to_string()),
+            workspace: workspace.clone(),
+            interactive: false,
+            file: None,
+            kind: None,
+        })
+        .expect("add command should succeed");
+        assert_eq!(code, 0);
+        assert!(
+            workspace
+                .join("docs/syu/requirements/auth/auth.yaml")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn resolve_add_invocation_reports_missing_id_on_non_terminal_streams() {
+        let mut prompt_io = FakePromptIo {
+            terminal: false,
+            ..Default::default()
+        };
+        let error = resolve_add_invocation_with_prompt_io(
+            &AddArgs {
+                layer: LookupKind::Requirement,
+                id: None,
+                workspace: PathBuf::from("."),
+                interactive: false,
+                file: None,
+                kind: None,
+            },
+            &mut prompt_io,
+        )
+        .expect_err("non-terminal add runs should require an explicit ID");
+
+        assert!(
+            error
+                .to_string()
+                .contains("needs a definition ID when stdin/stdout are not terminals")
+        );
+        assert!(prompt_io.prompts.is_empty());
+    }
+
+    #[test]
+    fn prompt_for_parsed_id_retries_blank_and_invalid_values() {
+        let mut prompt_io = FakePromptIo {
+            terminal: true,
+            lines: VecDeque::from([
+                String::new(),
+                "not-an-id".to_string(),
+                "REQ-AUTH-001".to_string(),
+            ]),
+            ..Default::default()
+        };
+
+        let parsed =
+            prompt_for_parsed_id(LookupKind::Requirement, &mut prompt_io).expect("prompt succeeds");
+
+        assert_eq!(parsed.normalized, "REQ-AUTH-001");
+        assert_eq!(prompt_io.prompts.len(), 3);
+        assert!(
+            prompt_io
+                .prompts
+                .iter()
+                .all(|(label, default)| label == "Definition ID" && default.is_none())
+        );
+    }
+
+    #[test]
+    fn resolve_feature_kind_interactive_retries_invalid_values_and_accepts_defaults() {
+        let parsed = ParsedId::parse(LookupKind::Feature, "FEAT-AUTH-LOGIN-001").expect("id");
+        let mut prompt_io = FakePromptIo {
+            terminal: true,
+            lines: VecDeque::from(["Auth".to_string(), String::new()]),
+            ..Default::default()
+        };
+
+        let kind = resolve_feature_kind(
+            &AddArgs {
+                layer: LookupKind::Feature,
+                id: Some(parsed.normalized.clone()),
+                workspace: PathBuf::from("."),
+                interactive: true,
+                file: None,
+                kind: None,
+            },
+            &parsed,
+            &mut prompt_io,
+        )
+        .expect("feature kind prompts should recover");
+
+        assert_eq!(kind, "auth");
+        assert_eq!(
+            prompt_io.prompts,
+            vec![
+                ("Feature kind".to_string(), Some("auth".to_string())),
+                ("Feature kind".to_string(), Some("auth".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_interactive_file_prompt_returns_none_for_blank_overrides() {
+        let parsed = ParsedId::parse(LookupKind::Feature, "FEAT-AUTH-LOGIN-001").expect("id");
+        let mut prompt_io = FakePromptIo {
+            terminal: true,
+            lines: VecDeque::from([String::new()]),
+            ..Default::default()
+        };
+
+        let file = resolve_interactive_file_prompt(
+            &AddArgs {
+                layer: LookupKind::Feature,
+                id: Some(parsed.normalized.clone()),
+                workspace: PathBuf::from("."),
+                interactive: true,
+                file: None,
+                kind: None,
+            },
+            &parsed,
+            Some("auth"),
+            &mut prompt_io,
+        )
+        .expect("file prompts should succeed");
+
+        assert_eq!(file, None);
+        assert_eq!(
+            prompt_io.prompts,
+            vec![(
+                "YAML file".to_string(),
+                Some("features/auth/login.yaml".to_string())
+            )]
+        );
     }
 }

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -3,6 +3,7 @@
 
 use std::{
     fs,
+    io::{self, IsTerminal, Write},
     path::{Component, Path, PathBuf},
 };
 
@@ -21,47 +22,36 @@ use crate::{
 use super::{lookup::WorkspaceLookup, shell_quote_path};
 
 pub fn run_add_command(args: &AddArgs) -> Result<i32> {
-    let workspace = load_workspace(&args.workspace)?;
-    let parsed_id = ParsedId::parse(args.layer, &args.id)?;
-
     if args.layer != LookupKind::Feature && args.kind.is_some() {
         bail!("`--kind` is only supported when scaffolding features");
     }
+    let resolved = resolve_add_invocation(args)?;
+    let workspace = load_workspace(&resolved.workspace)?;
     if WorkspaceLookup::new(&workspace)
-        .find(&parsed_id.normalized)
+        .find(&resolved.parsed_id.normalized)
         .is_some()
     {
         bail!(
             "{} `{}` already exists in `{}`",
             args.layer.label(),
-            parsed_id.normalized,
+            resolved.parsed_id.normalized,
             workspace.root.display()
         );
     }
-
-    let feature_kind = match args.layer {
-        LookupKind::Feature => {
-            let kind = args
-                .kind
-                .as_deref()
-                .unwrap_or(parsed_id.folder_slug.as_str());
-            Some(normalize_feature_kind(kind)?)
-        }
-        _ => None,
-    };
     let target = resolve_target_path(
         &workspace,
         args.layer,
-        args.file.as_deref(),
-        &parsed_id,
-        feature_kind.as_deref(),
+        resolved.file.as_deref(),
+        &resolved.parsed_id,
+        resolved.feature_kind.as_deref(),
     )?;
     let created_target_file = !target.absolute.exists();
     let feature_registry_update = if args.layer == LookupKind::Feature {
         Some(prepare_feature_registry_update(
             &workspace,
             &target.absolute,
-            feature_kind
+            resolved
+                .feature_kind
                 .as_deref()
                 .expect("features require a registry kind"),
         )?)
@@ -69,7 +59,12 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
         None
     };
 
-    write_stub_document(args.layer, &parsed_id, feature_kind.as_deref(), &target)?;
+    write_stub_document(
+        args.layer,
+        &resolved.parsed_id,
+        resolved.feature_kind.as_deref(),
+        &target,
+    )?;
 
     let registry_updated = if let Some(update) = feature_registry_update {
         write_feature_registry_update(update)?
@@ -80,12 +75,20 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
     print_add_summary(
         &workspace,
         args.layer,
-        &parsed_id.normalized,
+        &resolved.parsed_id.normalized,
         &target.absolute,
         created_target_file,
         registry_updated,
     );
     Ok(0)
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedAddInvocation {
+    workspace: PathBuf,
+    parsed_id: ParsedId,
+    feature_kind: Option<String>,
+    file: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -139,6 +142,153 @@ struct TargetPath {
 struct FeatureRegistryUpdate {
     path: PathBuf,
     updated_contents: Option<String>,
+}
+
+fn resolve_add_invocation(args: &AddArgs) -> Result<ResolvedAddInvocation> {
+    let (raw_id, workspace) = resolve_workspace_and_id(args)?;
+    let parsed_id = match raw_id {
+        Some(id) => ParsedId::parse(args.layer, &id)?,
+        None => prompt_for_parsed_id(args.layer)?,
+    };
+    let feature_kind = match args.layer {
+        LookupKind::Feature => Some(resolve_feature_kind(args, &parsed_id)?),
+        _ => None,
+    };
+    let file = resolve_interactive_file_prompt(args, &parsed_id, feature_kind.as_deref())?;
+
+    Ok(ResolvedAddInvocation {
+        workspace,
+        parsed_id,
+        feature_kind,
+        file,
+    })
+}
+
+fn resolve_workspace_and_id(args: &AddArgs) -> Result<(Option<String>, PathBuf)> {
+    let mut id = args.id.clone();
+    let mut workspace = args.workspace.clone();
+
+    if args.interactive
+        && workspace == Path::new(".")
+        && id.as_deref().is_some_and(|candidate| {
+            ParsedId::parse(args.layer, candidate).is_err() && Path::new(candidate).exists()
+        })
+    {
+        workspace = PathBuf::from(
+            id.take()
+                .expect("interactive workspace override should still be present"),
+        );
+    }
+
+    Ok((id, workspace))
+}
+
+fn resolve_feature_kind(args: &AddArgs, parsed_id: &ParsedId) -> Result<String> {
+    if let Some(kind) = args.kind.as_deref() {
+        return normalize_feature_kind(kind);
+    }
+    if args.interactive {
+        ensure_prompt_terminal(
+            "`syu add --interactive` requires a terminal to prompt for a feature kind",
+        )?;
+        loop {
+            let raw = prompt_with_default("Feature kind", parsed_id.folder_slug.as_str())?;
+            match normalize_feature_kind(&raw) {
+                Ok(kind) => return Ok(kind),
+                Err(error) => eprintln!("{error:#}"),
+            }
+        }
+    }
+
+    normalize_feature_kind(parsed_id.folder_slug.as_str())
+}
+
+fn resolve_interactive_file_prompt(
+    args: &AddArgs,
+    parsed_id: &ParsedId,
+    feature_kind: Option<&str>,
+) -> Result<Option<PathBuf>> {
+    if let Some(file) = &args.file {
+        return Ok(Some(file.clone()));
+    }
+    if !args.interactive {
+        return Ok(None);
+    }
+
+    ensure_prompt_terminal(
+        "`syu add --interactive` requires a terminal to prompt for a file path",
+    )?;
+    let default_relative = default_document_path(args.layer, parsed_id, feature_kind);
+    Ok(
+        prompt_optional_path("YAML file", &default_relative.display().to_string())?
+            .map(PathBuf::from),
+    )
+}
+
+fn prompt_for_parsed_id(layer: LookupKind) -> Result<ParsedId> {
+    ensure_prompt_terminal(
+        "interactive `syu add` prompts require a terminal; provide the ID explicitly when stdin/stdout are not terminals",
+    )?;
+
+    loop {
+        let raw = prompt_required("Definition ID")?;
+        match ParsedId::parse(layer, &raw) {
+            Ok(parsed) => return Ok(parsed),
+            Err(error) => eprintln!("{error:#}"),
+        }
+    }
+}
+
+fn ensure_prompt_terminal(message: &str) -> Result<()> {
+    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+        return Ok(());
+    }
+
+    bail!("{message}");
+}
+
+fn prompt_required(label: &str) -> Result<String> {
+    loop {
+        let raw = prompt_line(label, None)?;
+        if !raw.is_empty() {
+            return Ok(raw);
+        }
+        eprintln!("{label} is required.");
+    }
+}
+
+fn prompt_with_default(label: &str, default: &str) -> Result<String> {
+    let raw = prompt_line(label, Some(default))?;
+    if raw.is_empty() {
+        Ok(default.to_string())
+    } else {
+        Ok(raw)
+    }
+}
+
+fn prompt_optional_path(label: &str, default: &str) -> Result<Option<String>> {
+    let raw = prompt_line(label, Some(default))?;
+    if raw.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(raw))
+    }
+}
+
+fn prompt_line(label: &str, default: Option<&str>) -> Result<String> {
+    match default {
+        Some(value) => print!("{label} [{value}]: "),
+        None => print!("{label}: "),
+    }
+    io::stdout()
+        .flush()
+        .context("failed to flush interactive `syu add` prompt")?;
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .context("failed to read interactive `syu add` input")?;
+    Ok(input.trim().to_string())
 }
 
 fn normalize_definition_id(raw: &str, layer: LookupKind) -> Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,8 +194,9 @@ mod tests {
             Cli {
                 command: Some(Commands::Add(AddArgs {
                     layer: LookupKind::Feature,
-                    id: "FEAT-AUTH-001".to_string(),
+                    id: Some("FEAT-AUTH-001".to_string()),
                     workspace: PathBuf::from("workspace"),
+                    interactive: false,
                     file: Some(PathBuf::from("docs/syu/features/auth/login.yaml")),
                     kind: Some("auth".to_string()),
                 })),
@@ -206,10 +207,18 @@ mod tests {
 
         assert!(matches!(
             add,
-            super::Dispatch::Add(crate::cli::AddArgs { layer, id, workspace, file, kind })
+            super::Dispatch::Add(crate::cli::AddArgs {
+                layer,
+                id,
+                workspace,
+                interactive,
+                file,
+                kind
+            })
                 if layer == LookupKind::Feature
-                    && id == "FEAT-AUTH-001"
+                    && id.as_deref() == Some("FEAT-AUTH-001")
                     && workspace == Path::new("workspace")
+                    && !interactive
                     && file == Some(PathBuf::from("docs/syu/features/auth/login.yaml"))
                     && kind.as_deref() == Some("auth")
         ));

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -1,4 +1,10 @@
 use assert_cmd::cargo::CommandCargoExt;
+#[cfg(unix)]
+use std::{
+    env,
+    io::Write,
+    process::{Output, Stdio},
+};
 use std::{fs, path::Path, process::Command};
 use tempfile::tempdir;
 
@@ -13,6 +19,42 @@ fn init_workspace(workspace: &Path, extra_args: &[&str]) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(unix)]
+fn run_interactive_add(current_dir: &Path, args: &[&str], input: &str) -> Output {
+    let binary = env::var("CARGO_BIN_EXE_syu").expect("cargo should expose the syu binary path");
+    let command = std::iter::once(binary.as_str())
+        .chain(args.iter().copied())
+        .map(shell_quote)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut child = Command::new("script")
+        .current_dir(current_dir)
+        .arg("-qec")
+        .arg(command)
+        .arg("/dev/null")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("interactive add should start");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin should be piped")
+        .write_all(input.as_bytes())
+        .expect("interactive input should be written");
+
+    child
+        .wait_with_output()
+        .expect("interactive add should finish")
 }
 
 #[test]
@@ -288,4 +330,65 @@ fn add_command_rejects_feature_kind_for_non_feature_layers() {
         String::from_utf8_lossy(&output.stderr)
             .contains("only supported when scaffolding features")
     );
+}
+
+#[cfg(unix)]
+#[test]
+// REQ-CORE-020
+fn add_command_prompts_for_a_missing_id_in_the_current_workspace() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = run_interactive_add(&workspace, &["add", "requirement"], "REQ-AUTH-LOGIN-001\n");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Definition ID:"));
+
+    let file = workspace.join("docs/syu/requirements/auth/login.yaml");
+    let contents = fs::read_to_string(&file).expect("interactive requirement file should exist");
+    assert!(contents.contains("id: REQ-AUTH-LOGIN-001"));
+}
+
+#[cfg(unix)]
+#[test]
+// REQ-CORE-020
+fn add_command_interactive_mode_accepts_a_workspace_path_before_prompting() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = run_interactive_add(
+        tempdir.path(),
+        &[
+            "add",
+            "feature",
+            workspace.to_str().expect("workspace path should be utf-8"),
+            "--interactive",
+        ],
+        "FEAT-AUTH-LOGIN-001\nauth\nfeatures/auth/flows.yaml\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Definition ID:"));
+    assert!(stdout.contains("Feature kind [auth]:"));
+    assert!(stdout.contains("YAML file [features/auth/login.yaml]:"));
+
+    let feature_file = workspace.join("docs/syu/features/auth/flows.yaml");
+    let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(
+        feature_file.exists(),
+        "interactive feature file should be created"
+    );
+    assert!(registry.contains("file: auth/flows.yaml"));
 }

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -332,6 +332,27 @@ fn add_command_rejects_feature_kind_for_non_feature_layers() {
     );
 }
 
+#[test]
+// REQ-CORE-020
+fn add_command_requires_an_explicit_id_when_not_attached_to_a_terminal() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .current_dir(&workspace)
+        .args(["add", "requirement"])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("needs a definition ID when stdin/stdout are not terminals")
+    );
+}
+
 #[cfg(unix)]
 #[test]
 // REQ-CORE-020
@@ -352,6 +373,48 @@ fn add_command_prompts_for_a_missing_id_in_the_current_workspace() {
     let file = workspace.join("docs/syu/requirements/auth/login.yaml");
     let contents = fs::read_to_string(&file).expect("interactive requirement file should exist");
     assert!(contents.contains("id: REQ-AUTH-LOGIN-001"));
+}
+
+#[cfg(unix)]
+#[test]
+// REQ-CORE-020
+fn add_command_interactive_mode_retries_invalid_prompts_and_accepts_defaults() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let output = run_interactive_add(
+        &workspace,
+        &["add", "feature", "--interactive"],
+        "\nnot-an-id\nFEAT-AUTH-LOGIN-001\nAuth\n\n\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let transcript = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("Definition ID:"));
+    assert!(stdout.contains("Feature kind [auth]:"));
+    assert!(stdout.contains("YAML file [features/auth/login.yaml]:"));
+    assert!(transcript.contains("Definition ID is required."));
+    assert!(transcript.contains("feature IDs must start with `FEAT-`"));
+    assert!(transcript.contains("feature `--kind` must contain only lowercase ASCII letters"));
+
+    let feature_file = workspace.join("docs/syu/features/auth/login.yaml");
+    let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
+        .expect("feature registry should exist");
+    assert!(
+        feature_file.exists(),
+        "interactive feature file should use the default path"
+    );
+    assert!(registry.contains("file: auth/login.yaml"));
 }
 
 #[cfg(unix)]

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -83,8 +83,10 @@ fn add_help_mentions_explicit_file_and_feature_kind() {
     assert!(output.status.success(), "add help should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--interactive"));
     assert!(stdout.contains("--file"));
     assert!(stdout.contains("--kind"));
+    assert!(stdout.contains("syu add requirement --interactive"));
     assert!(stdout.contains("FEAT-AUTH-LOGIN-001 --kind auth"));
 }
 


### PR DESCRIPTION
## Summary
- add terminal prompts for missing `syu add` IDs plus an explicit `--interactive` flow for kind and file overrides
- keep the existing non-interactive scaffolding behavior while allowing interactive runs against an explicit workspace path
- document the guided add flow in the checked-in spec and getting-started guide

## Validation
- cargo test --quiet --lib --test add_command --test help_command
- cargo run -- add feature <workspace> --interactive
- python3 scripts/generate-site-docs.py
- cargo run --quiet -- report . --output docs/generated/syu-report.md
- bash scripts/ci/quality-gates.sh

Closes #148