### PR TITLE
docs: scope early alpha migration support

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -121,9 +121,9 @@ This guide only has release-by-release notes starting at `alpha.5`. The earlier
 layout stabilized, so this repository does **not** maintain step-by-step upgrade
 instructions for those versions. If you are upgrading from one of those early
 alphas, treat `alpha.5` as the first supported landing point: compare your
-workspace against a freshly generated `alpha.7` scaffold, make the required
-`spec.root` and validation-config updates, then run `syu validate .` until the
-workspace is green.
+workspace against a freshly generated scaffold from the version you are
+upgrading to, make the required `spec.root` and validation-config updates, then
+run `syu validate .` until the workspace is green.
 
 | syu version | `spec.root` default | `require_reciprocal_links` | `report.output` |
 |---|---|---|---|

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -116,9 +116,18 @@ for the full contribution workflow.
 
 ## Version compatibility summary
 
+This guide only has release-by-release notes starting at `alpha.5`. The earlier
+`alpha.1`-`alpha.4` builds shipped before the current migration notes and docs
+layout stabilized, so this repository does **not** maintain step-by-step upgrade
+instructions for those versions. If you are upgrading from one of those early
+alphas, treat `alpha.5` as the first supported landing point: compare your
+workspace against a freshly generated `alpha.7` scaffold, make the required
+`spec.root` and validation-config updates, then run `syu validate .` until the
+workspace is green.
+
 | syu version | `spec.root` default | `require_reciprocal_links` | `report.output` |
 |---|---|---|---|
-| alpha.1–alpha.4 | — (not yet documented) | — | — |
+| alpha.1–alpha.4 | pre-`alpha.5`; migrate manually to the `alpha.5+` layout first | not yet documented | not yet documented |
 | alpha.5 | `docs/spec` | not present | not present |
 | alpha.6 | `docs/syu` | not present | not present |
 | alpha.7 | `docs/syu` | `true` | stdout when unset; otherwise configured path |


### PR DESCRIPTION
## Summary
- explain why alpha.1-alpha.4 do not have step-by-step migration notes
- give early adopters a concrete manual upgrade path toward the supported alpha.5+ layout
- replace the ambiguous compatibility-table placeholder with explicit scope

## Linked issue or specification
- Closes #403