### PR TITLE
fix: correct syu list help examples

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,7 +58,7 @@ Examples:
 
 Note:
   Pass the workspace root that contains syu.yaml.
-  docs/syu is the default spec.root inside that workspace.";
+  The configured spec.root lives inside that workspace; do not pass it directly.";
 
 const SEARCH_AFTER_HELP: &str = "\
 Examples:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,10 +51,14 @@ const WORKSPACE_HELP: &str = "Workspace root containing syu.yaml and the configu
 const LIST_AFTER_HELP: &str = "\
 Examples:
   syu list
-  syu list docs/syu
+  syu list path/to/workspace
   syu list requirement
-  syu list requirement docs/syu
-  syu list docs/syu requirement";
+  syu list requirement path/to/workspace
+  syu list path/to/workspace requirement
+
+Note:
+  Pass the workspace root that contains syu.yaml.
+  docs/syu is the default spec.root inside that workspace.";
 
 const SEARCH_AFTER_HELP: &str = "\
 Examples:

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -237,8 +237,10 @@ fn list_command_help_documents_both_argument_orders() {
         "help should explain the workspace-root expectation:\n{stdout}",
     );
     assert!(
-        stdout.contains("docs/syu is the default spec.root inside that workspace."),
-        "help should explain why docs/syu is not the workspace path:\n{stdout}",
+        stdout.contains(
+            "The configured spec.root lives inside that workspace; do not pass it directly."
+        ),
+        "help should explain why the spec.root itself is not the workspace path:\n{stdout}",
     );
 }
 

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -225,12 +225,20 @@ fn list_command_help_documents_both_argument_orders() {
     assert!(output.status.success(), "help should succeed");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("syu list requirement docs/syu"),
+        stdout.contains("syu list requirement path/to/workspace"),
         "help should show the kind-first example:\n{stdout}",
     );
     assert!(
-        stdout.contains("syu list docs/syu requirement"),
+        stdout.contains("syu list path/to/workspace requirement"),
         "help should show the workspace-first example:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Pass the workspace root that contains syu.yaml."),
+        "help should explain the workspace-root expectation:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("docs/syu is the default spec.root inside that workspace."),
+        "help should explain why docs/syu is not the workspace path:\n{stdout}",
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the broken docs/syu list help examples with workspace-root examples
- explain that docs/syu is the default spec root inside the workspace
- add a regression test for the help text

Closes #210.