### PR TITLE
fix: add next-step guidance for validation failures

### DIFF
--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -892,8 +892,9 @@ fn render_text_report(
         }
     }
 
+    let workspace_arg = shell_quote_path(workspace_arg);
+
     if overall_success && result.issues.is_empty() && !quiet {
-        let workspace_arg = shell_quote_path(workspace_arg);
         writeln!(&mut output).expect("writing to String must succeed");
         writeln!(&mut output, "What to do next:").expect("writing to String must succeed");
         writeln!(
@@ -914,6 +915,29 @@ fn render_text_report(
         writeln!(
             &mut output,
             "  syu show <ID> {workspace_arg}    inspect a single spec item in detail"
+        )
+        .expect("writing to String must succeed");
+    } else if !overall_success {
+        writeln!(&mut output).expect("writing to String must succeed");
+        writeln!(&mut output, "What to inspect next:").expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu show <ID> {workspace_arg}           inspect one requirement, feature, policy, or philosophy named above"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu validate {workspace_arg} --severity error   rerun with only error-level issues if you need the shortest list first"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu validate {workspace_arg} --genre graph      focus on missing links, reciprocal links, or missing definitions"
+        )
+        .expect("writing to String must succeed");
+        writeln!(
+            &mut output,
+            "  syu app {workspace_arg}                 open the browser UI to inspect the same workspace graph visually"
         )
         .expect("writing to String must succeed");
     }

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -274,6 +274,11 @@ fn check_command_reports_missing_definition_links() {
     assert!(stdout.contains("referenced rules:"));
     assert!(stdout.contains("Linked definitions must exist"));
     assert!(stdout.contains("REQ-MISSING-999"));
+    assert!(stdout.contains("What to inspect next:"));
+    assert!(stdout.contains("syu show <ID>"));
+    assert!(stdout.contains("--severity error"));
+    assert!(stdout.contains("--genre graph"));
+    assert!(stdout.contains("syu app "));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a failure-only next-step block to text validation output
- point users to show, filtered validate reruns, and the browser UI after validation errors
- cover the new guidance in the validation command regression test

## Testing
- cargo test --test check_command check_command_reports_missing_definition_links
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- cargo run -- validate tests/fixtures/workspaces/failing
