### PR TITLE
docs: clarify README quick start prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ verified.
 Pick the newcomer path that matches what you need next:
 
 - **Quick start**: stay in this README when you want the shortest path from install
-  to `syu validate .`.
+  to `syu validate .` and only need a short layer refresher before the first
+  commands.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
 - **Troubleshooting**: jump to
@@ -162,9 +163,18 @@ below. The rest of this section assumes you installed the published CLI.
 
 ## Quick start
 
-Before you start: required — read [`docs/guide/concepts.md`](docs/guide/concepts.md)
-first. The next steps assume you already understand the four layers and the
-reciprocal links between policies, requirements, and features.
+Stay in this README for the shortest install-to-validate path. The four layers
+are:
+
+- `philosophy`: the ideal state and values the project protects
+- `policy`: the repository-wide rules that make philosophy operational
+- `requirement`: a specific obligation that satisfies policy
+- `feature`: the implemented capability that satisfies a requirement
+
+Policies, requirements, and features should link to each other so
+`syu validate .` can catch missing reciprocal links and specification drift. If
+you want the fuller rationale and authoring guidance first, read
+[`docs/guide/concepts.md`](docs/guide/concepts.md) before continuing.
 
 Step 0: required — run `syu init .` before any of the other commands in a new repository.
 

--- a/README.md
+++ b/README.md
@@ -163,18 +163,18 @@ below. The rest of this section assumes you installed the published CLI.
 
 ## Quick start
 
-Stay in this README for the shortest install-to-validate path. The four layers
-are:
+Stay in this README for the shortest install-to-validate path. If you skipped
+[`docs/guide/concepts.md`](docs/guide/concepts.md), use the
+[Why four layers?](#why-four-layers) section above as the refresher on
+`philosophy`, `policy`, `requirements`, and `features`.
 
-- `philosophy`: the ideal state and values the project protects
-- `policy`: the repository-wide rules that make philosophy operational
-- `requirement`: a specific obligation that satisfies policy
-- `feature`: the implemented capability that satisfies a requirement
+The first manual edit in this quick start happens in the generated requirement
+YAML: add `linked_policies:` and `linked_features:` there, then update the
+adjacent policy and feature YAML so they add the reciprocal
+`linked_requirements:` entry back to the new requirement.
 
-Policies, requirements, and features should link to each other so
-`syu validate .` can catch missing reciprocal links and specification drift. If
-you want the fuller rationale and authoring guidance first, read
-[`docs/guide/concepts.md`](docs/guide/concepts.md) before continuing.
+Read [`docs/guide/concepts.md`](docs/guide/concepts.md) first if you want the
+fuller rationale and authoring guidance before continuing.
 
 Step 0: required — run `syu init .` before any of the other commands in a new repository.
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -264,12 +264,13 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/tutorial.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
     assert!(readme.contains("shortest install-to-validate path"));
+    assert!(readme.contains("[Why four layers?](#why-four-layers)"));
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));
     assert!(readme.contains("add at least one `linked_policies:` entry"));
+    assert!(readme.contains("`linked_requirements:` entry back to the new requirement"));
     assert!(readme.contains("scaffold any still-missing adjacent policy or"));
     assert!(readme.contains("feature documents so they link back to the new requirement."));
-    assert!(readme.contains("missing reciprocal links and specification drift"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -263,13 +263,13 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("## Choose your path"));
     assert!(readme.contains("docs/guide/tutorial.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
-    assert!(readme.contains("Before you start: required"));
+    assert!(readme.contains("shortest install-to-validate path"));
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));
     assert!(readme.contains("add at least one `linked_policies:` entry"));
     assert!(readme.contains("scaffold any still-missing adjacent policy or"));
     assert!(readme.contains("feature documents so they link back to the new requirement."));
-    assert!(readme.contains("reciprocal links between policies, requirements, and features"));
+    assert!(readme.contains("missing reciprocal links and specification drift"));
     assert!(readme.contains("syu init"));
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));


### PR DESCRIPTION
## Summary
- make the README path chooser warn that Quick start includes only a short layer refresher
- replace the mandatory concepts-guide detour with an inline four-layer refresher in Quick start
- update the repository quality assertion to match the new README-first wording

## Linked issue or specification

- Issue: #255
- Requirement / feature IDs: PHIL-003, POL-004, FEAT-DOCS-001

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed