### PR TITLE
fix: stabilize CodeQL on merge_group

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,9 +46,14 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: rust
+          ref: ${{ github.event_name == 'merge_group' && format('refs/heads/{0}', github.event.repository.default_branch) || '' }}
+          sha: ${{ github.event_name == 'merge_group' && github.sha || '' }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          ref: ${{ github.event_name == 'merge_group' && format('refs/heads/{0}', github.event.repository.default_branch) || '' }}
+          sha: ${{ github.event_name == 'merge_group' && github.sha || '' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,8 +46,6 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: rust
-          ref: ${{ github.event_name == 'merge_group' && format('refs/heads/{0}', github.event.repository.default_branch) || '' }}
-          sha: ${{ github.event_name == 'merge_group' && github.sha || '' }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
## Summary\n- pass an explicit stable ref and sha to CodeQL when the workflow is triggered by merge_group\n- avoid relying on the ephemeral gh-readonly-queue ref for analysis reporting\n\nThis should unblock the merge queue when CodeQL is the required check.