### PR TITLE
docs: fix polyglot trace coverage docs

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -137,14 +137,15 @@ of editing `syu.yaml`.
 
 ### `validate.require_symbol_trace_coverage`
 
-When `true`, `syu` scans Rust source and test files to confirm that every public
-symbol belongs to some feature and every test belongs to some requirement.
+When `true`, `syu` scans Rust, Python, and TypeScript/JavaScript source and
+test files to confirm that every public symbol belongs to some feature and
+every test belongs to some requirement.
 
 - `false`: only declared traces are verified
 - `true`: undeclared public APIs and tests become validation errors
 
 This is useful once the repository wants maintenance work to stay fully owned by
-the specification.
+the specification across the supported implementation languages.
 For an experimental strict run, use `syu validate . --require-symbol-trace-coverage`.
 
 ### `app.bind`

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -375,6 +375,7 @@ fn repository_declares_documentation_guides() {
     assert!(tutorial.contains("[troubleshooting](./troubleshooting.md)"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("validate.allow_planned"));
+    assert!(configuration.contains("Rust, Python, and TypeScript/JavaScript"));
     assert!(configuration.contains("--spec-root"));
     assert!(configuration.contains(&format!("version: {current_version}")));
     assert!(configuration.contains("docs/syu/config/overview.yaml"));


### PR DESCRIPTION
## Summary
- update the configuration guide so symbol trace coverage matches the Rust, Python, and TypeScript/JavaScript implementation
- lock the wording in the repository-quality assertions

Closes #239