### PR TITLE
feat: clarify which README path fits which reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,24 @@ verified.
 
 Pick the newcomer path that matches what you need next:
 
-- **Getting started**: if you are using `syu` for the first time and want the
-  shortest install-to-validate path, the in-page four-layer refresher is the
-  fastest path through first workspace setup explained step by step.
-- **Quick start**: stay in this README when you want the shortest path from install
-  to `syu validate .` and only need a short layer refresher before the first
-  commands.
+- **Getting started**: choose this if you are new to `syu`, want a guided first
+  run, and do **not** already know the four-layer model. Expect the most
+  hand-holding and roughly 10-15 minutes for the first workspace setup.
+- **Quick start**: stay in this README when you already want a compact reference
+  card, are happy with a short layer refresher, and want the fastest install-to-
+  `syu validate .` path in about 5 minutes.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
-  want a realistic end-to-end repository story instead of a short scaffold flow.
+  learn best from a realistic repository story, want more narrative context than
+  Quick start, and do not mind a longer walkthrough.
 - **Trace adapter matrix**: open
   [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
-  when you already have a workspace and need to know which built-in languages
-  support symbol validation only versus richer `doc_contains` and strict
-  coverage checks.
+  when you already have a workspace and need a capability reference for which
+  built-in languages support symbol validation only versus richer
+  `doc_contains` and strict coverage checks.
 - **Troubleshooting**: jump to
   [`docs/guide/troubleshooting.md`](docs/guide/troubleshooting.md) when validation
-  or traceability errors are already blocking you.
+  or traceability errors are already blocking you and you want the shortest path
+  to unblocking an existing workspace instead of following the onboarding flow.
 
 Keep the detailed guides close:
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -298,12 +298,14 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/spec-antipatterns.md"));
     assert!(readme.contains("docs/guide/vscode-extension.md"));
     assert!(readme.contains("shortest install-to-validate path"));
-    assert!(readme.contains("the in-page four-layer refresher is"));
+    assert!(readme.contains("do **not** already know the four-layer model"));
     assert!(readme.contains("**Getting started**"));
-    assert!(readme.contains("using `syu` for the first time"));
+    assert!(readme.contains("new to `syu`"));
     assert!(readme.contains("already have a workspace"));
-    assert!(readme.contains("first workspace setup"));
-    assert!(readme.contains("explained step by step"));
+    assert!(readme.contains("10-15 minutes"));
+    assert!(readme.contains("about 5 minutes"));
+    assert!(readme.contains("longer walkthrough"));
+    assert!(readme.contains("unblocking an existing workspace"));
     assert!(readme.contains("[Why four layers?](#why-four-layers)"));
     assert!(readme.contains("Step 0: required"));
     assert!(readme.contains("Generate a requirement stub"));


### PR DESCRIPTION
## Summary\n- clarify who each README entry path is for, including prior knowledge and time/depth expectations\n- make Quick start vs Getting started vs Tutorial easier to choose without guessing\n- keep the repository quality assertions aligned with the updated README wording\n\nCloses #264