### PR TITLE
docs: fix polyglot trace coverage references

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Key behaviors:
 - `validate.allow_planned` controls whether `planned` requirements and features are allowed at all
 - `validate.require_non_orphaned_items` turns isolated layered definitions into validation errors
 - `validate.require_reciprocal_links` keeps adjacent-layer backlinks mandatory by default while still allowing phased migration when disabled
-- `validate.require_symbol_trace_coverage` opt-in checks that public Rust symbols belong to features and tests belong to requirements
+- `validate.require_symbol_trace_coverage` opt-in checks that public Rust, Python, and TypeScript/JavaScript symbols belong to features and tests belong to requirements
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence
 - `app.bind` and `app.port` define the default local browser-app address and port unless `--bind` / `--port` override them
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -83,11 +83,12 @@ description: "Generated reference for docs/syu/config/validate.yaml"
 - **key**: validate.require_symbol_trace_coverage
   - **type**: boolean
   - **default**: False
-  - **summary**: Enforces ownership for public Rust symbols and Rust tests.
+  - **summary**: Enforces ownership for public Rust, Python, and TypeScript/JavaScript symbols and tests.
   - **description**:
     - |
-      When enabled, `syu` requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement, in addition to
+      When enabled, `syu` requires every public Rust, Python, and
+      TypeScript/JavaScript symbol to belong to some feature and every test in
+      those supported languages to belong to some requirement, in addition to
       verifying declared traces. The validate command can enable or disable this
       for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.
@@ -155,10 +156,11 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust symbols and Rust tests.
+    summary: Enforces ownership for public Rust, Python, and TypeScript/JavaScript symbols and tests.
     description: |
-      When enabled, `syu` requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement, in addition to
+      When enabled, `syu` requires every public Rust, Python, and
+      TypeScript/JavaScript symbol to belong to some feature and every test in
+      those supported languages to belong to some requirement, in addition to
       verifying declared traces. The validate command can enable or disable this
       for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -374,14 +374,15 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
   - **genre**: coverage
   - **severity**: error
   - **title**: Coverage inventory paths must be walkable
-  - **summary**: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
+  - **summary**: Strict trace coverage starts by discovering supported Rust, Python, and TypeScript/JavaScript source and test files under `src/` and `tests/`.
   - **description**:
     - |
       The strict trace coverage rule only means something when `syu` can walk the
-      repository paths that are supposed to contain owned Rust source and test
-      files. If directory discovery fails, the inventory itself is incomplete and
-      any 100-percent coverage conclusion would be misleading. This rule surfaces
-      repository layout problems before coverage claims become untrustworthy.
+      repository paths that are supposed to contain owned Rust, Python, and
+      TypeScript/JavaScript source and test files. If directory discovery fails,
+      the inventory itself is incomplete and any 100-percent coverage conclusion
+      would be misleading. This rule surfaces repository layout problems before
+      coverage claims become untrustworthy.
 - **code**: SYU-coverage-read-001
   - **genre**: coverage
   - **severity**: error
@@ -798,13 +799,14 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, and TypeScript/JavaScript source and test files under `src/` and `tests/`.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
-      repository paths that are supposed to contain owned Rust source and test
-      files. If directory discovery fails, the inventory itself is incomplete and
-      any 100-percent coverage conclusion would be misleading. This rule surfaces
-      repository layout problems before coverage claims become untrustworthy.
+      repository paths that are supposed to contain owned Rust, Python, and
+      TypeScript/JavaScript source and test files. If directory discovery fails,
+      the inventory itself is incomplete and any 100-percent coverage conclusion
+      would be misleading. This rule surfaces repository layout problems before
+      coverage claims become untrustworthy.
 
   - code: SYU-coverage-read-001
     genre: coverage

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -58,10 +58,11 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust symbols and Rust tests.
+    summary: Enforces ownership for public Rust, Python, and TypeScript/JavaScript symbols and tests.
     description: |
-      When enabled, `syu` requires every public Rust symbol to belong to some
-      feature and every Rust test to belong to some requirement, in addition to
+      When enabled, `syu` requires every public Rust, Python, and
+      TypeScript/JavaScript symbol to belong to some feature and every test in
+      those supported languages to belong to some requirement, in addition to
       verifying declared traces. The validate command can enable or disable this
       for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.

--- a/docs/syu/features/validation/validation.yaml
+++ b/docs/syu/features/validation/validation.yaml
@@ -363,13 +363,14 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering Rust sources under `src/` and `tests/`.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, and TypeScript/JavaScript source and test files under `src/` and `tests/`.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
-      repository paths that are supposed to contain owned Rust source and test
-      files. If directory discovery fails, the inventory itself is incomplete and
-      any 100-percent coverage conclusion would be misleading. This rule surfaces
-      repository layout problems before coverage claims become untrustworthy.
+      repository paths that are supposed to contain owned Rust, Python, and
+      TypeScript/JavaScript source and test files. If directory discovery fails,
+      the inventory itself is incomplete and any 100-percent coverage conclusion
+      would be misleading. This rule surfaces repository layout problems before
+      coverage claims become untrustworthy.
 
   - code: SYU-coverage-read-001
     genre: coverage

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -385,16 +385,22 @@ fn repository_declares_documentation_guides() {
     assert!(config_spec.contains("spec.root"));
     assert!(config_validate.contains("validate.default_fix"));
     assert!(config_validate.contains("validate.require_symbol_trace_coverage"));
+    assert!(config_validate.contains("Rust, Python, and TypeScript/JavaScript"));
     assert!(config_runtimes.contains("runtimes.python.command"));
     assert!(generated_config_overview.contains("docs/syu/config/overview.yaml"));
     assert!(generated_config_overview.contains("current CLI version"));
     assert!(generated_config_spec.contains("docs/syu/config/spec.yaml"));
     assert!(generated_config_validate.contains("validate.default_fix"));
+    assert!(generated_config_validate.contains("Rust, Python, and TypeScript/JavaScript"));
     assert!(generated_config_runtimes.contains("docs/syu/config/runtimes.yaml"));
     assert!(generated_site_index.contains("/docs/generated/site-spec/features/cli/show-list"));
     assert!(generated_site_index.contains("/docs/generated/site-spec/features/validation"));
     assert!(generated_validation.contains("docs/syu/features/validation/validation.yaml"));
     assert!(generated_validation.contains("SYU-graph-reference-001"));
+    assert!(
+        generated_validation
+            .contains("Rust, Python, and TypeScript/JavaScript source and test files")
+    );
     assert!(generated_docs_freshness.contains("FEAT-QUALITY-001"));
     assert!(generated_docs_freshness.contains("check_generated_docs_freshness"));
     assert!(generated_docs_freshness.contains("python3 scripts/generate-site-docs.py"));


### PR DESCRIPTION
## Summary
- align the self-hosted validation rule docs with the Rust/Python/TypeScript-JavaScript coverage implementation
- fix the matching config reference and README wording so all trace-coverage docs describe the same language scope
- add repository-quality assertions that keep the generated validation/config docs from regressing back to Rust-only wording

## Testing
- bash scripts/ci/quality-gates.sh

Closes #250
