### PR TITLE
docs: surface verified install flow

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,17 +28,40 @@ syu app .                            # 4. Browse in the browser
 
 Make sure `syu` is installed and available on your `PATH`.
 
-**Option A — Install from a release (recommended)**
+**Option A — Verify the release installer before running it (recommended)**
+
+For security-sensitive environments, download the installer and checksum file
+first, verify the checksum locally, then run the checked file:
+
+```bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" -o install-syu.sh
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/checksums.sha256" -o checksums.sha256
+sha256sum --ignore-missing -c checksums.sha256
+bash install-syu.sh
+```
+
+On macOS, replace `sha256sum` with `shasum -a 256`.
+
+If you also want to verify the downloaded archive after the installer resolves
+your platform, use:
+
+```bash
+gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
+```
+
+**Option B — Run the installer directly**
 
 ```bash
 curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash
 ```
 
 This uses the current installer entrypoint plus `SYU_VERSION=alpha` so you stay
-on the latest alpha during the prerelease phase. It places `syu` in
+on the latest alpha during the prerelease phase. Use this shortcut when you
+already trust the release source and want the shortest path. It places `syu` in
 `~/.local/bin`. Add that directory to your `PATH` if it is not already there.
 
-**Option B — Build from source**
+**Option C — Build from source**
 
 Building from source requires [Rust and Cargo](https://rustup.rs). This option is only needed when contributing to `syu` itself, not for using it in your own project.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -41,14 +41,15 @@ sha256sum --ignore-missing -c checksums.sha256
 bash install-syu.sh
 ```
 
-On macOS, replace `sha256sum` with `shasum -a 256`.
-
-If you also want to verify the downloaded archive after the installer resolves
-your platform, use:
+On macOS, run the checksum check with the matching command instead:
 
 ```bash
-gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
+shasum -a 256 --ignore-missing -c checksums.sha256
 ```
+
+The getting-started path above verifies the installer script itself. If you need
+additional archive-level provenance checks, download the platform archive
+separately and verify it before installation.
 
 **Option B — Run the installer directly**
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -299,6 +299,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("add at least one `linked_policies:` entry"));
     assert!(getting_started.contains("update those policy and feature documents so"));
     assert!(getting_started.contains("install-syu.sh"));
+    assert!(getting_started.contains("checksums.sha256"));
+    assert!(getting_started.contains("gh attestation verify"));
+    assert!(getting_started.contains("security-sensitive environments"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains(&format!(
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -300,8 +300,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("update those policy and feature documents so"));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("checksums.sha256"));
-    assert!(getting_started.contains("gh attestation verify"));
     assert!(getting_started.contains("security-sensitive environments"));
+    assert!(getting_started.contains("shasum -a 256 --ignore-missing -c checksums.sha256"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
     assert!(getting_started.contains(&format!(
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"


### PR DESCRIPTION
## Summary
- make the getting-started guide lead with the verified installer flow already documented in the README
- keep the one-line installer as an explicit shortcut for trusted environments
- extend repository-quality coverage so the docs guide keeps checksum and attestation guidance

Closes #233