### PR TITLE
feat: surface the visual explorer guide from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Pick the newcomer path that matches what you need next:
   commands.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
+- **Visual explorer**: start with [`docs/guide/app.md`](docs/guide/app.md) or run
+  `syu app .` when you want graphical spec navigation before learning the full
+  text-first CLI flow.
 - **Trace adapter matrix**: open
   [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
   when you already have a workspace and need to know which built-in languages
@@ -53,6 +56,7 @@ Keep the detailed guides close:
 - [`docs/guide/concepts.md`](docs/guide/concepts.md)
 - [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - [`docs/guide/tutorial.md`](docs/guide/tutorial.md)
+- [`docs/guide/app.md`](docs/guide/app.md)
 - [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
 - [`docs/guide/configuration.md`](docs/guide/configuration.md)
 - [`docs/guide/spec-antipatterns.md`](docs/guide/spec-antipatterns.md)

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -6,8 +6,9 @@
 
 If you started from the README newcomer chooser, this guide is the visual-first
 path back into the same onboarding flow. Return to the
-[`site landing page`](/) when you want the text-first install, tutorial,
-migration, or troubleshooting entry points instead.
+[`README chooser on GitHub`](https://github.com/ugoite/syu/blob/main/README.md#choose-your-path)
+when you want the text-first install, tutorial, migration, or troubleshooting
+entry points instead.
 
 ```bash
 syu app .

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -294,12 +294,14 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/trace-adapter-support.md"));
     assert!(readme.contains("Trace adapter matrix"));
     assert!(readme.contains("docs/guide/tutorial.md"));
+    assert!(readme.contains("docs/guide/app.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
     assert!(readme.contains("docs/guide/spec-antipatterns.md"));
     assert!(readme.contains("docs/guide/vscode-extension.md"));
     assert!(readme.contains("shortest install-to-validate path"));
     assert!(readme.contains("the in-page four-layer refresher is"));
     assert!(readme.contains("**Getting started**"));
+    assert!(readme.contains("**Visual explorer**"));
     assert!(readme.contains("using `syu` for the first time"));
     assert!(readme.contains("already have a workspace"));
     assert!(readme.contains("first workspace setup"));
@@ -356,6 +358,7 @@ fn repository_declares_documentation_guides() {
     assert!(anti_patterns.contains("When to merge, split, or rename spec items"));
     assert!(anti_patterns.contains("green-but-messy spec"));
     assert!(app_guide.contains("Status badge"));
+    assert!(app_guide.contains("README chooser on GitHub"));
     assert!(app_guide.contains("## Search shortcuts"));
     assert!(app_guide.contains("ArrowDown"));
     assert!(app_guide.contains("Escape"));


### PR DESCRIPTION
## Summary\n- add the visual explorer path to the README newcomer chooser\n- include the app guide in the README guide index\n- link the app guide back to the README chooser and cover it in repository quality checks\n\n## Testing\n- bash scripts/ci/quality-gates.sh\n- cargo run -- validate .\n- npm --prefix website run build