### PR TITLE
docs: clarify quick-start validation timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Understand the model first? Start with [`docs/guide/concepts.md`](docs/guide/con
 before you begin editing YAML.
 
 ```bash
-syu init .          # 1. Create spec scaffold
-syu add requirement REQ-AUTH-001  # 2. Add spec items with generated YAML stubs
-syu validate .      # 3. Check everything is linked
-syu app .           # 4. Browse in the browser
+syu init .                           # 1. Create spec scaffold
+syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
+# 3. Edit the new requirement and reciprocal links before validating
+syu validate .                       # 4. Check everything is linked
+syu app .                            # 5. Browse in the browser
 ```
 
 Use `syu browse .` when you want terminal-first exploration, or `syu app .`

--- a/README.md
+++ b/README.md
@@ -101,9 +101,16 @@ before you begin editing YAML.
 ```bash
 syu init .                           # 1. Create spec scaffold
 syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
-# 3. Edit the new requirement and reciprocal links before validating
-syu validate .                       # 4. Check everything is linked
-syu app .                            # 5. Browse in the browser
+```
+
+Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
+(or your configured `spec.root`), add at least one `linked_policies:` entry and
+one `linked_features:` entry, then update those policy and feature documents so
+they link back to the new requirement.
+
+```bash
+syu validate .                       # 3. Check everything is linked
+syu app .                            # 4. Browse in the browser
 ```
 
 Use `syu browse .` when you want terminal-first exploration, or `syu app .`

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,10 +10,11 @@ layers before you start editing YAML.
 Start here once `syu` is installed:
 
 ```bash
-syu init .          # 1. Create spec scaffold
-syu add requirement REQ-AUTH-001  # 2. Add your next spec item
-syu validate .      # 3. Check everything is linked
-syu app .           # 4. Browse in the browser
+syu init .                           # 1. Create spec scaffold
+syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
+# 3. Edit the new requirement and reciprocal links before validating
+syu validate .                       # 4. Check everything is linked
+syu app .                            # 5. Browse in the browser
 ```
 
 ## Before you begin

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,9 +12,16 @@ Start here once `syu` is installed:
 ```bash
 syu init .                           # 1. Create spec scaffold
 syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
-# 3. Edit the new requirement and reciprocal links before validating
-syu validate .                       # 4. Check everything is linked
-syu app .                            # 5. Browse in the browser
+```
+
+Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
+(or your configured `spec.root`), add at least one `linked_policies:` entry and
+one `linked_features:` entry, then update those policy and feature documents so
+they link back to the new requirement.
+
+```bash
+syu validate .                       # 3. Check everything is linked
+syu app .                            # 4. Browse in the browser
 ```
 
 ## Before you begin

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -267,9 +267,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));
     assert!(getting_started.contains("Generate a requirement stub"));
-    assert!(getting_started.contains(
-        "Edit the new requirement and reciprocal links before validating"
-    ));
+    assert!(
+        getting_started.contains("Edit the new requirement and reciprocal links before validating")
+    );
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains(&format!(

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -232,7 +232,8 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/concepts.md"));
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));
-    assert!(readme.contains("Edit the new requirement and reciprocal links before validating"));
+    assert!(readme.contains("add at least one `linked_policies:` entry"));
+    assert!(readme.contains("update those policy and feature documents so"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));
@@ -267,9 +268,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));
     assert!(getting_started.contains("Generate a requirement stub"));
-    assert!(
-        getting_started.contains("Edit the new requirement and reciprocal links before validating")
-    );
+    assert!(getting_started.contains("add at least one `linked_policies:` entry"));
+    assert!(getting_started.contains("update those policy and feature documents so"));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains(&format!(

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -231,7 +231,8 @@ fn repository_declares_documentation_guides() {
 
     assert!(readme.contains("docs/guide/concepts.md"));
     assert!(readme.contains("Step 0: required"));
-    assert!(readme.contains("Add spec items with generated YAML stubs"));
+    assert!(readme.contains("Generate a requirement stub"));
+    assert!(readme.contains("Edit the new requirement and reciprocal links before validating"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));
@@ -265,6 +266,10 @@ fn repository_declares_documentation_guides() {
     assert!(concepts.contains("Specification Reference"));
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));
+    assert!(getting_started.contains("Generate a requirement stub"));
+    assert!(getting_started.contains(
+        "Edit the new requirement and reciprocal links before validating"
+    ));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains(&format!(


### PR DESCRIPTION
## Summary
- stop implying that a newly added requirement stub validates immediately
- tell users to edit reciprocal links before running validate
- lock the guidance into the repository-quality docs test

Closes #211.