### PR TITLE
fix: make validate quiet mode suppress success summaries

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -444,7 +444,7 @@ Filters stay view-oriented: they narrow the visible diagnostics while preserving
 the full validation result and exit code.
 
 For CI or shell scripts that still want text output, add `--quiet` to suppress
-the next-step guidance block while keeping the validation summary and exit code.
+the success summary and next-step guidance while keeping the exit code behavior.
 
 ### Understanding validation output
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -473,7 +473,7 @@ pub struct ValidateArgs {
     )]
     pub require_symbol_trace_coverage: Option<bool>,
 
-    #[arg(help = "Suppress next-step guidance in successful text output")]
+    #[arg(help = "Suppress the text summary and next-step guidance in successful text output")]
     #[arg(short, long, action = ArgAction::SetTrue)]
     pub quiet: bool,
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -771,6 +771,7 @@ fn render_text_report(
 ) -> String {
     let mut output = String::new();
     let status = if overall_success { "passed" } else { "failed" };
+    let quiet_success = quiet && overall_success && result.issues.is_empty();
     let filtered_suffix = if filtered_view.is_some() {
         " (filtered view)"
     } else {
@@ -779,63 +780,65 @@ fn render_text_report(
 
     writeln!(&mut output, "syu validate {status}{filtered_suffix}")
         .expect("writing to String must succeed");
-    writeln!(
-        &mut output,
-        "workspace: {}",
-        result.workspace_root.display()
-    )
-    .expect("writing to String must succeed");
-    writeln!(
-        &mut output,
-        "definitions: philosophies={} policies={} requirements={} features={}",
-        result.definition_counts.philosophies,
-        result.definition_counts.policies,
-        result.definition_counts.requirements,
-        result.definition_counts.features
-    )
-    .expect("writing to String must succeed");
-    if let Some(summary) = text_summary {
+    if !quiet_success {
         writeln!(
             &mut output,
-            "checks: {} built-in rules across {} workspace items ({})",
-            summary.checked_rule_count,
-            summary.workspace_item_count,
-            summary.checked_genres.join(", ")
+            "workspace: {}",
+            result.workspace_root.display()
         )
         .expect("writing to String must succeed");
-        if !summary.disabled_checks.is_empty() {
-            let disabled_rule_count: usize = summary
-                .disabled_checks
-                .iter()
-                .map(|notice| notice.rule_count)
-                .sum();
-            let noun = if disabled_rule_count == 1 {
-                "rule is"
-            } else {
-                "rules are"
-            };
-            let details = summary
-                .disabled_checks
-                .iter()
-                .map(DisabledRuleNotice::describe)
-                .collect::<Vec<_>>()
-                .join(", ");
+        writeln!(
+            &mut output,
+            "definitions: philosophies={} policies={} requirements={} features={}",
+            result.definition_counts.philosophies,
+            result.definition_counts.policies,
+            result.definition_counts.requirements,
+            result.definition_counts.features
+        )
+        .expect("writing to String must succeed");
+        if let Some(summary) = text_summary {
             writeln!(
                 &mut output,
-                "note: {disabled_rule_count} built-in {noun} disabled by current config ({details})"
+                "checks: {} built-in rules across {} workspace items ({})",
+                summary.checked_rule_count,
+                summary.workspace_item_count,
+                summary.checked_genres.join(", ")
             )
             .expect("writing to String must succeed");
+            if !summary.disabled_checks.is_empty() {
+                let disabled_rule_count: usize = summary
+                    .disabled_checks
+                    .iter()
+                    .map(|notice| notice.rule_count)
+                    .sum();
+                let noun = if disabled_rule_count == 1 {
+                    "rule is"
+                } else {
+                    "rules are"
+                };
+                let details = summary
+                    .disabled_checks
+                    .iter()
+                    .map(DisabledRuleNotice::describe)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                writeln!(
+                    &mut output,
+                    "note: {disabled_rule_count} built-in {noun} disabled by current config ({details})"
+                )
+                .expect("writing to String must succeed");
+            }
         }
+        writeln!(
+            &mut output,
+            "traceability: requirements={}/{} traces validated; features={}/{} traces validated",
+            result.trace_summary.requirement_traces.validated,
+            result.trace_summary.requirement_traces.declared,
+            result.trace_summary.feature_traces.validated,
+            result.trace_summary.feature_traces.declared
+        )
+        .expect("writing to String must succeed");
     }
-    writeln!(
-        &mut output,
-        "traceability: requirements={}/{} traces validated; features={}/{} traces validated",
-        result.trace_summary.requirement_traces.validated,
-        result.trace_summary.requirement_traces.declared,
-        result.trace_summary.feature_traces.validated,
-        result.trace_summary.feature_traces.declared
-    )
-    .expect("writing to String must succeed");
 
     if let Some(filtered_view) = filtered_view {
         writeln!(&mut output, "filters: {}", filtered_view.describe_filters())

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -232,7 +232,7 @@ fn check_command_prints_workspace_aware_next_steps_for_explicit_paths() {
 
 #[test]
 // REQ-CORE-001
-fn check_command_quiet_suppresses_next_step_guidance() {
+fn check_command_quiet_suppresses_success_summary_and_next_step_guidance() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("validate")
@@ -250,7 +250,10 @@ fn check_command_quiet_suppresses_next_step_guidance() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("syu validate passed"));
-    assert!(stdout.contains("checks:"));
+    assert!(!stdout.contains("workspace:"));
+    assert!(!stdout.contains("definitions:"));
+    assert!(!stdout.contains("checks:"));
+    assert!(!stdout.contains("traceability:"));
     assert!(
         !stdout.contains("What to do next:"),
         "quiet mode should suppress next-step guidance: {stdout}"


### PR DESCRIPTION
## Summary
- make successful text runs with --quiet emit only the validation status line
- keep the full summary for non-quiet output and for failure cases
- update the CLI help text and regression coverage for the quiet contract

## Testing
- cargo test --test check_command check_command_quiet_suppresses_success_summary_and_next_step_guidance
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- cargo run -- validate . --quiet
