### PR TITLE
fix: reorder interactive browse layers

### DIFF
--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -23,8 +23,8 @@ use super::{
 enum TopLevelSection {
     Philosophy,
     Policy,
-    Feature,
     Requirement,
+    Feature,
     Errors,
 }
 
@@ -61,6 +61,46 @@ struct BrowseState {
     result: CheckResult,
 }
 
+impl TopLevelSection {
+    const MENU_ORDER: [Self; 5] = [
+        Self::Philosophy,
+        Self::Policy,
+        Self::Requirement,
+        Self::Feature,
+        Self::Errors,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Philosophy => "philosophy",
+            Self::Policy => "policy",
+            Self::Requirement => "requirement",
+            Self::Feature => "feature",
+            Self::Errors => "errors",
+        }
+    }
+
+    fn count(self, result: &CheckResult) -> usize {
+        match self {
+            Self::Philosophy => result.definition_counts.philosophies,
+            Self::Policy => result.definition_counts.policies,
+            Self::Requirement => result.definition_counts.requirements,
+            Self::Feature => result.definition_counts.features,
+            Self::Errors => result.issues.len(),
+        }
+    }
+
+    fn into_view(self) -> View {
+        match self {
+            Self::Philosophy => View::List(EntityKind::Philosophy),
+            Self::Policy => View::List(EntityKind::Policy),
+            Self::Requirement => View::List(EntityKind::Requirement),
+            Self::Feature => View::List(EntityKind::Feature),
+            Self::Errors => View::Errors,
+        }
+    }
+}
+
 impl BrowseState {
     fn lookup(&self) -> Option<WorkspaceLookup<'_>> {
         self.workspace.as_ref().map(WorkspaceLookup::new)
@@ -72,13 +112,7 @@ impl BrowseState {
         loop {
             view = match view {
                 View::Menu => match self.show_top_level_menu()? {
-                    Some(section) => match section {
-                        TopLevelSection::Philosophy => View::List(EntityKind::Philosophy),
-                        TopLevelSection::Policy => View::List(EntityKind::Policy),
-                        TopLevelSection::Feature => View::List(EntityKind::Feature),
-                        TopLevelSection::Requirement => View::List(EntityKind::Requirement),
-                        TopLevelSection::Errors => View::Errors,
-                    },
+                    Some(section) => section.into_view(),
                     None => return Ok(0),
                 },
                 View::List(kind) => match self.show_entity_list(kind)? {
@@ -102,32 +136,21 @@ impl BrowseState {
     }
 
     fn show_top_level_menu(&self) -> Result<Option<TopLevelSection>> {
-        const SECTIONS: [TopLevelSection; 5] = [
-            TopLevelSection::Philosophy,
-            TopLevelSection::Policy,
-            TopLevelSection::Requirement,
-            TopLevelSection::Feature,
-            TopLevelSection::Errors,
-        ];
-
         self.print_summary("syu interactive browser");
-        println!(
-            "1. philosophy ({})",
-            self.result.definition_counts.philosophies
-        );
-        println!("2. policy ({})", self.result.definition_counts.policies);
-        println!(
-            "3. requirement ({})",
-            self.result.definition_counts.requirements
-        );
-        println!("4. feature ({})", self.result.definition_counts.features);
-        println!("5. errors ({})", self.result.issues.len());
+        for (index, section) in TopLevelSection::MENU_ORDER.iter().enumerate() {
+            println!(
+                "{}. {} ({})",
+                index + 1,
+                section.label(),
+                section.count(&self.result)
+            );
+        }
         println!("0. exit");
 
         match prompt_number("Select a section", 5)? {
             Some(0) => Ok(None),
             None => Ok(None),
-            Some(choice) => Ok(SECTIONS.get(choice - 1).copied()),
+            Some(choice) => Ok(TopLevelSection::MENU_ORDER.get(choice - 1).copied()),
         }
     }
 

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -105,8 +105,8 @@ impl BrowseState {
         const SECTIONS: [TopLevelSection; 5] = [
             TopLevelSection::Philosophy,
             TopLevelSection::Policy,
-            TopLevelSection::Feature,
             TopLevelSection::Requirement,
+            TopLevelSection::Feature,
             TopLevelSection::Errors,
         ];
 
@@ -116,11 +116,11 @@ impl BrowseState {
             self.result.definition_counts.philosophies
         );
         println!("2. policy ({})", self.result.definition_counts.policies);
-        println!("3. feature ({})", self.result.definition_counts.features);
         println!(
-            "4. requirement ({})",
+            "3. requirement ({})",
             self.result.definition_counts.requirements
         );
+        println!("4. feature ({})", self.result.definition_counts.features);
         println!("5. errors ({})", self.result.issues.len());
         println!("0. exit");
 
@@ -343,11 +343,11 @@ impl BrowseState {
         println!("=== {heading} ===");
         println!("workspace: {}", self.result.workspace_root.display());
         println!(
-            "philosophy={} policy={} feature={} requirement={} errors={}",
+            "philosophy={} policy={} requirement={} feature={} errors={}",
             self.result.definition_counts.philosophies,
             self.result.definition_counts.policies,
-            self.result.definition_counts.features,
             self.result.definition_counts.requirements,
+            self.result.definition_counts.features,
             self.result.issues.len()
         );
         println!();

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -106,6 +106,40 @@ fn browse_command_walks_all_sections_in_a_passing_workspace() {
 }
 
 #[test]
+fn browse_command_menu_uses_documented_layer_order() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("browse")
+        .arg(fixture_path("passing"))
+        .write_stdin("0\n")
+        .output()
+        .expect("browse command should run");
+
+    assert!(output.status.success(), "browse UI should not fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let philosophy_index = stdout.find("1. philosophy").expect("philosophy item");
+    let policy_index = stdout.find("2. policy").expect("policy item");
+    let requirement_index = stdout.find("3. requirement").expect("requirement item");
+    let feature_index = stdout.find("4. feature").expect("feature item");
+    let summary = stdout
+        .lines()
+        .find(|line| line.starts_with("philosophy="))
+        .expect("summary line");
+
+    assert!(
+        philosophy_index < policy_index
+            && policy_index < requirement_index
+            && requirement_index < feature_index,
+        "interactive menu should follow the documented layer order:\n{stdout}",
+    );
+    assert!(
+        summary.find("requirement=").expect("requirement count")
+            < summary.find("feature=").expect("feature count"),
+        "summary counts should list requirement before feature:\n{summary}",
+    );
+}
+
+#[test]
 fn browse_command_handles_detail_views_without_links() {
     let tempdir = tempdir().expect("tempdir should exist");
     let docs_root = tempdir.path().join("docs/syu");

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -140,6 +140,50 @@ fn browse_command_menu_uses_documented_layer_order() {
 }
 
 #[test]
+fn browse_command_menu_selection_three_opens_requirements() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("browse")
+        .arg(fixture_path("passing"))
+        .write_stdin("3\n1\n0\n0\n")
+        .output()
+        .expect("browse command should run");
+
+    assert!(output.status.success(), "browse UI should not fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== requirement detail ==="),
+        "selection 3 should open the requirement layer:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("=== feature detail ==="),
+        "selection 3 should not dispatch to the feature layer:\n{stdout}",
+    );
+}
+
+#[test]
+fn browse_command_menu_selection_four_opens_features() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("browse")
+        .arg(fixture_path("passing"))
+        .write_stdin("4\n1\n0\n0\n")
+        .output()
+        .expect("browse command should run");
+
+    assert!(output.status.success(), "browse UI should not fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== feature detail ==="),
+        "selection 4 should open the feature layer:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("=== requirement detail ==="),
+        "selection 4 should not dispatch to the requirement layer:\n{stdout}",
+    );
+}
+
+#[test]
 fn browse_command_handles_detail_views_without_links() {
     let tempdir = tempdir().expect("tempdir should exist");
     let docs_root = tempdir.path().join("docs/syu");


### PR DESCRIPTION
Summary:
- reorder the interactive browse top-level menu to philosophy, policy, requirement, feature, errors
- align the shared browse summary counts with the same documented hierarchy
- add browse command coverage that locks the interactive menu order in place

Linked issue or specification:
- Issue: #261
- Requirement / feature IDs: PHIL-003, POL-004, FEAT-CLI-BROWSE

Validation:
- [x] scripts/ci/quality-gates.sh
- [ ] scripts/ci/coverage.sh summary (required when Rust logic changes)
- [x] cargo run -- validate .
- [x] Docs, examples, or self-spec updated when behavior changed

Release notes:
- [ ] This change should appear in the next release notes
- [x] No release note needed