### PR TITLE
ci: name browser app artifacts by run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,8 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v7
         with:
-          name: browser-app-dist
+          # Keep a stable prefix for discovery while tying each artifact to one run.
+          name: browser-app-dist-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
           path: app/dist
           if-no-files-found: error
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -715,7 +715,11 @@ fn repository_ships_browser_app() {
     assert!(ci_workflow.contains("Build browser app bundle"));
     assert!(ci_workflow.contains("scripts/ci/check-browser-app-freshness.sh"));
     assert!(ci_workflow.contains("if: success()"));
-    assert!(ci_workflow.contains("name: browser-app-dist"));
+    assert!(
+        ci_workflow.contains(
+            "browser-app-dist-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}"
+        )
+    );
     assert!(build_script.contains("syu-app-dist"));
     assert!(build_script.contains("npm ci"));
     assert!(build_script.contains("build:wasm"));


### PR DESCRIPTION
## Summary
- replace the stale hardcoded browser-app artifact name with a run-scoped name
- keep the uploaded bundle easy to tie back to the failing workflow run
- add repository-quality coverage for the artifact naming convention

Closes #306