### PR TITLE
docs: prioritize verified installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,35 @@ GHCR packages under `ghcr.io/ugoite/syu`. Download the installer from the
 current CLI release; the script prefers the matching package artifact and falls
 back to GitHub release assets if anonymous package pulls are not available yet.
 
+For security-sensitive environments, prefer the verified download flow below
+before running the installer script.
+
+### Recommended: verify before running
+
+Each release publishes a `checksums.sha256` file alongside the installer.
+Download both files, verify the checksum, then run the local copy:
+
+```bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" -o install-syu.sh
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/checksums.sha256" -o checksums.sha256
+sha256sum --ignore-missing -c checksums.sha256
+bash install-syu.sh
+```
+
+On macOS, replace `sha256sum` with `shasum -a 256`.
+
+Published release archives also carry GitHub artifact attestations. Verify one with:
+
+```bash
+gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
+```
+
+### Shortcut: run the installer directly
+
+If you already trust the release source and want the shortest path, use the
+one-line entrypoint:
+
 Current installer entrypoint:
 
 ```bash
@@ -64,27 +93,6 @@ Install a specific prerelease:
 
 ```bash
 curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.7 bash
-```
-
-### Verify the installer checksum
-
-Each release publishes a `checksums.sha256` file alongside the installer.
-Verify the installer before running it:
-
-```bash
-RELEASE=v0.0.1-alpha.7
-curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" -o install-syu.sh
-curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/checksums.sha256" -o checksums.sha256
-sha256sum --ignore-missing -c checksums.sha256
-bash install-syu.sh
-```
-
-On macOS, replace `sha256sum` with `shasum -a 256`.
-
-Published release archives also carry GitHub artifact attestations. Verify one with:
-
-```bash
-gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
 ```
 
 If you're contributing to `syu` itself from source, jump to

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ bash install-syu.sh
 
 On macOS, replace `sha256sum` with `shasum -a 256`.
 
-Published release archives also carry GitHub artifact attestations. Verify one with:
+The checksum step above verifies the installer script itself. Published release
+archives also carry GitHub artifact attestations, so you can separately verify
+the platform archive that the installer downloads before it unpacks the binary:
 
 ```bash
 gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -205,6 +205,8 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("security-sensitive environments"));
     assert!(readme.contains("checksums.sha256"));
     assert!(readme.contains("gh attestation verify"));
+    assert!(readme.contains("verifies the installer script itself"));
+    assert!(readme.contains("the platform archive that the installer downloads"));
     assert!(
         verify_idx < shortcut_idx,
         "README should present the verify-first flow before the one-line shortcut"

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -164,6 +164,12 @@ fn repository_declares_installer_contract() {
     let installed_binary_smoke = read_file("scripts/ci/installed-binary-smoke.sh");
     let mock_registry = read_file("scripts/ci/mock_package_registry.py");
     let readme = read_file("README.md");
+    let verify_idx = readme
+        .find("Recommended: verify before running")
+        .expect("README should document the verify-first installer flow");
+    let shortcut_idx = readme
+        .find("Shortcut: run the installer directly")
+        .expect("README should still document the one-line shortcut");
 
     assert!(installer.contains("FEAT-INSTALL-001"));
     assert!(installer.contains("resolve_repository"));
@@ -196,6 +202,13 @@ fn repository_declares_installer_contract() {
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
     )));
     assert!(readme.contains("GitHub Packages"));
+    assert!(readme.contains("security-sensitive environments"));
+    assert!(readme.contains("checksums.sha256"));
+    assert!(readme.contains("gh attestation verify"));
+    assert!(
+        verify_idx < shortcut_idx,
+        "README should present the verify-first flow before the one-line shortcut"
+    );
     assert!(!readme.contains("raw.githubusercontent.com/ugoite/syu/main/scripts/install-syu.sh"));
 }
 


### PR DESCRIPTION
## Summary
- move the verify-first installer path ahead of the curl-pipe-bash shortcut
- add a security-sensitive environments callout and keep the shortcut as an explicit tradeoff
- add a regression test for the README ordering

Closes #214.