### PR TITLE
feat: link the migration guide from the README chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Pick the newcomer path that matches what you need next:
   commands.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
+- **Migration / upgrade**: open [`docs/guide/migration.md`](docs/guide/migration.md)
+  when you already have a `syu` workspace and want the release-specific steps
+  for moving between alpha versions safely.
 - **Trace adapter matrix**: open
   [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
   when you already have a workspace and need to know which built-in languages
@@ -53,6 +56,7 @@ Keep the detailed guides close:
 - [`docs/guide/concepts.md`](docs/guide/concepts.md)
 - [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - [`docs/guide/tutorial.md`](docs/guide/tutorial.md)
+- [`docs/guide/migration.md`](docs/guide/migration.md)
 - [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
 - [`docs/guide/configuration.md`](docs/guide/configuration.md)
 - [`docs/guide/spec-antipatterns.md`](docs/guide/spec-antipatterns.md)

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -294,12 +294,14 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/trace-adapter-support.md"));
     assert!(readme.contains("Trace adapter matrix"));
     assert!(readme.contains("docs/guide/tutorial.md"));
+    assert!(readme.contains("docs/guide/migration.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
     assert!(readme.contains("docs/guide/spec-antipatterns.md"));
     assert!(readme.contains("docs/guide/vscode-extension.md"));
     assert!(readme.contains("shortest install-to-validate path"));
     assert!(readme.contains("the in-page four-layer refresher is"));
     assert!(readme.contains("**Getting started**"));
+    assert!(readme.contains("**Migration / upgrade**"));
     assert!(readme.contains("using `syu` for the first time"));
     assert!(readme.contains("already have a workspace"));
     assert!(readme.contains("first workspace setup"));


### PR DESCRIPTION
## Summary\n- add a migration/upgrade entry to the README path chooser\n- include the migration guide in the main README guide list\n- keep the repository quality assertions aligned with the updated guide list\n\nCloses #374