### PR TITLE
feat: activate devcontainer pre-commit hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "cargo install cargo-llvm-cov --locked && python3 -m pip install --upgrade pip pre-commit",
+  "postCreateCommand": "cargo install cargo-llvm-cov --locked && bash scripts/install-precommit.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,9 @@ If you use the hooks, install them once:
 scripts/install-precommit.sh
 ```
 
+The devcontainer/Codespaces post-create step runs this script automatically so
+the hooks are active as soon as the environment finishes provisioning.
+
 ## Dependency security
 
 Dependency advisories are checked automatically on a weekly schedule (every Monday

--- a/scripts/install-precommit.sh
+++ b/scripts/install-precommit.sh
@@ -29,8 +29,46 @@ install_precommit() {
   "$python_bin" -m pip install --user --upgrade pip pre-commit
 }
 
+find_precommit_bin() {
+  local python_bin="$1"
+
+  if command -v pre-commit >/dev/null 2>&1; then
+    command -v pre-commit
+    return 0
+  fi
+
+  local user_base
+  user_base="$("$python_bin" -m site --user-base)"
+  if [ -x "$user_base/bin/pre-commit" ]; then
+    echo "$user_base/bin/pre-commit"
+    return 0
+  fi
+
+  if command -v pipx >/dev/null 2>&1; then
+    local pipx_bin
+    pipx_bin="${PIPX_BIN_DIR:-}"
+    if [ -z "$pipx_bin" ]; then
+      pipx_bin="$(pipx environment --value PIPX_BIN_DIR 2>/dev/null || true)"
+    fi
+    if [ -n "$pipx_bin" ] && [ -x "$pipx_bin/pre-commit" ]; then
+      echo "$pipx_bin/pre-commit"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 install_hooks() {
-  pre-commit install --hook-type pre-commit --hook-type pre-push
+  local python_bin="$1"
+  local precommit_bin
+
+  if precommit_bin="$(find_precommit_bin "$python_bin")"; then
+    "$precommit_bin" install --hook-type pre-commit --hook-type pre-push
+    return 0
+  fi
+
+  "$python_bin" -m pre_commit install --hook-type pre-commit --hook-type pre-push
 }
 
 main() {
@@ -38,7 +76,7 @@ main() {
   python_bin="$(find_python)"
 
   install_precommit "$python_bin"
-  install_hooks
+  install_hooks "$python_bin"
 
   echo "pre-commit is installed and hooks are active."
   echo "Run 'pre-commit run --all-files --hook-stage pre-commit' to verify the local setup."

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -365,6 +365,7 @@ fn repository_declares_devcontainer_configuration() {
     let devcontainer = read_file(".devcontainer/devcontainer.json");
     assert!(devcontainer.contains("FEAT-CONTRIB-001"));
     assert!(devcontainer.contains("cargo install cargo-llvm-cov --locked"));
+    assert!(devcontainer.contains("scripts/install-precommit.sh"));
     assert!(devcontainer.contains("ghcr.io/devcontainers/features/python:1"));
 }
 
@@ -410,6 +411,7 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("scripts/ci/check-app-dist-freshness.sh"));
     assert!(contributing.contains("app/dist"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
+    assert!(contributing.contains("devcontainer/Codespaces post-create step"));
     assert!(contributing.contains("GitHub Pages"));
     assert!(contributing.contains("release track"));
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -12,6 +12,7 @@ fn read_file(path: &str) -> String {
 // REQ-CORE-005
 fn repository_declares_precommit_and_quality_gates() {
     let precommit = read_file(".pre-commit-config.yaml");
+    let install_precommit = read_file("scripts/install-precommit.sh");
     let quality_script = read_file("scripts/ci/quality-gates.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
     let contributing = read_file("CONTRIBUTING.md");
@@ -30,6 +31,8 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(quality_script.contains("cargo test"));
     assert!(quality_script.contains("cargo run -- validate ."));
     assert!(quality_script.contains("check-generated-docs-freshness.sh"));
+    assert!(install_precommit.contains("site --user-base"));
+    assert!(install_precommit.contains("pre_commit install"));
 
     assert!(ci_workflow.contains("FEAT-QUALITY-001"));
     assert!(ci_workflow.contains("precommit:"));


### PR DESCRIPTION
## Summary
- have the devcontainer run the shared hook installer during post-create setup
- document that Codespaces/devcontainers finish hook activation automatically
- add repository-quality coverage for the new onboarding path

Closes #215.