### PR TITLE
docs: require concepts before quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ below. The rest of this section assumes you installed the published CLI.
 
 ## Quick start
 
-Step 0: required — run `syu init .` before any of the other commands in a new repository.
+Before you start: required — read [`docs/guide/concepts.md`](docs/guide/concepts.md)
+first. The next steps assume you already understand the four layers and the
+reciprocal links between policies, requirements, and features.
 
-Understand the model first? Start with [`docs/guide/concepts.md`](docs/guide/concepts.md)
-before you begin editing YAML.
+Step 0: required — run `syu init .` before any of the other commands in a new repository.
 
 ```bash
 syu init .                           # 1. Create spec scaffold

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -263,10 +263,12 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("## Choose your path"));
     assert!(readme.contains("docs/guide/tutorial.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
+    assert!(readme.contains("Before you start: required"));
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));
     assert!(readme.contains("add at least one `linked_policies:` entry"));
     assert!(readme.contains("update those policy and feature documents so"));
+    assert!(readme.contains("reciprocal links between policies, requirements, and features"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));
@@ -371,7 +373,6 @@ fn repository_declares_documentation_guides() {
     assert!(tutorial.contains("Want a different entry point?"));
     assert!(tutorial.contains("[getting started](./getting-started.md)"));
     assert!(tutorial.contains("[troubleshooting](./troubleshooting.md)"));
-    assert!(readme.contains("Understand the model first?"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("validate.allow_planned"));
     assert!(configuration.contains("--spec-root"));


### PR DESCRIPTION
## Summary
- move the README concepts guidance into an explicit required pre-step ahead of Quick start
- explain that the next edits rely on understanding the four layers and reciprocal links
- lock the stronger README wording into repository-quality coverage

Closes #236