### PR TITLE
docs: clarify bug report version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,9 @@ body:
     attributes:
       value: |
         Thanks for taking the time to improve `syu`.
-        Please include a minimal reproduction and the exact `syu` version when possible.
+        Please include a minimal reproduction.
+        If the report involves CLI behavior, include the exact `syu` version.
+        If the report is documentation-only or about repository automation, enter `not applicable` in the version field.
 
   - type: textarea
     id: summary
@@ -29,9 +31,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: syu version
-      description: "Example: `0.0.1-alpha.7` or `v0.0.1-alpha.4`"
-      placeholder: 0.0.1-alpha.7
+      label: syu version (or `not applicable`)
+      description: "Example: `0.0.1-alpha.7`, `v0.0.1-alpha.4`, `main`, or `not applicable`"
+      placeholder: 0.0.1-alpha.7 or not applicable
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,8 +10,19 @@ body:
       value: |
         Thanks for taking the time to improve `syu`.
         Please include a minimal reproduction.
-        If the report involves CLI behavior, include the exact `syu` version.
-        If the report is documentation-only or about repository automation, enter `not applicable` in the version field.
+        Pick the affected area below so CLI/runtime bugs can still require an exact `syu` version without forcing docs-only and repository-automation reports into the same input convention.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: What area is affected?
+      description: Choose the surface where you hit the problem.
+      options:
+        - CLI or runtime behavior
+        - Documentation or generated docs
+        - Repository automation or CI
+    validations:
+      required: true
 
   - type: textarea
     id: summary
@@ -31,11 +42,11 @@ body:
   - type: input
     id: version
     attributes:
-      label: syu version (or `not applicable`)
-      description: "Example: `0.0.1-alpha.7`, `v0.0.1-alpha.4`, `main`, or `not applicable`"
-      placeholder: 0.0.1-alpha.7 or not applicable
+      label: syu version
+      description: "Required for CLI or runtime bugs. Example: `0.0.1-alpha.7`, `v0.0.1-alpha.4`, or `main`"
+      placeholder: 0.0.1-alpha.7
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: environment

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -419,6 +419,9 @@ fn repository_declares_contribution_workflow_assets() {
 
     assert!(bug_report.contains("FEAT-CONTRIB-002"));
     assert!(bug_report.contains("What happened?"));
+    assert!(bug_report.contains("What area is affected?"));
+    assert!(bug_report.contains("CLI or runtime behavior"));
+    assert!(bug_report.contains("Required for CLI or runtime bugs"));
     assert!(bug_report.contains("Steps to reproduce"));
 
     assert!(feature_request.contains("FEAT-CONTRIB-002"));


### PR DESCRIPTION
## Summary
- explain when reporters should provide an exact syu version
- explicitly allow `not applicable` for docs-only and automation defects
- keep the field required while making the form internally consistent

Closes #212.