### PR TITLE
docs: add contributor model orientation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,11 @@ releaseable at all times.
 
 ## Start with the model
 
-Before you change code, docs, or release workflow, read
-[`docs/guide/concepts.md`](docs/guide/concepts.md). `syu` is built around the
-four-layer model: philosophy -> policy -> requirement -> feature.
+Before you change behavior, specs, contributor guidance, or release workflow,
+read [`docs/guide/concepts.md`](docs/guide/concepts.md). For small typo-only or
+mechanical CI fixes, you can start with the workflow below and come back to the
+guide when you need the fuller model. `syu` is built around the four-layer
+model: philosophy -> policies -> requirements -> features.
 
 The contribution workflow exists to keep those layers connected to real code,
 tests, docs, and maintenance work. In practice that means spec edits under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,17 @@
 `syu` uses GitHub Flow. `main` is the only long-lived branch and it should stay
 releaseable at all times.
 
+## Start with the model
+
+Before you change code, docs, or release workflow, read
+[`docs/guide/concepts.md`](docs/guide/concepts.md). `syu` is built around the
+four-layer model: philosophy -> policy -> requirement -> feature.
+
+The contribution workflow exists to keep those layers connected to real code,
+tests, docs, and maintenance work. In practice that means spec edits under
+`docs/syu/` are part of normal feature and bug-fix work here, not optional
+after-the-fact documentation.
+
 ## Working model
 
 1. Branch from `main`.

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -493,7 +493,7 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("GitHub Flow"));
     assert!(contributing.contains("main"));
     assert!(contributing.contains("docs/guide/concepts.md"));
-    assert!(contributing.contains("philosophy -> policy -> requirement -> feature"));
+    assert!(contributing.contains("philosophy -> policies -> requirements -> features"));
     assert!(contributing.contains("spec edits under"));
     assert!(contributing.contains(".worktrees/"));
     assert!(contributing.contains("scripts/ci/quality-gates.sh"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -492,6 +492,9 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("FEAT-CONTRIB-002"));
     assert!(contributing.contains("GitHub Flow"));
     assert!(contributing.contains("main"));
+    assert!(contributing.contains("docs/guide/concepts.md"));
+    assert!(contributing.contains("philosophy -> policy -> requirement -> feature"));
+    assert!(contributing.contains("spec edits under"));
     assert!(contributing.contains(".worktrees/"));
     assert!(contributing.contains("scripts/ci/quality-gates.sh"));
     assert!(contributing.contains("scripts/ci/check-generated-docs-freshness.sh"));


### PR DESCRIPTION
## Summary
- add a short four-layer orientation section near the top of CONTRIBUTING.md
- point contributors at `docs/guide/concepts.md` before the GitHub Flow workflow
- clarify that spec edits under `docs/syu/` are normal feature and bug-fix work

## Linked issue or specification

- Issue: #258
- Requirement / feature IDs: PHIL-001, PHIL-003, POL-006, FEAT-CONTRIB-002

## Validation

- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes

- [ ] This change should appear in the next release notes
- [x] No release note needed