### PR TITLE
docs: clarify tutorial feature registry step

### DIFF
--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -192,9 +192,8 @@ features:
 
 Because this walkthrough keeps using the generated
 `docs/syu/features/core/core.yaml`, the starter registry entry in
-`docs/syu/features/features.yaml` already points at the right file. Keep the
-generated metadata header from `syu init`, and make sure the `files` section
-still looks like this:
+`docs/syu/features/features.yaml` already points at the right file. For this
+tutorial step, just make sure the `files` section still looks like this:
 
 ```yaml
 files:

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -190,8 +190,11 @@ features:
       - REQ-STORE-001
 ```
 
-In `docs/syu/features/features.yaml`, keep the generated metadata header from
-`syu init` and add the new file entry under `files`:
+Because this walkthrough keeps using the generated
+`docs/syu/features/core/core.yaml`, the starter registry entry in
+`docs/syu/features/features.yaml` already points at the right file. Keep the
+generated metadata header from `syu init`, and make sure the `files` section
+still looks like this:
 
 ```yaml
 files:
@@ -199,9 +202,9 @@ files:
     file: core/core.yaml
 ```
 
-If you add another feature document later, keep `docs/syu/features/features.yaml`
-in sync. `syu validate` reports feature YAML files on disk that are missing from
-that registry.
+Only add another `files` entry when you introduce a second feature document
+later. Keep `docs/syu/features/features.yaml` in sync then; `syu validate`
+reports feature YAML files on disk that are missing from that registry.
 
 ---
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -377,6 +377,8 @@ fn repository_declares_documentation_guides() {
     assert!(tutorial.contains("Want a different entry point?"));
     assert!(tutorial.contains("[getting started](./getting-started.md)"));
     assert!(tutorial.contains("[troubleshooting](./troubleshooting.md)"));
+    assert!(tutorial.contains("starter registry entry"));
+    assert!(tutorial.contains("Only add another `files` entry"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("validate.allow_planned"));
     assert!(configuration.contains("Rust, Python, and TypeScript/JavaScript"));


### PR DESCRIPTION
## Summary
- explain that the tutorial keeps using the generated `core/core.yaml` feature document
- show that the starter feature registry entry already covers that walkthrough path
- reserve new `files` entries for the later case where a second feature document is introduced

## Linked issue or specification

- Issue: #257
- Requirement / feature IDs: PHIL-003, FEAT-DOCS-001

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed