### PR TITLE
feat: guide syu add with adjacent scaffold suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,15 @@ syu init .                           # 1. Create spec scaffold
 syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
 ```
 
-`syu add requirement` prints the generated requirement path plus the reciprocal-link
-follow-up you still need before validation will pass.
+`syu add requirement` prints the generated requirement path, the reciprocal-link
+follow-up you still need, and matching `syu add ...` suggestions for adjacent
+stubs before validation will pass.
 
 Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
 (or your configured `spec.root`), add at least one `linked_policies:` entry and
-one `linked_features:` entry, then update those policy and feature documents so
-they link back to the new requirement.
+one `linked_features:` entry, scaffold any still-missing adjacent policy or
+feature document with the suggested commands, then update those policy and
+feature documents so they link back to the new requirement.
 
 ```bash
 syu validate .                       # 3. Check everything is linked
@@ -281,8 +283,10 @@ syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.ya
 `syu add` keeps the command intentionally small. It derives a default title and
 document path from the ID, uses the configured `spec.root`, and updates
 `features/features.yaml` automatically when you scaffold a new feature document.
-Edit the generated stub fields and reciprocal links before you expect
-`syu validate` to pass cleanly.
+It also prints matching scaffold suggestions for adjacent definitions so the
+next reciprocal-link edits are concrete instead of guesswork. Edit the generated
+stub fields and reciprocal links before you expect `syu validate` to pass
+cleanly.
 
 ### `syu validate`
 

--- a/docs/generated/site-spec/features/cli/add.md
+++ b/docs/generated/site-spec/features/cli/add.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/add.yaml"
 
 - **id**: FEAT-ADD-001
   - **title**: Follow-up spec authoring scaffold
-  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
+  - **summary**: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance plus matching adjacent scaffold suggestions before the next validation run.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-020
@@ -41,7 +41,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance plus matching adjacent scaffold suggestions before the next validation run.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -218,10 +218,11 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
       work while explicitly guiding contributors toward the reciprocal links they
-      still need before the next validation run. When contributors omit the ID in
-      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
-      SHOULD let them confirm or override the default feature kind and target
-      YAML path before writing the stub.
+      still need before the next validation run, including concrete scaffold
+      commands for adjacent definitions when those documents do not exist yet.
+      When contributors omit the ID in a terminal, `syu add` SHOULD prompt for
+      it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -445,10 +446,11 @@ requirements:
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
       work while explicitly guiding contributors toward the reciprocal links they
-      still need before the next validation run. When contributors omit the ID in
-      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
-      SHOULD let them confirm or override the default feature kind and target
-      YAML path before writing the stub.
+      still need before the next validation run, including concrete scaffold
+      commands for adjacent definitions when those documents do not exist yet.
+      When contributors omit the ID in a terminal, `syu add` SHOULD prompt for
+      it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,8 +25,9 @@ syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
 
 Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
 (or your configured `spec.root`), add at least one `linked_policies:` entry and
-one `linked_features:` entry, then update those policy and feature documents so
-they link back to the new requirement.
+one `linked_features:` entry, scaffold any still-missing adjacent policy or
+feature document with the suggested commands, then update those policy and
+feature documents so they link back to the new requirement.
 
 ```bash
 syu validate .                       # 3. Check everything is linked

--- a/docs/syu/features/cli/add.yaml
+++ b/docs/syu/features/cli/add.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-ADD-001
     title: Follow-up spec authoring scaffold
-    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance before the next validation run.
+    summary: Scaffold new philosophy, policy, requirement, and feature YAML stubs after init, with optional terminal prompts for missing IDs or custom paths, while keeping feature registry maintenance explicit and printing layer-aware reciprocal-link follow-up guidance plus matching adjacent scaffold suggestions before the next validation run.
     status: implemented
     linked_requirements:
       - REQ-CORE-020

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -196,10 +196,11 @@ requirements:
       the explicit feature registry when creating a new feature document. Output
       SHOULD stay concise enough for normal code review and hand-edited follow-up
       work while explicitly guiding contributors toward the reciprocal links they
-      still need before the next validation run. When contributors omit the ID in
-      a terminal, `syu add` SHOULD prompt for it, and `syu add --interactive`
-      SHOULD let them confirm or override the default feature kind and target
-      YAML path before writing the stub.
+      still need before the next validation run, including concrete scaffold
+      commands for adjacent definitions when those documents do not exist yet.
+      When contributors omit the ID in a terminal, `syu add` SHOULD prompt for
+      it, and `syu add --interactive` SHOULD let them confirm or override the
+      default feature kind and target YAML path before writing the stub.
     priority: medium
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ Examples:
   syu init path/to/workspace --name my-project --spec-root spec/contracts --template polyglot --id-prefix store";
 
 const ADD_AFTER_HELP: &str = "\
-After writing a stub, `syu add` prints the reciprocal-link follow-up needed before `syu validate` will pass cleanly.
+After writing a stub, `syu add` prints the reciprocal-link follow-up and matching scaffold suggestions needed before `syu validate` will pass cleanly.
 
 Examples:
   syu add philosophy PHIL-002

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -669,6 +669,59 @@ fn format_instruction_list(items: &[String]) -> String {
     }
 }
 
+fn suggested_linked_kinds(layer: LookupKind) -> &'static [LookupKind] {
+    match layer {
+        LookupKind::Philosophy => &[LookupKind::Policy],
+        LookupKind::Policy => &[LookupKind::Philosophy, LookupKind::Requirement],
+        LookupKind::Requirement => &[LookupKind::Policy, LookupKind::Feature],
+        LookupKind::Feature => &[LookupKind::Requirement],
+    }
+}
+
+fn suggested_linked_id(id: &str, kind: LookupKind) -> String {
+    let mut segments = id.split('-').collect::<Vec<_>>();
+    segments[0] = match kind {
+        LookupKind::Philosophy => "PHIL",
+        LookupKind::Policy => "POL",
+        LookupKind::Requirement => "REQ",
+        LookupKind::Feature => "FEAT",
+    };
+    segments.join("-")
+}
+
+fn scaffold_missing_link_instruction(workspace: &Workspace, layer: LookupKind, id: &str) -> String {
+    let linked_kinds = suggested_linked_kinds(layer);
+    let linked_labels = linked_kinds
+        .iter()
+        .map(|kind| kind.label().to_string())
+        .collect::<Vec<_>>();
+    let workspace_arg = shell_quote_path(&workspace.root);
+    let commands = linked_kinds
+        .iter()
+        .map(|kind| {
+            format!(
+                "`syu add {} {} {workspace_arg}`",
+                kind.label(),
+                suggested_linked_id(id, *kind)
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if linked_kinds.len() == 1 {
+        format!(
+            "If the linked {} stub does not exist yet, scaffold it with {}.",
+            linked_kinds[0].label(),
+            commands[0]
+        )
+    } else {
+        format!(
+            "If linked {} stubs are still missing, scaffold them with {}.",
+            format_instruction_list(&linked_labels),
+            format_instruction_list(&commands)
+        )
+    }
+}
+
 fn reciprocal_link_entry_instruction(layer: LookupKind, id: &str) -> String {
     let fields = reciprocal_link_fields(layer)
         .iter()
@@ -853,6 +906,7 @@ fn add_follow_up_steps(
         "Edit {target_label} and fill the stub fields for `{id}`."
     )];
     steps.push(reciprocal_link_entry_instruction(layer, id));
+    steps.push(scaffold_missing_link_instruction(workspace, layer, id));
     steps.push(reciprocal_link_back_instruction(layer, id));
 
     steps.push(format!(
@@ -1068,13 +1122,19 @@ mod tests {
         );
 
         assert!(philosophy_steps[1].contains("linked_policies"));
-        assert!(philosophy_steps[2].contains("linked policy"));
+        assert!(philosophy_steps[2].contains("syu add policy POL-001"));
+        assert!(philosophy_steps[3].contains("linked policy"));
         assert!(policy_steps[1].contains("linked_philosophies"));
         assert!(policy_steps[1].contains("linked_requirements"));
+        assert!(policy_steps[2].contains("syu add philosophy PHIL-001"));
+        assert!(policy_steps[2].contains("syu add requirement REQ-001"));
         assert!(requirement_steps[1].contains("linked_policies"));
         assert!(requirement_steps[1].contains("linked_features"));
+        assert!(requirement_steps[2].contains("syu add policy POL-AUTH-001"));
+        assert!(requirement_steps[2].contains("syu add feature FEAT-AUTH-001"));
         assert!(feature_steps[1].contains("linked_requirements"));
-        assert!(feature_steps[2].contains("linked requirement"));
+        assert!(feature_steps[2].contains("syu add requirement REQ-AUTH-LOGIN-001"));
+        assert!(feature_steps[3].contains("linked requirement"));
         assert!(
             feature_steps
                 .last()

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -1010,7 +1010,7 @@ mod tests {
         normalize_definition_id, normalize_feature_kind, prepare_feature_registry_update,
         prompt_for_parsed_id, render_item_block, render_new_document,
         resolve_add_invocation_with_prompt_io, resolve_explicit_file, resolve_feature_kind,
-        resolve_interactive_file_prompt, run_add_command, title_case_slug,
+        resolve_interactive_file_prompt, run_add_command, suggested_linked_id, title_case_slug,
         validate_existing_document, write_feature_registry_update, write_stub_document,
     };
 
@@ -1163,6 +1163,26 @@ mod tests {
                 .last()
                 .expect("feature guidance should include validation")
                 .contains("syu validate")
+        );
+    }
+
+    #[test]
+    fn suggested_linked_id_rewrites_prefixes_for_each_layer() {
+        assert_eq!(
+            suggested_linked_id("POL-AUTH-001", LookupKind::Philosophy),
+            "PHIL-AUTH-001"
+        );
+        assert_eq!(
+            suggested_linked_id("REQ-AUTH-001", LookupKind::Policy),
+            "POL-AUTH-001"
+        );
+        assert_eq!(
+            suggested_linked_id("FEAT-AUTH-001", LookupKind::Requirement),
+            "REQ-AUTH-001"
+        );
+        assert_eq!(
+            suggested_linked_id("REQ-AUTH-001", LookupKind::Feature),
+            "FEAT-AUTH-001"
         );
     }
 

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -672,7 +672,9 @@ fn format_instruction_list(items: &[String]) -> String {
 fn suggested_linked_kinds(layer: LookupKind) -> &'static [LookupKind] {
     match layer {
         LookupKind::Philosophy => &[LookupKind::Policy],
-        LookupKind::Policy => &[LookupKind::Philosophy, LookupKind::Requirement],
+        // Policies usually attach to an existing project philosophy; synthesizing a
+        // "matching" philosophy ID from a policy ID is too misleading to suggest.
+        LookupKind::Policy => &[LookupKind::Requirement],
         LookupKind::Requirement => &[LookupKind::Policy, LookupKind::Feature],
         LookupKind::Feature => &[LookupKind::Requirement],
     }
@@ -689,36 +691,53 @@ fn suggested_linked_id(id: &str, kind: LookupKind) -> String {
     segments.join("-")
 }
 
-fn scaffold_missing_link_instruction(workspace: &Workspace, layer: LookupKind, id: &str) -> String {
-    let linked_kinds = suggested_linked_kinds(layer);
-    let linked_labels = linked_kinds
-        .iter()
-        .map(|kind| kind.label().to_string())
-        .collect::<Vec<_>>();
+fn scaffold_missing_link_instruction(
+    workspace: &Workspace,
+    layer: LookupKind,
+    id: &str,
+) -> Option<String> {
+    let lookup = WorkspaceLookup::new(workspace);
     let workspace_arg = shell_quote_path(&workspace.root);
+    let linked_kinds = suggested_linked_kinds(layer)
+        .iter()
+        .filter_map(|kind| {
+            let suggested_id = suggested_linked_id(id, *kind);
+            (lookup.find(&suggested_id).is_none()).then_some((*kind, suggested_id))
+        })
+        .collect::<Vec<_>>();
+
+    if linked_kinds.is_empty() {
+        return None;
+    }
+
     let commands = linked_kinds
         .iter()
-        .map(|kind| {
+        .map(|(kind, suggested_id)| {
             format!(
                 "`syu add {} {} {workspace_arg}`",
                 kind.label(),
-                suggested_linked_id(id, *kind)
+                suggested_id
             )
         })
         .collect::<Vec<_>>();
 
     if linked_kinds.len() == 1 {
-        format!(
+        let (kind, _) = linked_kinds[0];
+        Some(format!(
             "If the linked {} stub does not exist yet, scaffold it with {}.",
-            linked_kinds[0].label(),
+            kind.label(),
             commands[0]
-        )
+        ))
     } else {
-        format!(
+        let linked_labels = linked_kinds
+            .iter()
+            .map(|(kind, _)| kind.label().to_string())
+            .collect::<Vec<_>>();
+        Some(format!(
             "If linked {} stubs are still missing, scaffold them with {}.",
             format_instruction_list(&linked_labels),
             format_instruction_list(&commands)
-        )
+        ))
     }
 }
 
@@ -906,7 +925,9 @@ fn add_follow_up_steps(
         "Edit {target_label} and fill the stub fields for `{id}`."
     )];
     steps.push(reciprocal_link_entry_instruction(layer, id));
-    steps.push(scaffold_missing_link_instruction(workspace, layer, id));
+    if let Some(scaffold_instruction) = scaffold_missing_link_instruction(workspace, layer, id) {
+        steps.push(scaffold_instruction);
+    }
     steps.push(reciprocal_link_back_instruction(layer, id));
 
     steps.push(format!(
@@ -968,6 +989,7 @@ fn title_case_slug(slug: &str) -> String {
 mod tests {
     use anyhow::Result;
     use std::{
+        collections::BTreeMap,
         collections::VecDeque,
         fs,
         path::{Path, PathBuf},
@@ -978,6 +1000,7 @@ mod tests {
     use crate::{
         cli::{AddArgs, InitArgs, LookupKind, OutputFormat, StarterTemplate},
         config::SyuConfig,
+        model::Requirement,
         workspace::Workspace,
     };
 
@@ -1126,8 +1149,8 @@ mod tests {
         assert!(philosophy_steps[3].contains("linked policy"));
         assert!(policy_steps[1].contains("linked_philosophies"));
         assert!(policy_steps[1].contains("linked_requirements"));
-        assert!(policy_steps[2].contains("syu add philosophy PHIL-001"));
         assert!(policy_steps[2].contains("syu add requirement REQ-001"));
+        assert!(!policy_steps[2].contains("syu add philosophy"));
         assert!(requirement_steps[1].contains("linked_policies"));
         assert!(requirement_steps[1].contains("linked_features"));
         assert!(requirement_steps[2].contains("syu add policy POL-AUTH-001"));
@@ -1140,6 +1163,41 @@ mod tests {
                 .last()
                 .expect("feature guidance should include validation")
                 .contains("syu validate")
+        );
+    }
+
+    #[test]
+    fn add_follow_up_steps_skip_existing_scaffold_commands() {
+        let (_tempdir, mut workspace) = test_workspace();
+        workspace.requirements.push(Requirement {
+            id: "REQ-AUTH-001".to_string(),
+            title: "Existing requirement".to_string(),
+            description: "Already scaffolded".to_string(),
+            priority: "high".to_string(),
+            status: "planned".to_string(),
+            linked_policies: Vec::new(),
+            linked_features: Vec::new(),
+            tests: BTreeMap::new(),
+        });
+        let policy_target = workspace.spec_root.join("policies/policies.yaml");
+
+        let policy_steps = add_follow_up_steps(
+            &workspace,
+            LookupKind::Policy,
+            "POL-AUTH-001",
+            &policy_target,
+        );
+
+        assert_eq!(policy_steps.len(), 4);
+        assert!(
+            !policy_steps
+                .iter()
+                .any(|step| step.contains("syu add requirement REQ-AUTH-001"))
+        );
+        assert!(
+            !policy_steps
+                .iter()
+                .any(|step| step.contains("syu add philosophy"))
         );
     }
 

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -103,6 +103,8 @@ fn add_command_creates_requirement_files_from_the_id_prefix() {
     assert!(stdout.contains("Next steps:"));
     assert!(stdout.contains("Edit docs/syu/requirements/auth/auth.yaml"));
     assert!(stdout.contains("linked_policies:` entry and one `linked_features:` entry"));
+    assert!(stdout.contains("syu add policy POL-AUTH-001"));
+    assert!(stdout.contains("syu add feature FEAT-AUTH-001"));
     assert!(
         stdout
             .contains("Update each linked policy and feature so they link back to `REQ-AUTH-001`.")
@@ -135,6 +137,7 @@ fn add_command_updates_the_feature_registry_for_new_feature_files() {
     assert!(
         stdout.contains("Add at least one `linked_requirements:` entry in `FEAT-AUTH-LOGIN-001`.")
     );
+    assert!(stdout.contains("syu add requirement REQ-AUTH-LOGIN-001"));
     assert!(
         stdout
             .contains("Update each linked requirement so it links back to `FEAT-AUTH-LOGIN-001`.")

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -146,6 +146,35 @@ fn add_command_updates_the_feature_registry_for_new_feature_files() {
 
 #[test]
 // REQ-CORE-020
+fn add_command_skips_existing_or_unreliable_scaffold_suggestions() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    init_workspace(&workspace, &[]);
+
+    let requirement = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "requirement", "REQ-AUTH-001"])
+        .arg(&workspace)
+        .output()
+        .expect("requirement command should run");
+    assert!(requirement.status.success());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["add", "policy", "POL-AUTH-001"])
+        .arg(&workspace)
+        .output()
+        .expect("policy command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("syu add requirement REQ-AUTH-001"));
+    assert!(!stdout.contains("syu add philosophy"));
+    assert!(stdout.contains("Update each linked philosophy and requirement"));
+}
+
+#[test]
+// REQ-CORE-020
 fn add_command_defaults_feature_kind_from_the_feature_id_prefix() {
     let tempdir = tempdir().expect("tempdir should exist");
     let workspace = tempdir.path().join("workspace");

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -86,7 +86,9 @@ fn add_help_mentions_explicit_file_and_feature_kind() {
     assert!(stdout.contains("--interactive"));
     assert!(stdout.contains("--file"));
     assert!(stdout.contains("--kind"));
-    assert!(stdout.contains("prints the reciprocal-link follow-up needed"));
+    assert!(
+        stdout.contains("prints the reciprocal-link follow-up and matching scaffold suggestions")
+    );
     assert!(stdout.contains("syu add requirement --interactive"));
     assert!(stdout.contains("FEAT-AUTH-LOGIN-001 --kind auth"));
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -267,7 +267,8 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));
     assert!(readme.contains("add at least one `linked_policies:` entry"));
-    assert!(readme.contains("update those policy and feature documents so"));
+    assert!(readme.contains("scaffold any still-missing adjacent policy or"));
+    assert!(readme.contains("feature documents so they link back to the new requirement."));
     assert!(readme.contains("reciprocal links between policies, requirements, and features"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
@@ -314,7 +315,10 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("Start here once `syu` is installed:"));
     assert!(getting_started.contains("Generate a requirement stub"));
     assert!(getting_started.contains("add at least one `linked_policies:` entry"));
-    assert!(getting_started.contains("update those policy and feature documents so"));
+    assert!(getting_started.contains("scaffold any still-missing adjacent policy or"));
+    assert!(
+        getting_started.contains("feature documents so they link back to the new requirement.")
+    );
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("checksums.sha256"));
     assert!(getting_started.contains("security-sensitive environments"));


### PR DESCRIPTION
## Summary
- add matching `syu add ...` suggestions to `syu add` follow-up output so adjacent stubs are easier to scaffold
- document the more guided add flow in the self-hosted spec, README, getting-started guide, and generated docs
- extend add/help/repository-quality coverage for the new guidance

## Testing
- bash scripts/ci/quality-gates.sh

Closes #237
