### PR TITLE
docs: clarify examples and templates links

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,10 +599,10 @@ missing files.
 
 The repository ships working example projects:
 
-- [`examples/rust-only`](examples/rust-only) — minimal single-language Rust starter
-- [`examples/python-only`](examples/python-only) — minimal Python-first starter
-- [`examples/polyglot`](examples/polyglot) — one requirement and feature traced across Rust, Python, and TypeScript
-- [`examples/team-scale`](examples/team-scale) — a larger Rust workspace that shows phased adoption, nested documents, and recovery drills
+- [`examples/rust-only`](examples/rust-only) — minimal single-language Rust starter, and the checked-in match for `syu init . --template rust-only`
+- [`examples/python-only`](examples/python-only) — minimal Python-first starter, and the checked-in match for `syu init . --template python-only`
+- [`examples/polyglot`](examples/polyglot) — one requirement and feature traced across Rust, Python, and TypeScript, and the checked-in match for `syu init . --template polyglot`
+- [`examples/team-scale`](examples/team-scale) — a larger Rust workspace that shows phased adoption, nested documents, and recovery drills; reference-only, not a starter template
 
 Each one is validated in the automated test suite.
 

--- a/examples/polyglot/README.md
+++ b/examples/polyglot/README.md
@@ -4,6 +4,8 @@ This example demonstrates a multi-language workspace where a single
 requirement and feature are traced across **Rust**, **Python**, and
 **TypeScript** source files simultaneously.
 
+It is the checked-in reference workspace that matches `syu init . --template polyglot`.
+
 ## Files
 
 | Path | What it defines |

--- a/examples/python-only/README.md
+++ b/examples/python-only/README.md
@@ -4,6 +4,8 @@ This example demonstrates a minimal single-language Python workspace.
 It contains one philosophy, one policy, one requirement, and one feature —
 all mutually linked and traced to a Python test file.
 
+It is the checked-in reference workspace that matches `syu init . --template python-only`.
+
 ## Files
 
 | Path | What it defines |

--- a/examples/rust-only/README.md
+++ b/examples/rust-only/README.md
@@ -4,6 +4,8 @@ This example demonstrates a minimal single-language Rust workspace.
 It contains one philosophy, one policy, one requirement, and one feature —
 all mutually linked and traced to a Rust source file.
 
+It is the checked-in reference workspace that matches `syu init . --template rust-only`.
+
 ## Files
 
 | Path | What it defines |

--- a/examples/team-scale/README.md
+++ b/examples/team-scale/README.md
@@ -5,6 +5,9 @@ the single-feature starter shape. It keeps one philosophy, two policies, three
 requirements, and four features split across nested documents and traced into
 separate Rust source and test files.
 
+Unlike the smaller language-focused examples, this workspace is reference-only:
+it does not correspond to a `syu init --template ...` starter.
+
 ## What this example demonstrates
 
 - **Team-scale growth**: multiple requirements and features are split by area


### PR DESCRIPTION
## Summary
- label which checked-in examples correspond to starter templates
- call out team-scale as a reference-only example
- make the README examples list explain the template/example relationship directly

## Linked issue or specification
- Issue: #375
- Requirement / feature IDs: FEAT-DOCS-001

## Validation
- [x] bash scripts/ci/quality-gates.sh
- [x] cargo run -- validate .
- [x] npm --prefix website ci
- [x] npm --prefix website run build
