### PR TITLE
docs: expand contributor browser workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ commit them.
 For changes under `app/`, install the browser app dependencies first:
 
 ```bash
-cd app
-npm ci
+npm --prefix app ci
 ```
 
 When the change affects the built bundle, run the same freshness flow CI uses:
@@ -68,9 +67,8 @@ When the change affects browser behavior, routing, or Playwright coverage, also
 install the local browser once and run the end-to-end suite:
 
 ```bash
-cd app
-npx playwright install --with-deps chromium
-npm run test:e2e
+npx --prefix app playwright install --with-deps chromium
+npm --prefix app run test:e2e
 ```
 
 `npm run test:e2e` uses `app/playwright.config.ts` to launch
@@ -82,16 +80,14 @@ For `website/` changes, install the docs-site dependencies and use the local dev
 server while iterating:
 
 ```bash
-cd website
-npm ci
-npm run start
+npm --prefix website ci
+npm --prefix website run start
 ```
 
 Before opening a pull request, run the same docs-site build CI uses:
 
 ```bash
-cd website
-npm run build
+npm --prefix website run build
 ```
 
 `npm run build` regenerates the checked-in site docs first, matching

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,58 @@ scripts/ci/check-app-dist-freshness.sh
 That rebuilds the browser app and fails when the checked-in `app/dist` bundle is
 stale, leaving the regenerated files in your worktree so you can review and
 commit them.
+
+### Browser app workflow
+
+For changes under `app/`, install the browser app dependencies first:
+
+```bash
+cd app
+npm ci
+```
+
+When the change affects the built bundle, run the same freshness flow CI uses:
+
+```bash
+scripts/ci/check-app-dist-freshness.sh
+```
+
+That script runs `npm run build:wasm`, `npm run check`, and `npm run build`,
+then compares the regenerated output against the checked-in `app/dist` bundle.
+
+When the change affects browser behavior, routing, or Playwright coverage, also
+install the local browser once and run the end-to-end suite:
+
+```bash
+cd app
+npx playwright install --with-deps chromium
+npm run test:e2e
+```
+
+`npm run test:e2e` uses `app/playwright.config.ts` to launch
+`cargo run -- app .` automatically, so run it after the shared Rust gates pass.
+
+### Documentation site workflow
+
+For `website/` changes, install the docs-site dependencies and use the local dev
+server while iterating:
+
+```bash
+cd website
+npm ci
+npm run start
+```
+
+Before opening a pull request, run the same docs-site build CI uses:
+
+```bash
+cd website
+npm run build
+```
+
+`npm run build` regenerates the checked-in site docs first, matching
+`.github/actions/build-docs-site`.
+
 ### Rust version
 
 The minimum supported Rust version (MSRV) is **1.88**. CI verifies this with a

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -486,11 +486,12 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("app/dist"));
     assert!(contributing.contains("npm run build:wasm"));
     assert!(contributing.contains("npm run check"));
-    assert!(contributing.contains("npx playwright install --with-deps chromium"));
-    assert!(contributing.contains("npm run test:e2e"));
+    assert!(contributing.contains("npx --prefix app playwright install --with-deps chromium"));
+    assert!(contributing.contains("npm --prefix app run test:e2e"));
     assert!(contributing.contains("app/playwright.config.ts"));
-    assert!(contributing.contains("cd website"));
-    assert!(contributing.contains("npm run start"));
+    assert!(contributing.contains("npm --prefix website ci"));
+    assert!(contributing.contains("npm --prefix website run start"));
+    assert!(contributing.contains("npm --prefix website run build"));
     assert!(contributing.contains(".github/actions/build-docs-site"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("devcontainer/Codespaces post-create step"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -484,6 +484,14 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("docs/generated/"));
     assert!(contributing.contains("scripts/ci/check-app-dist-freshness.sh"));
     assert!(contributing.contains("app/dist"));
+    assert!(contributing.contains("npm run build:wasm"));
+    assert!(contributing.contains("npm run check"));
+    assert!(contributing.contains("npx playwright install --with-deps chromium"));
+    assert!(contributing.contains("npm run test:e2e"));
+    assert!(contributing.contains("app/playwright.config.ts"));
+    assert!(contributing.contains("cd website"));
+    assert!(contributing.contains("npm run start"));
+    assert!(contributing.contains(".github/actions/build-docs-site"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("devcontainer/Codespaces post-create step"));
     assert!(contributing.contains("GitHub Pages"));


### PR DESCRIPTION
## Summary
- add concrete browser-app setup, Playwright, and dist-freshness steps to CONTRIBUTING
- document the local docs-site dev/build flow that matches CI
- lock the new contributor workflow guidance in repository-quality assertions

Closes #240