### PR TITLE
docs: separate README quick start from getting-started

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,9 +9,10 @@ layers before you start editing YAML.
 
 Need a different level of guidance?
 
-- Jump back to the [README quick start](../../README.md#quick-start) when you
-  want the shortest install-to-validate path and are happy with a compact
-  command card.
+- Jump back to the
+  [README quick start on GitHub](https://github.com/ugoite/syu/blob/main/README.md#quick-start)
+  when you want the shortest install-to-validate path and are happy with a
+  compact command card.
 - Stay on this page when you want the first workspace setup explained step by
   step, including why the manual YAML edits matter before validation.
 - Follow the [end-to-end tutorial](./tutorial.md) when you want a realistic,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,30 +9,20 @@ layers before you start editing YAML.
 
 Need a different level of guidance?
 
-- Stay on this page when you want the shortest path from install to a working
-  `syu validate .`.
+- Jump back to the [README quick start](../../README.md#quick-start) when you
+  want the shortest install-to-validate path and are happy with a compact
+  command card.
+- Stay on this page when you want the first workspace setup explained step by
+  step, including why the manual YAML edits matter before validation.
 - Follow the [end-to-end tutorial](./tutorial.md) when you want a realistic,
   worked repository story instead of the shortest setup path.
 - Jump to [troubleshooting](./troubleshooting.md) when validation or linking is
   already failing and you need to unblock a workspace.
 
-Start here once `syu` is installed:
-
-```bash
-syu init .                           # 1. Create spec scaffold
-syu add requirement REQ-AUTH-001     # 2. Generate a requirement stub
-```
-
-Before step 3, open the generated requirement YAML under `docs/syu/requirements/`
-(or your configured `spec.root`), add at least one `linked_policies:` entry and
-one `linked_features:` entry, scaffold any still-missing adjacent policy or
-feature document with the suggested commands, then update those policy and
-feature documents so they link back to the new requirement.
-
-```bash
-syu validate .                       # 3. Check everything is linked
-syu app .                            # 4. Browse in the browser
-```
+This guide assumes `syu` is already installed. Unlike the README quick start,
+it slows down at the first manual editing step so you can see where the
+scaffolded files live, how reciprocal links fit together, and what to fix
+before the first `syu validate .` run.
 
 ## Before you begin
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -312,13 +312,9 @@ fn repository_declares_documentation_guides() {
     assert!(!app_guide.contains("`planned`, `implemented`, or `deprecated`"));
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Need a different level of guidance?"));
-    assert!(getting_started.contains("Start here once `syu` is installed:"));
-    assert!(getting_started.contains("Generate a requirement stub"));
-    assert!(getting_started.contains("add at least one `linked_policies:` entry"));
-    assert!(getting_started.contains("scaffold any still-missing adjacent policy or"));
-    assert!(
-        getting_started.contains("feature documents so they link back to the new requirement.")
-    );
+    assert!(getting_started.contains("README quick start"));
+    assert!(getting_started.contains("first workspace setup explained step by"));
+    assert!(getting_started.contains("slows down at the first manual editing step"));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("checksums.sha256"));
     assert!(getting_started.contains("security-sensitive environments"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -313,6 +313,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Need a different level of guidance?"));
     assert!(getting_started.contains("README quick start"));
+    assert!(getting_started.contains("https://github.com/ugoite/syu/blob/main/README.md#quick-start"));
     assert!(getting_started.contains("first workspace setup explained step by"));
     assert!(getting_started.contains("slows down at the first manual editing step"));
     assert!(getting_started.contains("install-syu.sh"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -313,7 +313,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Need a different level of guidance?"));
     assert!(getting_started.contains("README quick start"));
-    assert!(getting_started.contains("https://github.com/ugoite/syu/blob/main/README.md#quick-start"));
+    assert!(
+        getting_started.contains("https://github.com/ugoite/syu/blob/main/README.md#quick-start")
+    );
     assert!(getting_started.contains("first workspace setup explained step by"));
     assert!(getting_started.contains("slows down at the first manual editing step"));
     assert!(getting_started.contains("install-syu.sh"));


### PR DESCRIPTION
## Summary
- make getting-started explicitly describe itself as the guided first-time path
- send shortest-path readers back to the README quick start instead of duplicating the same command block
- update the repository quality assertions to cover the new guide split

## Linked issue or specification

- Issue: #256
- Requirement / feature IDs: PHIL-003, POL-005, FEAT-DOCS-001

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed