### PR TITLE
docs: clarify pinned installer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,29 +122,38 @@ gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
 If you already trust the release source and want the shortest path, use the
 one-line entrypoint:
 
+The download URL stays pinned to the installer shipped with this checked-in
+documentation version. Use `SYU_VERSION=alpha`, `stable`, or an explicit
+version selector when you want that installer to fetch a different published
+package track after it starts.
+
 Current installer entrypoint:
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | bash
 ```
 
 During the alpha phase, prefer the `alpha` track selector so the same installer
 entrypoint always resolves to the latest published alpha:
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_VERSION=alpha bash
 ```
 
 Install to a custom directory:
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_INSTALL_DIR=$HOME/bin bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_INSTALL_DIR=$HOME/bin bash
 ```
 
 Install a specific prerelease:
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=v0.0.1-alpha.7 bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_VERSION="$RELEASE" bash
 ```
 
 If you're contributing to `syu` itself from source, jump to

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -63,13 +63,15 @@ separately and verify it before installation.
 **Option B — Run the installer directly**
 
 ```bash
-curl -fsSL https://github.com/ugoite/syu/releases/download/v0.0.1-alpha.7/install-syu.sh | env SYU_VERSION=alpha bash
+RELEASE=v0.0.1-alpha.7
+curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_VERSION=alpha bash
 ```
 
-This uses the current installer entrypoint plus `SYU_VERSION=alpha` so you stay
-on the latest alpha during the prerelease phase. Use this shortcut when you
-already trust the release source and want the shortest path. It places `syu` in
-`~/.local/bin`. Add that directory to your `PATH` if it is not already there.
+This keeps the download URL pinned to the current checked-in release while
+`SYU_VERSION=alpha` tells the installer to fetch the latest published alpha
+package once it starts. Use this shortcut when you already trust the release
+source and want the shortest path. It places `syu` in `~/.local/bin`. Add that
+directory to your `PATH` if it is not already there.
 
 **Windows — Use PowerShell for the zip, Git Bash for the installer script**
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -201,9 +201,7 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("install-syu.sh"));
     assert!(readme.contains("ugoite/syu"));
     assert!(readme.contains("SYU_VERSION"));
-    assert!(readme.contains(&format!(
-        "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
-    )));
+    assert!(readme.contains(&format!("RELEASE=v{current_version}")));
     assert!(readme.contains("GitHub Packages"));
     assert!(readme.contains("security-sensitive environments"));
     assert!(readme.contains("checksums.sha256"));
@@ -218,6 +216,9 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("If you are inside WSL"));
     assert!(!readme.contains("$asset.sha256"));
     assert!(readme.contains("syu.exe"));
+    assert!(readme.contains(&format!("RELEASE=v{current_version}")));
+    assert!(readme.contains("checked-in"));
+    assert!(readme.contains("package track"));
     assert!(readme.contains("verifies the installer script itself"));
     assert!(readme.contains("the platform archive that the installer downloads"));
     assert!(
@@ -327,9 +328,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("If you are inside WSL"));
     assert!(!getting_started.contains("$asset.sha256"));
     assert!(getting_started.contains("syu.exe"));
-    assert!(getting_started.contains(&format!(
-        "https://github.com/ugoite/syu/releases/download/v{current_version}/install-syu.sh"
-    )));
+    assert!(getting_started.contains(&format!("RELEASE=v{current_version}")));
+    assert!(getting_started.contains("current checked-in release"));
+    assert!(getting_started.contains("latest published alpha"));
     assert!(getting_started.contains("--template rust-only"));
     assert!(getting_started.contains("--id-prefix"));
     assert!(getting_started.contains("syu validate . --fix"));


### PR DESCRIPTION
## Summary
- switch installer examples to a reusable RELEASE variable instead of repeating a hard-coded tag in every block
- explain why the URL stays pinned while SYU_VERSION selects a different published package track
- update repository-quality checks to keep the new explanation and example shape in place

Closes #235