### PR TITLE
docs: link migration guide in README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Pick the newcomer path that matches what you need next:
   [`docs/guide/existing-repository.md`](docs/guide/existing-repository.md) when
   the repository already has code and history and you want an incremental
   adoption path instead of starting with `syu init`.
+- **Upgrade or migration**: start with
+  [`docs/guide/migration.md`](docs/guide/migration.md) when you are updating an
+  existing `syu` workspace between alpha releases and need the release-specific
+  upgrade steps first.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
 - **Trace adapter matrix**: open
@@ -55,6 +59,7 @@ Keep the detailed guides close:
 
 - [`docs/guide/concepts.md`](docs/guide/concepts.md)
 - [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
+- [`docs/guide/migration.md`](docs/guide/migration.md)
 - [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
 - [`docs/guide/existing-repository.md`](docs/guide/existing-repository.md)
 - [`docs/guide/tutorial.md`](docs/guide/tutorial.md)

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,8 +1,9 @@
 # Migration guide
 
-This page documents breaking changes and upgrade steps for each `syu` alpha
-release. When `syu validate .` starts failing after an upgrade, check the
-section for the version you just installed.
+Start here when you are upgrading an existing `syu` workspace between alpha
+releases. This page documents breaking changes and release-specific upgrade
+steps. When `syu validate .` starts failing after an upgrade, check the section
+for the version you just installed.
 
 > **Note:** `syu` is in alpha. The config schema, YAML spec format, and CLI
 > flags may change in any alpha release. This guide is updated with every


### PR DESCRIPTION
## Summary
- add an upgrade and migration path to the README newcomer chooser
- include the migration guide in the README guide list
- clarify at the top of the migration guide that it is the starting point for alpha upgrades

## Linked issue or specification
- Issue: #374
- Requirement / feature IDs: FEAT-DOCS-001

## Validation
- [x] bash scripts/ci/quality-gates.sh
- [x] cargo run -- validate .
- [x] npm --prefix website ci
- [x] npm --prefix website run build
