### PR TITLE
docs: narrow app guide status examples

### DIFF
--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -89,7 +89,7 @@ Below the sections panel, the documents for the active section are listed. Click
 Selecting an item shows:
 
 - **ID and title** — the stable identifier and human-readable name
-- **Status badge** — `planned`, `implemented`, or `deprecated`
+- **Status badge** — the lifecycle state from YAML (for example `planned` or `implemented`)
 - **Summary / description** — the prose from the YAML
 - **Links panel** — the upstream and downstream relationships (e.g. which requirements a feature satisfies; which policies a requirement enforces)
 - **Traces panel** — the declared test and implementation traces, with file path and symbol name

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -89,7 +89,7 @@ Below the sections panel, the documents for the active section are listed. Click
 Selecting an item shows:
 
 - **ID and title** — the stable identifier and human-readable name
-- **Status badge** — the lifecycle state from YAML (for example `planned` or `implemented`)
+- **Status badge** — the item's YAML `status:` field (for example `planned` or `implemented`)
 - **Summary / description** — the prose from the YAML
 - **Links panel** — the upstream and downstream relationships (e.g. which requirements a feature satisfies; which policies a requirement enforces)
 - **Traces panel** — the declared test and implementation traces, with file path and symbol name

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -205,6 +205,7 @@ fn repository_declares_documentation_guides() {
     let current_version = env!("CARGO_PKG_VERSION");
     let readme = read_file("README.md");
     let concepts = read_file("docs/guide/concepts.md");
+    let app_guide = read_file("docs/guide/app.md");
     let getting_started = read_file("docs/guide/getting-started.md");
     let configuration = read_file("docs/guide/configuration.md");
     let config_overview = read_file("docs/syu/config/overview.yaml");
@@ -263,6 +264,9 @@ fn repository_declares_documentation_guides() {
     assert!(concepts.contains("implemented"));
     assert!(concepts.contains("Continue with these pages"));
     assert!(concepts.contains("Specification Reference"));
+    assert!(app_guide.contains("Status badge"));
+    assert!(app_guide.contains("the lifecycle state from YAML"));
+    assert!(!app_guide.contains("`planned`, `implemented`, or `deprecated`"));
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));
     assert!(getting_started.contains("install-syu.sh"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -265,7 +265,7 @@ fn repository_declares_documentation_guides() {
     assert!(concepts.contains("Continue with these pages"));
     assert!(concepts.contains("Specification Reference"));
     assert!(app_guide.contains("Status badge"));
-    assert!(app_guide.contains("the lifecycle state from YAML"));
+    assert!(app_guide.contains("the item's YAML `status:` field"));
     assert!(!app_guide.contains("`planned`, `implemented`, or `deprecated`"));
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Start here once `syu` is installed:"));


### PR DESCRIPTION
## Summary
- stop advertising `deprecated` as a beginner-facing app guide status example
- describe the badge more generically as the YAML lifecycle state
- add a regression check in the repository docs test

Closes #213.