### PR TITLE
feat: guide add reciprocal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ syu init .                           # 1. Create spec scaffold
 syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
 ```
 
+`syu add requirement` prints the generated requirement path plus the reciprocal-link
+follow-up you still need before validation will pass.
+
 Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
 (or your configured `spec.root`), add at least one `linked_policies:` entry and
 one `linked_features:` entry, then update those policy and feature documents so

--- a/docs/generated/site-spec/features/cli/add.md
+++ b/docs/generated/site-spec/features/cli/add.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/add.yaml"
 
 - **id**: FEAT-ADD-001
   - **title**: Follow-up spec authoring scaffold
-  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
+  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-020
@@ -41,7 +41,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -217,9 +217,11 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
-      for it, and `syu add --interactive` SHOULD let them confirm or override the
-      default feature kind and target YAML path before writing the stub.
+      work while explicitly guiding contributors toward the reciprocal links they
+      still need before the next validation run. When contributors omit the ID in
+      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
+      SHOULD let them confirm or override the default feature kind and target
+      YAML path before writing the stub.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -442,9 +444,11 @@ requirements:
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
-      for it, and `syu add --interactive` SHOULD let them confirm or override the
-      default feature kind and target YAML path before writing the stub.
+      work while explicitly guiding contributors toward the reciprocal links they
+      still need before the next validation run. When contributors omit the ID in
+      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
+      SHOULD let them confirm or override the default feature kind and target
+      YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/syu/features/cli/add.yaml
+++ b/docs/syu/features/cli/add.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -195,9 +195,11 @@ requirements:
       the requested ID, MUST honor the configured `spec.root`, and MUST update
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
-      work. When contributors omit the ID in a terminal, `syu add` SHOULD prompt
-      for it, and `syu add --interactive` SHOULD let them confirm or override the
-      default feature kind and target YAML path before writing the stub.
+      work while explicitly guiding contributors toward the reciprocal links they
+      still need before the next validation run. When contributors omit the ID in
+      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
+      SHOULD let them confirm or override the default feature kind and target
+      YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,8 @@ Examples:
   syu init path/to/workspace --name my-project --spec-root spec/contracts --template polyglot --id-prefix store";
 
 const ADD_AFTER_HELP: &str = "\
+After writing a stub, `syu add` prints the reciprocal-link follow-up needed before `syu validate` will pass cleanly.
+
 Examples:
   syu add philosophy PHIL-002
   syu add policy POL-002 --file docs/syu/policies/policies.yaml

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -102,6 +102,41 @@ struct ParsedId {
     file_slug: String,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ReciprocalLinkField {
+    yaml_key: &'static str,
+    linked_kind_label: &'static str,
+}
+
+const PHILOSOPHY_RECIPROCAL_LINK_FIELDS: &[ReciprocalLinkField] = &[ReciprocalLinkField {
+    yaml_key: "linked_policies",
+    linked_kind_label: "policy",
+}];
+const POLICY_RECIPROCAL_LINK_FIELDS: &[ReciprocalLinkField] = &[
+    ReciprocalLinkField {
+        yaml_key: "linked_philosophies",
+        linked_kind_label: "philosophy",
+    },
+    ReciprocalLinkField {
+        yaml_key: "linked_requirements",
+        linked_kind_label: "requirement",
+    },
+];
+const REQUIREMENT_RECIPROCAL_LINK_FIELDS: &[ReciprocalLinkField] = &[
+    ReciprocalLinkField {
+        yaml_key: "linked_policies",
+        linked_kind_label: "policy",
+    },
+    ReciprocalLinkField {
+        yaml_key: "linked_features",
+        linked_kind_label: "feature",
+    },
+];
+const FEATURE_RECIPROCAL_LINK_FIELDS: &[ReciprocalLinkField] = &[ReciprocalLinkField {
+    yaml_key: "linked_requirements",
+    linked_kind_label: "requirement",
+}];
+
 impl ParsedId {
     fn parse(layer: LookupKind, raw: &str) -> Result<Self> {
         let normalized = normalize_definition_id(raw, layer)?;
@@ -606,23 +641,97 @@ fn render_new_document(
     }
 }
 
+fn reciprocal_link_fields(layer: LookupKind) -> &'static [ReciprocalLinkField] {
+    match layer {
+        LookupKind::Philosophy => PHILOSOPHY_RECIPROCAL_LINK_FIELDS,
+        LookupKind::Policy => POLICY_RECIPROCAL_LINK_FIELDS,
+        LookupKind::Requirement => REQUIREMENT_RECIPROCAL_LINK_FIELDS,
+        LookupKind::Feature => FEATURE_RECIPROCAL_LINK_FIELDS,
+    }
+}
+
+fn render_reciprocal_link_stub(layer: LookupKind) -> String {
+    reciprocal_link_fields(layer)
+        .iter()
+        .map(|field| format!("    {}: []", field.yaml_key))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_instruction_list(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [item] => item.clone(),
+        [first, second] => format!("{first} and {second}"),
+        _ => {
+            let mut joined = items[..items.len() - 1].join(", ");
+            joined.push_str(", and ");
+            joined.push_str(&items[items.len() - 1]);
+            joined
+        }
+    }
+}
+
+fn reciprocal_link_entry_instruction(layer: LookupKind, id: &str) -> String {
+    let fields = reciprocal_link_fields(layer)
+        .iter()
+        .map(|field| format!("`{}:`", field.yaml_key))
+        .collect::<Vec<_>>();
+
+    match fields.as_slice() {
+        [field] => format!("Add at least one {field} entry in `{id}`."),
+        [first, second] => {
+            format!("Add at least one {first} entry and one {second} entry in `{id}`.")
+        }
+        _ => {
+            let clauses = fields
+                .iter()
+                .map(|field| format!("at least one {field} entry"))
+                .collect::<Vec<_>>();
+            format!("Add {} in `{id}`.", format_instruction_list(&clauses))
+        }
+    }
+}
+
+fn reciprocal_link_back_instruction(layer: LookupKind, id: &str) -> String {
+    let linked_kinds = reciprocal_link_fields(layer)
+        .iter()
+        .map(|field| field.linked_kind_label.to_string())
+        .collect::<Vec<_>>();
+    let verb = if linked_kinds.len() == 1 {
+        "it links"
+    } else {
+        "they link"
+    };
+
+    format!(
+        "Update each linked {} so {verb} back to `{id}`.",
+        format_instruction_list(&linked_kinds)
+    )
+}
+
 fn render_item_block(layer: LookupKind, parsed_id: &ParsedId) -> String {
+    let reciprocal_links = render_reciprocal_link_stub(layer);
     match layer {
         LookupKind::Philosophy => format!(
-            "  - id: {}\n    title: {}\n    product_design_principle: |\n      Describe the durable product design principle for {}.\n    coding_guideline: |\n      Describe the coding guideline that keeps {} actionable in day-to-day work.\n    linked_policies: []",
-            parsed_id.normalized, parsed_id.title, parsed_id.normalized, parsed_id.normalized
+            "  - id: {}\n    title: {}\n    product_design_principle: |\n      Describe the durable product design principle for {}.\n    coding_guideline: |\n      Describe the coding guideline that keeps {} actionable in day-to-day work.\n{}",
+            parsed_id.normalized,
+            parsed_id.title,
+            parsed_id.normalized,
+            parsed_id.normalized,
+            reciprocal_links
         ),
         LookupKind::Policy => format!(
-            "  - id: {}\n    title: {}\n    summary: Document the rule enforced by {}.\n    description: |\n      Describe how this policy turns philosophy into a concrete contributor rule.\n    linked_philosophies: []\n    linked_requirements: []",
-            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+            "  - id: {}\n    title: {}\n    summary: Document the rule enforced by {}.\n    description: |\n      Describe how this policy turns philosophy into a concrete contributor rule.\n{}",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized, reciprocal_links
         ),
         LookupKind::Requirement => format!(
-            "  - id: {}\n    title: {}\n    description: |\n      Describe the concrete requirement that {} adds to the repository.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features: []\n    tests: {{}}",
-            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+            "  - id: {}\n    title: {}\n    description: |\n      Describe the concrete requirement that {} adds to the repository.\n    priority: high\n    status: planned\n{}\n    tests: {{}}",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized, reciprocal_links
         ),
         LookupKind::Feature => format!(
-            "  - id: {}\n    title: {}\n    summary: Describe the shipped capability that {} represents.\n    status: planned\n    linked_requirements: []\n    implementations: {{}}",
-            parsed_id.normalized, parsed_id.title, parsed_id.normalized
+            "  - id: {}\n    title: {}\n    summary: Describe the shipped capability that {} represents.\n    status: planned\n{}\n    implementations: {{}}",
+            parsed_id.normalized, parsed_id.title, parsed_id.normalized, reciprocal_links
         ),
     }
 }
@@ -744,41 +853,8 @@ fn add_follow_up_steps(
     let mut steps = vec![format!(
         "Edit {target_label} and fill the stub fields for `{id}`."
     )];
-
-    match layer {
-        LookupKind::Philosophy => {
-            steps.push(format!(
-                "Add at least one `linked_policies:` entry in `{id}`."
-            ));
-            steps.push(format!(
-                "Update each linked policy so it links back to `{id}`."
-            ));
-        }
-        LookupKind::Policy => {
-            steps.push(format!(
-                "Add at least one `linked_philosophies:` entry and one `linked_requirements:` entry in `{id}`."
-            ));
-            steps.push(format!(
-                "Update each linked philosophy and requirement so they link back to `{id}`."
-            ));
-        }
-        LookupKind::Requirement => {
-            steps.push(format!(
-                "Add at least one `linked_policies:` entry and one `linked_features:` entry in `{id}`."
-            ));
-            steps.push(format!(
-                "Update each linked policy and feature so they link back to `{id}`."
-            ));
-        }
-        LookupKind::Feature => {
-            steps.push(format!(
-                "Add at least one `linked_requirements:` entry in `{id}`."
-            ));
-            steps.push(format!(
-                "Update each linked requirement so it links back to `{id}`."
-            ));
-        }
-    }
+    steps.push(reciprocal_link_entry_instruction(layer, id));
+    steps.push(reciprocal_link_back_instruction(layer, id));
 
     steps.push(format!(
         "Run `syu validate {}` once the reciprocal links are in place.",

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -726,11 +726,65 @@ fn print_add_summary(
     }
     println!();
     println!("Next steps:");
-    println!("  1. Edit the generated stub fields and reciprocal links");
-    println!(
-        "  2. Run `syu validate {}` once the new item is linked",
+    for (index, step) in add_follow_up_steps(workspace, layer, id, target)
+        .into_iter()
+        .enumerate()
+    {
+        println!("  {}. {step}", index + 1);
+    }
+}
+
+fn add_follow_up_steps(
+    workspace: &Workspace,
+    layer: LookupKind,
+    id: &str,
+    target: &Path,
+) -> Vec<String> {
+    let target_label = display_workspace_path(workspace, target);
+    let mut steps = vec![format!(
+        "Edit {target_label} and fill the stub fields for `{id}`."
+    )];
+
+    match layer {
+        LookupKind::Philosophy => {
+            steps.push(format!(
+                "Add at least one `linked_policies:` entry in `{id}`."
+            ));
+            steps.push(format!(
+                "Update each linked policy so it links back to `{id}`."
+            ));
+        }
+        LookupKind::Policy => {
+            steps.push(format!(
+                "Add at least one `linked_philosophies:` entry and one `linked_requirements:` entry in `{id}`."
+            ));
+            steps.push(format!(
+                "Update each linked philosophy and requirement so they link back to `{id}`."
+            ));
+        }
+        LookupKind::Requirement => {
+            steps.push(format!(
+                "Add at least one `linked_policies:` entry and one `linked_features:` entry in `{id}`."
+            ));
+            steps.push(format!(
+                "Update each linked policy and feature so they link back to `{id}`."
+            ));
+        }
+        LookupKind::Feature => {
+            steps.push(format!(
+                "Add at least one `linked_requirements:` entry in `{id}`."
+            ));
+            steps.push(format!(
+                "Update each linked requirement so it links back to `{id}`."
+            ));
+        }
+    }
+
+    steps.push(format!(
+        "Run `syu validate {}` once the reciprocal links are in place.",
         shell_quote_path(&workspace.root)
-    );
+    ));
+    steps
 }
 
 fn display_workspace_path(workspace: &Workspace, path: &Path) -> String {
@@ -799,8 +853,8 @@ mod tests {
     };
 
     use super::{
-        AddPromptIo, FeatureRegistryUpdate, ParsedId, TargetPath, default_document_path,
-        default_folder_slug, default_title, ensure_target_within_spec_root,
+        AddPromptIo, FeatureRegistryUpdate, ParsedId, TargetPath, add_follow_up_steps,
+        default_document_path, default_folder_slug, default_title, ensure_target_within_spec_root,
         normalize_definition_id, normalize_feature_kind, prepare_feature_registry_update,
         prompt_for_parsed_id, render_item_block, render_new_document,
         resolve_add_invocation_with_prompt_io, resolve_explicit_file, resolve_feature_kind,
@@ -907,6 +961,51 @@ mod tests {
         assert_eq!(default_title(LookupKind::Policy), "New policy");
         assert_eq!(default_title(LookupKind::Feature), "New feature");
         assert_eq!(default_folder_slug(LookupKind::Policy), "policies");
+    }
+
+    #[test]
+    fn add_follow_up_steps_explain_reciprocal_links_for_each_layer() {
+        let (_tempdir, workspace) = test_workspace();
+        let philosophy_target = workspace.spec_root.join("philosophy/foundation.yaml");
+        let policy_target = workspace.spec_root.join("policies/policies.yaml");
+        let requirement_target = workspace.spec_root.join("requirements/auth/auth.yaml");
+        let feature_target = workspace.spec_root.join("features/auth/login.yaml");
+
+        let philosophy_steps = add_follow_up_steps(
+            &workspace,
+            LookupKind::Philosophy,
+            "PHIL-001",
+            &philosophy_target,
+        );
+        let policy_steps =
+            add_follow_up_steps(&workspace, LookupKind::Policy, "POL-001", &policy_target);
+        let requirement_steps = add_follow_up_steps(
+            &workspace,
+            LookupKind::Requirement,
+            "REQ-AUTH-001",
+            &requirement_target,
+        );
+        let feature_steps = add_follow_up_steps(
+            &workspace,
+            LookupKind::Feature,
+            "FEAT-AUTH-LOGIN-001",
+            &feature_target,
+        );
+
+        assert!(philosophy_steps[1].contains("linked_policies"));
+        assert!(philosophy_steps[2].contains("linked policy"));
+        assert!(policy_steps[1].contains("linked_philosophies"));
+        assert!(policy_steps[1].contains("linked_requirements"));
+        assert!(requirement_steps[1].contains("linked_policies"));
+        assert!(requirement_steps[1].contains("linked_features"));
+        assert!(feature_steps[1].contains("linked_requirements"));
+        assert!(feature_steps[2].contains("linked requirement"));
+        assert!(
+            feature_steps
+                .last()
+                .expect("feature guidance should include validation")
+                .contains("syu validate")
+        );
     }
 
     #[test]

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -659,16 +659,13 @@ fn render_reciprocal_link_stub(layer: LookupKind) -> String {
 }
 
 fn format_instruction_list(items: &[String]) -> String {
-    match items {
-        [] => String::new(),
-        [item] => item.clone(),
-        [first, second] => format!("{first} and {second}"),
-        _ => {
-            let mut joined = items[..items.len() - 1].join(", ");
-            joined.push_str(", and ");
-            joined.push_str(&items[items.len() - 1]);
-            joined
-        }
+    let (last, head) = items
+        .split_last()
+        .expect("instruction lists should contain at least one item");
+    if head.is_empty() {
+        last.clone()
+    } else {
+        format!("{} and {last}", head.join(", "))
     }
 }
 
@@ -677,19 +674,21 @@ fn reciprocal_link_entry_instruction(layer: LookupKind, id: &str) -> String {
         .iter()
         .map(|field| format!("`{}:`", field.yaml_key))
         .collect::<Vec<_>>();
+    let (first, rest) = fields
+        .split_first()
+        .expect("each layer should define at least one reciprocal link field");
 
-    match fields.as_slice() {
-        [field] => format!("Add at least one {field} entry in `{id}`."),
-        [first, second] => {
-            format!("Add at least one {first} entry and one {second} entry in `{id}`.")
-        }
-        _ => {
-            let clauses = fields
-                .iter()
-                .map(|field| format!("at least one {field} entry"))
-                .collect::<Vec<_>>();
-            format!("Add {} in `{id}`.", format_instruction_list(&clauses))
-        }
+    if rest.is_empty() {
+        format!("Add at least one {first} entry in `{id}`.")
+    } else {
+        let remaining = rest
+            .iter()
+            .map(|field| format!("one {field} entry"))
+            .collect::<Vec<_>>();
+        format!(
+            "Add at least one {first} entry and {} in `{id}`.",
+            format_instruction_list(&remaining)
+        )
     }
 }
 

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -94,11 +94,19 @@ fn add_command_creates_requirement_files_from_the_id_prefix() {
         .expect("command should run");
 
     assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let file = workspace.join("docs/syu/requirements/auth/auth.yaml");
     let contents = fs::read_to_string(&file).expect("requirement file should exist");
     assert!(contents.contains("prefix: REQ-AUTH"));
     assert!(contents.contains("id: REQ-AUTH-001"));
     assert!(contents.contains("status: planned"));
+    assert!(stdout.contains("Next steps:"));
+    assert!(stdout.contains("Edit docs/syu/requirements/auth/auth.yaml"));
+    assert!(stdout.contains("linked_policies:` entry and one `linked_features:` entry"));
+    assert!(
+        stdout
+            .contains("Update each linked policy and feature so they link back to `REQ-AUTH-001`.")
+    );
 }
 
 #[test]
@@ -116,12 +124,21 @@ fn add_command_updates_the_feature_registry_for_new_feature_files() {
         .expect("command should run");
 
     assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let feature_file = workspace.join("docs/syu/features/auth/login.yaml");
     let registry = fs::read_to_string(workspace.join("docs/syu/features/features.yaml"))
         .expect("feature registry should exist");
     assert!(feature_file.exists(), "feature file should be created");
     assert!(registry.contains("kind: auth"));
     assert!(registry.contains("file: auth/login.yaml"));
+    assert!(stdout.contains("updated docs/syu/features/features.yaml"));
+    assert!(
+        stdout.contains("Add at least one `linked_requirements:` entry in `FEAT-AUTH-LOGIN-001`.")
+    );
+    assert!(
+        stdout
+            .contains("Update each linked requirement so it links back to `FEAT-AUTH-LOGIN-001`.")
+    );
 }
 
 #[test]

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -86,6 +86,7 @@ fn add_help_mentions_explicit_file_and_feature_kind() {
     assert!(stdout.contains("--interactive"));
     assert!(stdout.contains("--file"));
     assert!(stdout.contains("--kind"));
+    assert!(stdout.contains("prints the reciprocal-link follow-up needed"));
     assert!(stdout.contains("syu add requirement --interactive"));
     assert!(stdout.contains("FEAT-AUTH-LOGIN-001 --kind auth"));
 }


### PR DESCRIPTION
## Summary\n- make syu add print layer-aware reciprocal-link follow-up steps before the next validation run\n- cover the new guidance in add/help tests and keep the output concise but specific\n- update the add feature/requirement specs, generated docs, CLI help, and README newcomer flow\n\n## Testing\n- cargo test --test add_command --test help_command\n- cargo run --quiet -- init "/workspace" && cargo run --quiet -- add requirement REQ-AUTH-001 "/workspace"\n- cargo run --quiet -- add feature FEAT-AUTH-LOGIN-001 "/workspace" --kind auth\n- scripts/ci/quality-gates.sh\n- scripts/ci/coverage.sh summary\n\nCloses #237