### PR TITLE
feat: preprovision browser app devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "cargo install cargo-llvm-cov --locked && bash scripts/install-precommit.sh",
+  "postCreateCommand": "cargo install cargo-llvm-cov --locked && cargo install wasm-pack --locked && (cd app && npm ci && npx playwright install --with-deps chromium) && bash scripts/install-precommit.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,10 @@ If you use the hooks, install them once:
 scripts/install-precommit.sh
 ```
 
-The devcontainer/Codespaces post-create step runs this script automatically so
-the hooks are active as soon as the environment finishes provisioning.
+The devcontainer/Codespaces post-create step runs this script automatically and
+also preinstalls `wasm-pack`, the `app/` dependencies, and Playwright Chromium
+so browser-app validation is ready as soon as the environment finishes
+provisioning.
 
 ## Dependency security
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -439,6 +439,9 @@ fn repository_declares_devcontainer_configuration() {
     let devcontainer = read_file(".devcontainer/devcontainer.json");
     assert!(devcontainer.contains("FEAT-CONTRIB-001"));
     assert!(devcontainer.contains("cargo install cargo-llvm-cov --locked"));
+    assert!(devcontainer.contains("cargo install wasm-pack --locked"));
+    assert!(devcontainer.contains("cd app && npm ci"));
+    assert!(devcontainer.contains("playwright install --with-deps chromium"));
     assert!(devcontainer.contains("scripts/install-precommit.sh"));
     assert!(devcontainer.contains("ghcr.io/devcontainers/features/python:1"));
 }
@@ -486,6 +489,8 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("app/dist"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("devcontainer/Codespaces post-create step"));
+    assert!(contributing.contains("wasm-pack"));
+    assert!(contributing.contains("Playwright Chromium"));
     assert!(contributing.contains("GitHub Pages"));
     assert!(contributing.contains("release track"));
 


### PR DESCRIPTION
## Summary
- extend the devcontainer post-create step with wasm-pack, app dependencies, and Playwright Chromium
- document that the contributor container now preprovisions the browser-app validation stack
- lock the new devcontainer contract in repository-quality assertions

Closes #241