### PR TITLE
docs: explain devcontainer post-create setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "cargo install cargo-llvm-cov --locked && cargo install wasm-pack --locked && (cd app && npm ci && npx playwright install --with-deps chromium) && bash scripts/install-precommit.sh",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# FEAT-CONTRIB-001
+
+set -euo pipefail
+
+repo_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+log_step() {
+  printf "\n[devcontainer] %s\n" "$1"
+}
+
+install_coverage_tooling() {
+  log_step "Installing cargo-llvm-cov for scripts/ci/coverage.sh summary."
+  cargo install cargo-llvm-cov --locked
+}
+
+install_wasm_tooling() {
+  log_step "Installing wasm-pack for scripts/ci/check-app-dist-freshness.sh."
+  cargo install wasm-pack --locked
+}
+
+install_browser_tooling() {
+  log_step "Installing browser-app dependencies for scripts/ci/check-app-dist-freshness.sh."
+  npm --prefix app ci
+
+  log_step "Installing Playwright Chromium for npm --prefix app run test:e2e."
+  npx --prefix app playwright install --with-deps chromium
+}
+
+install_precommit_tooling() {
+  log_step "Installing local hooks with scripts/install-precommit.sh."
+  bash scripts/install-precommit.sh
+}
+
+main() {
+  local root
+  root="$(repo_root)"
+
+  cd "$root"
+
+  log_step "Setting up the contributor toolchain. See CONTRIBUTING.md#local-checks for the workflows each tool unlocks."
+  install_coverage_tooling
+  install_wasm_tooling
+  install_browser_tooling
+  install_precommit_tooling
+  log_step "Devcontainer setup complete."
+}
+
+main "$@"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -22,7 +22,7 @@ install_wasm_tooling() {
 }
 
 install_browser_tooling() {
-  log_step "Installing browser-app dependencies for scripts/ci/check-app-dist-freshness.sh."
+  log_step "Installing browser-app dependencies for local app builds, scripts/ci/check-app-dist-freshness.sh, and npm --prefix app run test:e2e."
   npm --prefix app ci
 
   log_step "Installing Playwright Chromium for npm --prefix app run test:e2e."
@@ -40,7 +40,7 @@ main() {
 
   cd "$root"
 
-  log_step "Setting up the contributor toolchain. See CONTRIBUTING.md#local-checks for the workflows each tool unlocks."
+  log_step "Setting up the contributor toolchain. See CONTRIBUTING.md#local-checks for what this bootstrap installs and which workflows still stay opt-in."
   install_coverage_tooling
   install_wasm_tooling
   install_browser_tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,10 +109,18 @@ If you use the hooks, install them once:
 scripts/install-precommit.sh
 ```
 
-The devcontainer/Codespaces post-create step runs this script automatically and
-also preinstalls `wasm-pack`, the `app/` dependencies, and Playwright Chromium
-so browser-app validation is ready as soon as the environment finishes
-provisioning.
+The devcontainer/Codespaces post-create step runs
+`.devcontainer/post-create.sh` automatically so the setup explains itself while
+it provisions. That script:
+
+- installs `cargo-llvm-cov` for `scripts/ci/coverage.sh summary`
+- installs `wasm-pack` plus the `app/` dependencies for
+  `scripts/ci/check-app-dist-freshness.sh`
+- installs Playwright Chromium for `npm --prefix app run test:e2e`
+- runs `scripts/install-precommit.sh` so local hooks match the contributor path
+
+Read the script output or this section when you want to map setup time to the
+checks it unlocks.
 
 ## Dependency security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,13 +114,14 @@ The devcontainer/Codespaces post-create step runs
 it provisions. That script:
 
 - installs `cargo-llvm-cov` for `scripts/ci/coverage.sh summary`
-- installs `wasm-pack` plus the `app/` dependencies for
-  `scripts/ci/check-app-dist-freshness.sh`
+- installs `wasm-pack` plus the `app/` dependencies for local browser-app work,
+  `scripts/ci/check-app-dist-freshness.sh`, and `npm --prefix app run test:e2e`
 - installs Playwright Chromium for `npm --prefix app run test:e2e`
 - runs `scripts/install-precommit.sh` so local hooks match the contributor path
 
 Read the script output or this section when you want to map setup time to the
-checks it unlocks.
+checks it unlocks. It does **not** install `website/` docs-site dependencies,
+so run `npm --prefix website ci` yourself when you are working on the docs site.
 
 ## Dependency security
 

--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -30,6 +30,15 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
         - **symbols**:
           - FEAT-CONTRIB-001
           - postCreateCommand
+    - **shell**:
+      - **file**: .devcontainer/post-create.sh
+        - **symbols**:
+          - FEAT-CONTRIB-001
+          - install_coverage_tooling
+          - install_wasm_tooling
+          - install_browser_tooling
+          - install_precommit_tooling
+          - main
     - **rust**:
       - **file**: tests/example_workspaces.rs
         - **symbols**:
@@ -112,6 +121,15 @@ features:
           symbols:
             - FEAT-CONTRIB-001
             - postCreateCommand
+      shell:
+        - file: .devcontainer/post-create.sh
+          symbols:
+            - FEAT-CONTRIB-001
+            - install_coverage_tooling
+            - install_wasm_tooling
+            - install_browser_tooling
+            - install_precommit_tooling
+            - main
       rust:
         - file: tests/example_workspaces.rs
           symbols:

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 68/68
-- Feature-to-implementation traceability: 88/88
+- Feature-to-implementation traceability: 89/89
 
 ## Issues
 

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -15,6 +15,15 @@ features:
           symbols:
             - FEAT-CONTRIB-001
             - postCreateCommand
+      shell:
+        - file: .devcontainer/post-create.sh
+          symbols:
+            - FEAT-CONTRIB-001
+            - install_coverage_tooling
+            - install_wasm_tooling
+            - install_browser_tooling
+            - install_precommit_tooling
+            - main
       rust:
         - file: tests/example_workspaces.rs
           symbols:

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -459,6 +459,8 @@ fn repository_declares_devcontainer_configuration() {
     assert!(post_create.contains("playwright install --with-deps chromium"));
     assert!(post_create.contains("scripts/install-precommit.sh"));
     assert!(post_create.contains("CONTRIBUTING.md#local-checks"));
+    assert!(post_create.contains("local app builds"));
+    assert!(post_create.contains("stay opt-in"));
 }
 
 #[test]
@@ -517,6 +519,8 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("cargo-llvm-cov"));
     assert!(contributing.contains("wasm-pack"));
     assert!(contributing.contains("Playwright Chromium"));
+    assert!(contributing.contains("local browser-app work"));
+    assert!(contributing.contains("does **not** install `website/` docs-site dependencies"));
     assert!(contributing.contains("GitHub Pages"));
     assert!(contributing.contains("release track"));
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -448,13 +448,17 @@ fn repository_declares_documentation_guides() {
 // REQ-CORE-011
 fn repository_declares_devcontainer_configuration() {
     let devcontainer = read_file(".devcontainer/devcontainer.json");
+    let post_create = read_file(".devcontainer/post-create.sh");
     assert!(devcontainer.contains("FEAT-CONTRIB-001"));
-    assert!(devcontainer.contains("cargo install cargo-llvm-cov --locked"));
-    assert!(devcontainer.contains("cargo install wasm-pack --locked"));
-    assert!(devcontainer.contains("cd app && npm ci"));
-    assert!(devcontainer.contains("playwright install --with-deps chromium"));
-    assert!(devcontainer.contains("scripts/install-precommit.sh"));
+    assert!(devcontainer.contains("bash .devcontainer/post-create.sh"));
     assert!(devcontainer.contains("ghcr.io/devcontainers/features/python:1"));
+    assert!(post_create.contains("FEAT-CONTRIB-001"));
+    assert!(post_create.contains("cargo install cargo-llvm-cov --locked"));
+    assert!(post_create.contains("cargo install wasm-pack --locked"));
+    assert!(post_create.contains("npm --prefix app ci"));
+    assert!(post_create.contains("playwright install --with-deps chromium"));
+    assert!(post_create.contains("scripts/install-precommit.sh"));
+    assert!(post_create.contains("CONTRIBUTING.md#local-checks"));
 }
 
 #[test]
@@ -509,6 +513,8 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains(".github/actions/build-docs-site"));
     assert!(contributing.contains("scripts/install-precommit.sh"));
     assert!(contributing.contains("devcontainer/Codespaces post-create step"));
+    assert!(contributing.contains(".devcontainer/post-create.sh"));
+    assert!(contributing.contains("cargo-llvm-cov"));
     assert!(contributing.contains("wasm-pack"));
     assert!(contributing.contains("Playwright Chromium"));
     assert!(contributing.contains("GitHub Pages"));


### PR DESCRIPTION
Summary:
- move the devcontainer post-create flow into a named shell script under .devcontainer
- make the setup log explain which local checks each installed tool unlocks
- update contributor docs, self-spec references, and repository quality assertions for the new script

Linked issue or specification:
- Issue: #260
- Requirement / feature IDs: PHIL-002, PHIL-003, POL-006, FEAT-CONTRIB-001

Validation:
- [x] scripts/ci/quality-gates.sh
- [ ] scripts/ci/coverage.sh summary (required when Rust logic changes)
- [x] cargo run -- validate .
- [x] Docs, examples, or self-spec updated when behavior changed

Release notes:
- [ ] This change should appear in the next release notes
- [x] No release note needed