### PR TITLE
feat: make browse errors actionable

### DIFF
--- a/docs/generated/site-spec/features/cli/browse.md
+++ b/docs/generated/site-spec/features/cli/browse.md
@@ -39,7 +39,7 @@ description: "Generated reference for docs/syu/features/cli/browse.yaml"
           - *
 - **id**: FEAT-BROWSE-002
   - **title**: Non-interactive spec tree output
-  - **summary**: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus current errors) to stdout and exits, suitable for plain-text terminal review or logs.
+  - **summary**: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus actionable current errors with rule titles, messages, and suggestions when available) to stdout and exits, suitable for plain-text terminal review or logs.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-015
@@ -83,7 +83,7 @@ features:
 
   - id: FEAT-BROWSE-002
     title: Non-interactive spec tree output
-    summary: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus current errors) to stdout and exits, suitable for plain-text terminal review or logs.
+    summary: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus actionable current errors with rule titles, messages, and suggestions when available) to stdout and exits, suitable for plain-text terminal review or logs.
     status: implemented
     linked_requirements:
       - REQ-CORE-015

--- a/docs/syu/features/cli/browse.yaml
+++ b/docs/syu/features/cli/browse.yaml
@@ -25,7 +25,7 @@ features:
 
   - id: FEAT-BROWSE-002
     title: Non-interactive spec tree output
-    summary: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus current errors) to stdout and exits, suitable for plain-text terminal review or logs.
+    summary: Add a --non-interactive flag to `syu browse` that prints the browse snapshot (workspace metadata, grouped item counts and IDs, plus actionable current errors with rule titles, messages, and suggestions when available) to stdout and exits, suitable for plain-text terminal review or logs.
     status: implemented
     linked_requirements:
       - REQ-CORE-015

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -718,4 +718,22 @@ mod tests {
             "    suggestion: Add symbol `missingTsSymbol` to `frontend/broken-feature.ts` or update the YAML mapping for `FEAT-FAIL-001`."
         );
     }
+
+    #[test]
+    fn non_interactive_issue_format_falls_back_when_rule_metadata_is_missing() {
+        let lines = format_non_interactive_issue(&Issue::warning(
+            "SYU-custom-unknown-001",
+            "workspace .",
+            None,
+            "Custom validation output should still stay readable.",
+            None,
+        ));
+
+        assert_eq!(
+            lines,
+            vec![
+                "  [SYU-custom-unknown-001] workspace .: Custom validation output should still stay readable."
+            ]
+        );
+    }
 }

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use crate::{
     cli::{BrowseArgs, LookupKind as EntityKind},
     command::check::collect_check_result,
-    model::{CheckResult, Feature, Philosophy, Policy, Requirement},
+    model::{CheckResult, Feature, Issue, Philosophy, Policy, Requirement},
     rules::rule_by_code,
     workspace::{Workspace, load_workspace},
 };
@@ -370,7 +370,9 @@ impl BrowseState {
         if !self.result.issues.is_empty() {
             println!("=== errors ({}) ===", self.result.issues.len());
             for issue in &self.result.issues {
-                println!("  [{}] {}", issue.code, issue.subject);
+                for line in format_non_interactive_issue(issue) {
+                    println!("{line}");
+                }
             }
             println!();
         }
@@ -494,6 +496,32 @@ fn collapse_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+fn format_non_interactive_issue(issue: &Issue) -> Vec<String> {
+    let mut header = format!("  [{}] {}", issue.code, issue.subject);
+    if let Some(location) = issue.location.as_deref() {
+        header.push_str(&format!(" ({location})"));
+    }
+
+    if let Some(rule) = rule_by_code(&issue.code) {
+        header.push_str(&format!(
+            " — {}: {}",
+            rule.title,
+            collapse_whitespace(&issue.message)
+        ));
+    } else {
+        header.push_str(&format!(": {}", collapse_whitespace(&issue.message)));
+    }
+
+    let mut lines = vec![header];
+    if let Some(suggestion) = &issue.suggestion {
+        lines.push(format!(
+            "    suggestion: {}",
+            collapse_whitespace(suggestion)
+        ));
+    }
+    lines
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::BTreeMap, path::PathBuf};
@@ -501,13 +529,16 @@ mod tests {
     use crate::{
         command::check::collect_check_result,
         model::{
-            CheckResult, DefinitionCounts, Feature, Philosophy, Policy, Requirement,
+            CheckResult, DefinitionCounts, Feature, Issue, Philosophy, Policy, Requirement,
             TraceReference, TraceSummary,
         },
         workspace::{Workspace, load_workspace},
     };
 
-    use super::{BrowseState, EntityKind, collapse_whitespace, print_trace_summary};
+    use super::{
+        BrowseState, EntityKind, collapse_whitespace, format_non_interactive_issue,
+        print_trace_summary,
+    };
 
     fn fixture_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -662,6 +693,29 @@ mod tests {
         assert_eq!(
             collapse_whitespace("browse\n  keeps   context"),
             "browse keeps context"
+        );
+    }
+
+    #[test]
+    fn non_interactive_issue_format_includes_message_and_suggestion() {
+        let lines = format_non_interactive_issue(&Issue::error(
+            "SYU-trace-symbol-003",
+            "feature FEAT-FAIL-001",
+            Some("typescript:frontend/broken-feature.ts".to_string()),
+            "Declared symbol `missingTsSymbol` was not found in `frontend/broken-feature.ts`.",
+            Some(
+                "Add symbol `missingTsSymbol` to `frontend/broken-feature.ts` or update the YAML mapping for `FEAT-FAIL-001`."
+                    .to_string(),
+            ),
+        ));
+
+        assert_eq!(
+            lines[0],
+            "  [SYU-trace-symbol-003] feature FEAT-FAIL-001 (typescript:frontend/broken-feature.ts) — Declared trace symbols must exist in the traced file: Declared symbol `missingTsSymbol` was not found in `frontend/broken-feature.ts`."
+        );
+        assert_eq!(
+            lines[1],
+            "    suggestion: Add symbol `missingTsSymbol` to `frontend/broken-feature.ts` or update the YAML mapping for `FEAT-FAIL-001`."
         );
     }
 }

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -14,7 +14,10 @@ use crate::{
     workspace::{Workspace, load_workspace},
 };
 
-use super::lookup::WorkspaceLookup;
+use super::{
+    issue_text::{TextIssueFormat, format_text_issue},
+    lookup::WorkspaceLookup,
+};
 
 #[derive(Debug, Clone, Copy)]
 enum TopLevelSection {
@@ -497,29 +500,7 @@ fn collapse_whitespace(value: &str) -> String {
 }
 
 fn format_non_interactive_issue(issue: &Issue) -> Vec<String> {
-    let mut header = format!("  [{}] {}", issue.code, issue.subject);
-    if let Some(location) = issue.location.as_deref() {
-        header.push_str(&format!(" ({location})"));
-    }
-
-    if let Some(rule) = rule_by_code(&issue.code) {
-        header.push_str(&format!(
-            " — {}: {}",
-            rule.title,
-            collapse_whitespace(&issue.message)
-        ));
-    } else {
-        header.push_str(&format!(": {}", collapse_whitespace(&issue.message)));
-    }
-
-    let mut lines = vec![header];
-    if let Some(suggestion) = &issue.suggestion {
-        lines.push(format!(
-            "    suggestion: {}",
-            collapse_whitespace(suggestion)
-        ));
-    }
-    lines
+    format_text_issue(issue, TextIssueFormat::BrowseNonInteractive)
 }
 
 #[cfg(test)]

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -22,9 +22,11 @@ use crate::{
         CheckResult, DefinitionCounts, Feature, FeatureRegistryDocument, Issue, Philosophy, Policy,
         Requirement, Severity, TraceCount, TraceReference, TraceSummary,
     },
-    rules::{all_rules, attach_referenced_rules, referenced_rules, rule_by_code, rule_genre},
+    rules::{all_rules, attach_referenced_rules, referenced_rules, rule_genre},
     workspace::{Workspace, load_workspace},
 };
+
+use super::issue_text::{TextIssueFormat, format_text_issue};
 
 #[derive(Debug, Clone, Copy)]
 enum TraceRole {
@@ -823,33 +825,8 @@ fn render_text_report(
         writeln!(&mut output).expect("writing to String must succeed");
         writeln!(&mut output, "issues:").expect("writing to String must succeed");
         for issue in &result.issues {
-            let location = issue
-                .location
-                .as_deref()
-                .map(|value| format!(" ({value})"))
-                .unwrap_or_default();
-            writeln!(
-                &mut output,
-                "- [{:?}] {}{} {}{}: {}",
-                issue.severity,
-                issue.code,
-                rule_title_suffix(&issue.code),
-                issue.subject,
-                location,
-                issue.message
-            )
-            .expect("writing to String must succeed");
-            if let Some(rule) = rule_by_code(&issue.code) {
-                writeln!(
-                    &mut output,
-                    "  rule: {} / {} / {}",
-                    rule.genre, rule.code, rule.title
-                )
-                .expect("writing to String must succeed");
-            }
-            if let Some(suggestion) = &issue.suggestion {
-                writeln!(&mut output, "  suggestion: {suggestion}")
-                    .expect("writing to String must succeed");
+            for line in format_text_issue(issue, TextIssueFormat::Validate) {
+                writeln!(&mut output, "{line}").expect("writing to String must succeed");
             }
         }
     } else if let Some(filtered_view) = filtered_view
@@ -915,12 +892,6 @@ fn render_text_report(
     }
 
     output
-}
-
-fn rule_title_suffix(code: &str) -> String {
-    rule_by_code(code)
-        .map(|rule| format!(" ({})", rule.title))
-        .unwrap_or_default()
 }
 
 fn collapse_whitespace(value: &str) -> String {

--- a/src/command/issue_text.rs
+++ b/src/command/issue_text.rs
@@ -1,0 +1,94 @@
+use crate::model::Issue;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TextIssueFormat {
+    Validate,
+    BrowseNonInteractive,
+}
+
+pub(super) fn format_text_issue(issue: &Issue, format: TextIssueFormat) -> Vec<String> {
+    match format {
+        TextIssueFormat::Validate => {
+            let mut lines = vec![format!(
+                "- [{:?}] {}{} {}: {}",
+                issue.severity,
+                issue.code,
+                rule_title_suffix(&issue.code),
+                issue_subject_with_location(issue),
+                issue.message
+            )];
+
+            if let Some(rule) = crate::rules::rule_by_code(&issue.code) {
+                lines.push(format!(
+                    "  rule: {} / {} / {}",
+                    rule.genre, rule.code, rule.title
+                ));
+            }
+            if let Some(suggestion) = issue_suggestion(issue, false) {
+                lines.push(format!("  suggestion: {suggestion}"));
+            }
+
+            lines
+        }
+        TextIssueFormat::BrowseNonInteractive => {
+            let separator = if crate::rules::rule_by_code(&issue.code).is_some() {
+                " — "
+            } else {
+                ": "
+            };
+            let mut lines = vec![format!(
+                "  [{}] {}{}{}",
+                issue.code,
+                issue_subject_with_location(issue),
+                separator,
+                issue_message_with_rule_title(issue, true)
+            )];
+
+            if let Some(suggestion) = issue_suggestion(issue, true) {
+                lines.push(format!("    suggestion: {suggestion}"));
+            }
+
+            lines
+        }
+    }
+}
+
+fn issue_subject_with_location(issue: &Issue) -> String {
+    let mut subject = issue.subject.clone();
+    if let Some(location) = issue.location.as_deref() {
+        subject.push_str(&format!(" ({location})"));
+    }
+    subject
+}
+
+fn issue_message_with_rule_title(issue: &Issue, collapse: bool) -> String {
+    let message = if collapse {
+        collapse_whitespace(&issue.message)
+    } else {
+        issue.message.clone()
+    };
+
+    crate::rules::rule_by_code(&issue.code)
+        .map(|rule| format!("{}: {message}", rule.title))
+        .unwrap_or(message)
+}
+
+fn issue_suggestion(issue: &Issue, collapse: bool) -> Option<String> {
+    issue.suggestion.as_ref().map(|suggestion| {
+        if collapse {
+            collapse_whitespace(suggestion)
+        } else {
+            suggestion.clone()
+        }
+    })
+}
+
+fn rule_title_suffix(code: &str) -> String {
+    crate::rules::rule_by_code(code)
+        .map(|rule| format!(" ({})", rule.title))
+        .unwrap_or_default()
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/src/command/issue_text.rs
+++ b/src/command/issue_text.rs
@@ -41,7 +41,7 @@ pub(super) fn format_text_issue(issue: &Issue, format: TextIssueFormat) -> Vec<S
                 issue.code,
                 issue_subject_with_location(issue),
                 separator,
-                issue_message_with_rule_title(issue, true)
+                issue_message_with_rule_title(issue)
             )];
 
             if let Some(suggestion) = issue_suggestion(issue, true) {
@@ -61,13 +61,8 @@ fn issue_subject_with_location(issue: &Issue) -> String {
     subject
 }
 
-fn issue_message_with_rule_title(issue: &Issue, collapse: bool) -> String {
-    let message = if collapse {
-        collapse_whitespace(&issue.message)
-    } else {
-        issue.message.clone()
-    };
-
+fn issue_message_with_rule_title(issue: &Issue) -> String {
+    let message = collapse_whitespace(&issue.message);
     crate::rules::rule_by_code(&issue.code)
         .map(|rule| format!("{}: {message}", rule.title))
         .unwrap_or(message)

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod browse;
 pub mod check;
 pub mod init;
+mod issue_text;
 pub mod list;
 mod lookup;
 pub mod report;

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -232,4 +232,16 @@ fn browse_command_non_interactive_shows_errors_when_workspace_is_failing() {
         stdout.contains("SYU-graph-reference-001"),
         "should list error codes: {stdout}"
     );
+    assert!(
+        stdout.contains("Linked definitions must exist"),
+        "should include rule titles: {stdout}"
+    );
+    assert!(
+        stdout.contains("Linked requirement `REQ-MISSING-999` does not exist."),
+        "should include issue messages: {stdout}"
+    );
+    assert!(
+        stdout.contains("suggestion: Declare requirement `REQ-MISSING-999`"),
+        "should include actionable suggestions: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary\n- include rule titles, messages, locations, and suggestions in non-interactive browse error output\n- cover the richer plain-text output with browse command tests and a formatting helper fallback test\n- update the self-hosted browse feature spec and generated docs to reflect the more actionable error snapshot\n\n## Testing\n- cargo test --test browse_command\n- cargo run --quiet -- browse tests/fixtures/workspaces/failing --non-interactive\n- scripts/ci/quality-gates.sh\n- scripts/ci/coverage.sh summary\n\nCloses #238