### PR TITLE
docs: add visual-first README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Pick the newcomer path that matches what you need next:
   [`docs/guide/existing-repository.md`](docs/guide/existing-repository.md) when
   the repository already has code and history and you want an incremental
   adoption path instead of starting with `syu init`.
+- **Visual explorer**: open [`docs/guide/app.md`](docs/guide/app.md) or run
+  `syu app .` when you want graphical spec navigation before learning the full
+  CLI workflow.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
 - **Trace adapter matrix**: open

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -4,6 +4,11 @@
 
 `syu app .` serves a local browser UI for exploring your workspace specification interactively.
 
+If you started from the README newcomer chooser, this guide is the visual-first
+path back into the same onboarding flow. Return to the
+[`site landing page`](/) when you want the text-first install, tutorial,
+migration, or troubleshooting entry points instead.
+
 ```bash
 syu app .
 # → syu app listening on http://127.0.0.1:3000


### PR DESCRIPTION
## Summary
- add a visual-first path to the README newcomer chooser
- point that path at the browser app guide and `syu app .`
- link the app guide back to the main landing-page entry points

## Linked issue or specification
- Issue: #373
- Requirement / feature IDs: FEAT-DOCS-001, FEAT-APP-001

## Validation
- [x] bash scripts/ci/quality-gates.sh
- [x] cargo run -- validate .
- [x] npm --prefix website ci
- [x] npm --prefix website run build
