### PR TITLE
feat: add configurable warning exit codes for validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ syu validate . --format json
 syu validate . --severity error --genre trace
 syu validate . --rule SYU-trace-file-002
 syu validate . --id REQ-001
+syu validate . --warning-exit-code 3
 syu validate . --fix
 syu validate . --no-fix
 syu validate . --allow-planned=false
@@ -339,6 +340,9 @@ Use `--severity`, `--genre`, `--rule`, and `--id` to narrow the rendered issue l
 without changing the underlying validation result or exit code.
 Use the validate override flags for one-off stricter or looser runs without
 editing `syu.yaml`.
+By default, warning-only runs still exit 0. Add `--warning-exit-code <CODE>` when
+CI or shell automation needs a distinct non-zero status for warnings while
+keeping error-bearing runs on exit code 1.
 
 For a plain-English guide to common validation errors, see the
 [troubleshooting guide](docs/guide/troubleshooting.md).

--- a/docs/generated/site-spec/requirements/core/documentation.md
+++ b/docs/generated/site-spec/requirements/core/documentation.md
@@ -45,6 +45,7 @@ description: "Generated reference for docs/syu/requirements/core/documentation.y
           - init_help_mentions_custom_spec_roots
           - init_help_mentions_id_prefix_options
           - validate_help_lists_temporary_config_overrides
+          - validate_help_mentions_warning_exit_code_for_automation
       - **file**: tests/repository_quality.rs
         - **symbols**:
           - repository_declares_documentation_guides
@@ -108,6 +109,7 @@ requirements:
             - init_help_mentions_custom_spec_roots
             - init_help_mentions_id_prefix_options
             - validate_help_lists_temporary_config_overrides
+            - validate_help_mentions_warning_exit_code_for_automation
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -444,7 +444,12 @@ Filters stay view-oriented: they narrow the visible diagnostics while preserving
 the full validation result and exit code.
 
 For CI or shell scripts that still want text output, add `--quiet` to suppress
-the next-step guidance block while keeping the validation summary and exit code.
+the next-step guidance block while keeping the validation summary and default
+exit code behavior.
+
+Need warnings to stay visible in text output but still fail the job? Add
+`--warning-exit-code 3` (or another non-zero code) so warning-only runs return
+that code while error-bearing runs continue to return exit code 1.
 
 ### Understanding validation output
 

--- a/docs/syu/requirements/core/documentation.yaml
+++ b/docs/syu/requirements/core/documentation.yaml
@@ -28,6 +28,7 @@ requirements:
             - init_help_mentions_custom_spec_roots
             - init_help_mentions_id_prefix_options
             - validate_help_lists_temporary_config_overrides
+            - validate_help_mentions_warning_exit_code_for_automation
         - file: tests/repository_quality.rs
           symbols:
             - repository_declares_documentation_guides

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -473,6 +473,10 @@ pub struct ValidateArgs {
     )]
     pub require_symbol_trace_coverage: Option<bool>,
 
+    #[arg(help = "Use this exit code when validation has warnings but no errors")]
+    #[arg(long, value_name = "CODE")]
+    pub warning_exit_code: Option<u8>,
+
     #[arg(help = "Suppress next-step guidance in successful text output")]
     #[arg(short, long, action = ArgAction::SetTrue)]
     pub quiet: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@
 // REQ-CORE-001
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
-use std::path::PathBuf;
+use std::{num::NonZeroU8, path::PathBuf};
 
 const ROOT_AFTER_HELP: &str = "\
 New here?
@@ -475,7 +475,7 @@ pub struct ValidateArgs {
 
     #[arg(help = "Use this exit code when validation has warnings but no errors")]
     #[arg(long, value_name = "CODE")]
-    pub warning_exit_code: Option<u8>,
+    pub warning_exit_code: Option<NonZeroU8>,
 
     #[arg(help = "Suppress next-step guidance in successful text output")]
     #[arg(short, long, action = ArgAction::SetTrue)]

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -356,6 +356,11 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
         ),
     };
     let overall_success = result.is_success();
+    let warning_only_success = overall_success
+        && result
+            .issues
+            .iter()
+            .any(|issue| issue.severity == Severity::Warning);
     let filters = IssueFilters::from_args(args);
     let (result, filtered_view) = filter_check_result(result, &filters);
 
@@ -395,7 +400,17 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
         }
     }
 
-    Ok(if overall_success { 0 } else { 1 })
+    Ok(
+        match (
+            overall_success,
+            warning_only_success,
+            args.warning_exit_code,
+        ) {
+            (false, _, _) => 1,
+            (true, true, Some(code)) => i32::from(code),
+            (true, _, _) => 0,
+        },
+    )
 }
 
 // FEAT-CHECK-001
@@ -2714,6 +2729,7 @@ mod tests {
             require_non_orphaned_items: None,
             require_reciprocal_links: None,
             require_symbol_trace_coverage: None,
+            warning_exit_code: None,
             quiet: false,
         })
         .expect("command should render load errors");
@@ -2780,6 +2796,7 @@ mod tests {
             require_non_orphaned_items: None,
             require_reciprocal_links: None,
             require_symbol_trace_coverage: None,
+            warning_exit_code: None,
             quiet: false,
         })
         .expect_err("autofix failures should bubble up");
@@ -2805,6 +2822,7 @@ mod tests {
             require_non_orphaned_items: None,
             require_reciprocal_links: None,
             require_symbol_trace_coverage: None,
+            warning_exit_code: None,
             quiet: false,
         })
         .expect("command should complete");

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -407,7 +407,7 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             args.warning_exit_code,
         ) {
             (false, _, _) => 1,
-            (true, true, Some(code)) => i32::from(code),
+            (true, true, Some(code)) => i32::from(code.get()),
             (true, _, _) => 0,
         },
     )

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1179,6 +1179,7 @@ mod tests {
             require_non_orphaned_items: None,
             require_reciprocal_links: None,
             require_symbol_trace_coverage: None,
+            warning_exit_code: None,
             quiet: false,
         })
         .expect("interactive init workspace should validate");

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -173,6 +173,22 @@ fn add_help_mentions_explicit_file_and_feature_kind() {
 }
 
 #[test]
+// REQ-CORE-024
+fn validate_help_mentions_warning_exit_code_for_automation() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "validate help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--warning-exit-code"));
+    assert!(stdout.contains("warnings but no errors"));
+}
+
+#[test]
 fn init_help_lists_starter_templates() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/status_validation.rs
+++ b/tests/status_validation.rs
@@ -279,3 +279,27 @@ fn validate_keeps_error_exit_code_when_warning_exit_code_is_configured() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("SYU-delivery-implemented-001"));
 }
+
+#[test]
+// REQ-CORE-001
+fn validate_rejects_zero_warning_exit_code() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path(), true, "planned", "implemented", false, true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--warning-exit-code")
+        .arg("0")
+        .output()
+        .expect("validate should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("invalid value '0' for '--warning-exit-code <CODE>'"),
+        "zero warning exit code should be rejected\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/status_validation.rs
+++ b/tests/status_validation.rs
@@ -220,3 +220,62 @@ fn validate_warns_when_implemented_feature_links_only_to_planned_requirements() 
     assert!(stdout.contains("only to planned requirements"));
     assert!(stdout.contains("REQ-001"));
 }
+
+#[test]
+// REQ-CORE-001
+fn validate_can_use_a_custom_warning_exit_code_for_warning_only_runs() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(tempdir.path(), true, "planned", "implemented", false, true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--warning-exit-code")
+        .arg("3")
+        .output()
+        .expect("validate should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "warning-only validation should use the configured warning exit code\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-delivery-agreement-001"));
+}
+
+#[test]
+// REQ-CORE-001
+fn validate_keeps_error_exit_code_when_warning_exit_code_is_configured() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace(
+        tempdir.path(),
+        true,
+        "implemented",
+        "implemented",
+        false,
+        false,
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--warning-exit-code")
+        .arg("3")
+        .output()
+        .expect("validate should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "error-bearing validation should keep the normal failure exit code\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("SYU-delivery-implemented-001"));
+}


### PR DESCRIPTION
## Summary
- add a warning-only exit-code override for syu validate automation workflows
- document the new warning exit semantics in the README, getting-started guide, and help output
- cover the new flag in CLI, status-validation, and generated-doc traces

## Testing
- cargo test --test status_validation validate_can_use_a_custom_warning_exit_code_for_warning_only_runs
- cargo test --test status_validation validate_keeps_error_exit_code_when_warning_exit_code_is_configured
- cargo test --test help_command validate_help_mentions_warning_exit_code_for_automation
- bash scripts/ci/check-generated-docs-freshness.sh
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- npm --prefix website run build

## Linked issue or specification
- #379
- REQ-CORE-001
