### PR TITLE
fix: explain browser trace metrics for first-time users

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -628,6 +628,11 @@ function App() {
                 note="validated / declared"
                 tone="sky"
                 ratio={requirementTraceRatio}
+                hint={{
+                  label: "Requirement traces",
+                  description:
+                    "Declared traces are the requirement test references written in the spec. Validated traces are the declared references that syu could confirm in the current workspace. A gap means some declared requirement traces are stale or unresolved.",
+                }}
               />
               <CompactMetric
                 label="feature traces"
@@ -635,6 +640,11 @@ function App() {
                 note="validated / declared"
                 tone="violet"
                 ratio={featureTraceRatio}
+                hint={{
+                  label: "Feature traces",
+                  description:
+                    "Declared traces are the feature implementation references written in the spec. Validated traces are the declared references that syu could confirm in the current workspace. A gap means some declared feature traces are stale or unresolved.",
+                }}
               />
             </div>
           </section>
@@ -1243,12 +1253,17 @@ function CompactMetric({
   note,
   tone = "sky",
   ratio,
+  hint,
 }: {
   label: string;
   value: string;
   note: string;
   tone?: "sky" | "violet";
   ratio?: number;
+  hint?: {
+    label: string;
+    description: string;
+  };
 }) {
   const barClass = tone === "violet" ? "bg-violet-300" : "bg-sky-300";
 
@@ -1256,7 +1271,10 @@ function CompactMetric({
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3">
       <p className="text-[11px] uppercase tracking-[0.25em] text-slate-500">{label}</p>
       <p className="mt-2 text-lg font-semibold text-white">{value}</p>
-      <p className="mt-1 text-xs text-slate-400">{note}</p>
+      <div className="mt-1 flex items-center gap-1.5 text-xs text-slate-400">
+        <p>{note}</p>
+        {hint ? <InfoHint label={hint.label} description={hint.description} /> : null}
+      </div>
       {typeof ratio === "number" ? (
         <div className="mt-3 h-2 rounded-full bg-white/5">
           <div className={`h-full rounded-full ${barClass}`} style={{ width: `${ratio * 100}%` }} />

--- a/app/tests/browser-app.spec.ts
+++ b/app/tests/browser-app.spec.ts
@@ -168,6 +168,21 @@ test("loads deep links and supports keyboard search navigation", async ({ page }
   ).toBeVisible();
 });
 
+test("explains requirement and feature trace metrics", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", {
+      name: /Requirement traces: Declared traces are the requirement test references written in the spec\./i,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: /Feature traces: Declared traces are the feature implementation references written in the spec\./i,
+    }),
+  ).toBeVisible();
+});
+
 test("keeps duplicate validation issues independently selectable", async ({ page, request }) => {
   test.skip(!usesFailingWorkspace, "requires the failing fixture workspace");
 


### PR DESCRIPTION
## Summary\n- explain the requirement/feature trace metrics inline in the browser workspace sidebar\n- reuse the existing info-hint UI so the metrics stay lightweight but discoverable\n- cover the new hints in Playwright while keeping the browser build artifacts in sync\n\n## Testing\n- npm --prefix app run check\n- npm --prefix app run build\n- npm --prefix app run test:e2e\n- cargo test\n\nCloses #333