### PR TITLE
docs: add a Windows install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ bash install-syu.sh
 
 On macOS, replace `sha256sum` with `shasum -a 256`.
 
+### Windows: PowerShell by default, Git Bash on Windows, WSL as Linux
+
+If you are on Windows and want the clearest first-party path, use PowerShell
+and download the Windows archive directly. This avoids requiring Git Bash or
+WSL just to install `syu`.
+
+```powershell
+$release = 'v0.0.1-alpha.7'
+$asset = 'syu-x86_64-pc-windows-msvc.zip'
+$checksums = 'checksums.sha256'
+Invoke-WebRequest "https://github.com/ugoite/syu/releases/download/$release/$asset" -OutFile $asset
+Invoke-WebRequest "https://github.com/ugoite/syu/releases/download/$release/$checksums" -OutFile $checksums
+$expected = (
+  Get-Content $checksums |
+  Select-String -SimpleMatch $asset |
+  ForEach-Object { $_.Line.Split()[0].ToLower() }
+)
+if (-not $expected) { throw "Checksum for $asset not found" }
+$actual = (Get-FileHash $asset -Algorithm SHA256).Hash.ToLower()
+if ($actual -ne $expected) { throw 'Checksum mismatch' }
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\syu\bin'
+New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+Expand-Archive $asset -DestinationPath $installDir -Force
+& (Join-Path $installDir 'syu.exe') --version
+```
+
+If a new PowerShell session still cannot find `syu`, add
+`$env:LOCALAPPDATA\Programs\syu\bin` to your user `PATH`.
+
+If you prefer the Bash installer on Windows, run `install-syu.sh` from Git Bash.
+In that shell, the installer resolves the same `x86_64-pc-windows-msvc` archive
+and defaults to `%LOCALAPPDATA%\Programs\syu\bin`.
+
+If you are inside WSL, use the Linux installer path instead. There, the script
+resolves the Linux archive and installs to `~/.local/bin`.
+
 The checksum step above verifies the installer script itself. Published release
 archives also carry GitHub artifact attestations, so you can separately verify
 the platform archive that the installer downloads before it unpacks the binary:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -71,6 +71,41 @@ on the latest alpha during the prerelease phase. Use this shortcut when you
 already trust the release source and want the shortest path. It places `syu` in
 `~/.local/bin`. Add that directory to your `PATH` if it is not already there.
 
+**Windows — Use PowerShell for the zip, Git Bash for the installer script**
+
+If you are on Windows and want a first-party path that does not depend on Git
+Bash or WSL, download the Windows archive directly from PowerShell:
+
+```powershell
+$release = 'v0.0.1-alpha.7'
+$asset = 'syu-x86_64-pc-windows-msvc.zip'
+$checksums = 'checksums.sha256'
+Invoke-WebRequest "https://github.com/ugoite/syu/releases/download/$release/$asset" -OutFile $asset
+Invoke-WebRequest "https://github.com/ugoite/syu/releases/download/$release/$checksums" -OutFile $checksums
+$expected = (
+  Get-Content $checksums |
+  Select-String -SimpleMatch $asset |
+  ForEach-Object { $_.Line.Split()[0].ToLower() }
+)
+if (-not $expected) { throw "Checksum for $asset not found" }
+$actual = (Get-FileHash $asset -Algorithm SHA256).Hash.ToLower()
+if ($actual -ne $expected) { throw 'Checksum mismatch' }
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\syu\bin'
+New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+Expand-Archive $asset -DestinationPath $installDir -Force
+& (Join-Path $installDir 'syu.exe') --version
+```
+
+If a fresh shell still cannot find `syu`, add
+`$env:LOCALAPPDATA\Programs\syu\bin` to your user `PATH`.
+
+If you prefer the shell installer on Windows, run `install-syu.sh` from Git
+Bash. It resolves the same `x86_64-pc-windows-msvc` archive and installs to
+`%LOCALAPPDATA%\Programs\syu\bin`.
+
+If you are inside WSL, use the Linux installer path instead. There, the script
+resolves the Linux archive and installs to `~/.local/bin`.
+
 **Option C — Build from source**
 
 Building from source requires [Rust and Cargo](https://rustup.rs). This option is only needed when contributing to `syu` itself, not for using it in your own project.

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -208,6 +208,16 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("security-sensitive environments"));
     assert!(readme.contains("checksums.sha256"));
     assert!(readme.contains("gh attestation verify"));
+    assert!(readme.contains("PowerShell"));
+    assert!(readme.contains("Git Bash"));
+    assert!(readme.contains("checksums = 'checksums.sha256'"));
+    assert!(readme.contains("Select-String -SimpleMatch $asset"));
+    assert!(readme.contains("syu-x86_64-pc-windows-msvc.zip"));
+    assert!(readme.contains("Get-FileHash"));
+    assert!(readme.contains("LOCALAPPDATA"));
+    assert!(readme.contains("If you are inside WSL"));
+    assert!(!readme.contains("$asset.sha256"));
+    assert!(readme.contains("syu.exe"));
     assert!(readme.contains("verifies the installer script itself"));
     assert!(readme.contains("the platform archive that the installer downloads"));
     assert!(
@@ -307,6 +317,16 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("security-sensitive environments"));
     assert!(getting_started.contains("shasum -a 256 --ignore-missing -c checksums.sha256"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));
+    assert!(getting_started.contains("PowerShell"));
+    assert!(getting_started.contains("Git Bash"));
+    assert!(getting_started.contains("checksums = 'checksums.sha256'"));
+    assert!(getting_started.contains("Select-String -SimpleMatch $asset"));
+    assert!(getting_started.contains("syu-x86_64-pc-windows-msvc.zip"));
+    assert!(getting_started.contains("Get-FileHash"));
+    assert!(getting_started.contains("LOCALAPPDATA"));
+    assert!(getting_started.contains("If you are inside WSL"));
+    assert!(!getting_started.contains("$asset.sha256"));
+    assert!(getting_started.contains("syu.exe"));
     assert!(getting_started.contains(&format!(
         "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
     )));


### PR DESCRIPTION
## Summary
- document a first-party Windows install flow using PowerShell and the published zip artifact
- explain when to use Git Bash or WSL for the shell installer instead
- extend repository-quality coverage so both the README and getting-started guide keep the Windows path visible

Closes #234