### PR TITLE
docs: add a docs-first trace adapter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ missing files.
 
 The repository ships working example projects:
 
+- [`examples/docs-first`](examples/docs-first)
 - [`examples/go-only`](examples/go-only)
 - [`examples/rust-only`](examples/rust-only)
 - [`examples/python-only`](examples/python-only)

--- a/docs/guide/examples-and-templates.md
+++ b/docs/guide/examples-and-templates.md
@@ -25,6 +25,7 @@ whether you should scaffold a template or open one of the repository examples.
 
 | Path | Type | Best for | How to start |
 | --- | --- | --- | --- |
+| `docs-first` | Example only | documentation-heavy repositories that want a small reference for shell, markdown, and wildcard YAML traces | `examples/docs-first` |
 | `generic` | Template only | the shortest neutral scaffold when you do not want language-specific starter copy yet | `syu init .` |
 | `rust-only` | Template + example | Rust-first repositories that want starter IDs, file names, and copy tuned for Rust work | `syu init . --template rust-only` or `examples/rust-only` |
 | `python-only` | Template + example | Python-first repositories that want the same tuned starter shape for Python workflows | `syu init . --template python-only` or `examples/python-only` |

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -58,6 +58,10 @@ they do **not** participate in the repository-wide strict ownership scan.
   `file` + `symbols` (or `symbols: ["*"]` when one file intentionally belongs
   to one item), but do not expect doc-comment inspection or strict ownership
   inventory.
+- Want a runnable reference for that lighter mapping? Start with the
+  [`examples/docs-first` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/docs-first),
+  which demonstrates a shell symbol trace, markdown-backed requirement
+  evidence, and cautious wildcard YAML ownership in one small workspace.
 
 Even in rich-inspection languages, wildcard traces cannot use `doc_contains`
 because `symbols: ["*"]` does not point to one inspectable symbol.

--- a/examples/docs-first/README.md
+++ b/examples/docs-first/README.md
@@ -1,0 +1,46 @@
+# docs-first example
+
+This example demonstrates a small workspace for repositories where the most
+important traced artifacts are documentation, shell automation, and checked-in
+configuration rather than richly inspected application code.
+
+It keeps the example intentionally small while showing two useful pattern-based
+adapter shapes:
+
+- an explicit shell symbol trace for a single script function
+- wildcard YAML ownership for a file that intentionally belongs to one feature
+
+## Files
+
+| Path | What it defines |
+|------|-----------------|
+| `docs/syu/philosophy/foundation.yaml` | `PHIL-DOCS-001` — docs-first repositories should still keep traceable intent |
+| `docs/syu/policies/policies.yaml` | `POL-DOCS-001` linked to both requirements |
+| `docs/syu/requirements/core/docs.yaml` | `REQ-DOCS-001` and `REQ-DOCS-002` |
+| `docs/syu/features/documentation/docs.yaml` | `FEAT-DOCS-001` and `FEAT-DOCS-002` |
+| `scripts/publish-docs.sh` | shell implementation containing `publish_release_notes` |
+| `config/navigation.yaml` | a whole-file YAML artifact intentionally owned by one feature |
+| `README.md` | markdown-backed acceptance anchors for both requirements |
+
+## Try it
+
+```bash
+cd examples/docs-first
+syu validate .
+syu show REQ-DOCS-001
+syu show FEAT-DOCS-002
+```
+
+## DocsFirstAcceptanceChecklist
+
+- `REQ-DOCS-001` expects the release-note publishing flow to stay explicit.
+- `FEAT-DOCS-001` traces directly to the shell symbol `publish_release_notes`.
+- This mapping is valid without `doc_contains` because shell only supports
+  pattern-based symbol existence today.
+
+## DocsFirstNavigationChecklist
+
+- `REQ-DOCS-002` expects one checked-in navigation file to stay easy to inspect.
+- `FEAT-DOCS-002` owns `config/navigation.yaml` with `symbols: ["*"]`.
+- Use wildcard ownership carefully: it works best when one file intentionally
+  belongs to one feature instead of collecting unrelated concerns.

--- a/examples/docs-first/config/navigation.yaml
+++ b/examples/docs-first/config/navigation.yaml
@@ -1,0 +1,7 @@
+sections:
+  - id: intro
+    title: Introduction
+  - id: release-notes
+    title: Release notes
+  - id: troubleshooting
+    title: Troubleshooting

--- a/examples/docs-first/docs/syu/features/documentation/docs.yaml
+++ b/examples/docs-first/docs/syu/features/documentation/docs.yaml
@@ -1,0 +1,26 @@
+category: Docs-first Example Features
+version: 1
+
+features:
+  - id: FEAT-DOCS-001
+    title: Trace the release-note publishing script with an explicit shell symbol
+    summary: Demonstrate a named shell function trace for docs-first repositories.
+    status: implemented
+    linked_requirements:
+      - REQ-DOCS-001
+    implementations:
+      shell:
+        - file: scripts/publish-docs.sh
+          symbols:
+            - publish_release_notes
+  - id: FEAT-DOCS-002
+    title: Trace one dedicated navigation file with wildcard YAML ownership
+    summary: Demonstrate that wildcard ownership is acceptable when one YAML file intentionally belongs to one feature.
+    status: implemented
+    linked_requirements:
+      - REQ-DOCS-002
+    implementations:
+      yaml:
+        - file: config/navigation.yaml
+          symbols:
+            - "*"

--- a/examples/docs-first/docs/syu/features/features.yaml
+++ b/examples/docs-first/docs/syu/features/features.yaml
@@ -1,0 +1,4 @@
+version: "0.0.1-alpha.7"
+files:
+  - kind: documentation
+    file: documentation/docs.yaml

--- a/examples/docs-first/docs/syu/philosophy/foundation.yaml
+++ b/examples/docs-first/docs/syu/philosophy/foundation.yaml
@@ -1,0 +1,11 @@
+category: Philosophy
+version: 1
+language: en
+
+philosophies:
+  - id: PHIL-DOCS-001
+    title: Docs-first repositories should still keep traceable intent close to the files people read first
+    product_design_principle: Keep documentation, scripts, and config traceable even when rich code inspection is unnecessary.
+    coding_guideline: Prefer explicit file or symbol ownership over unsupported-language placeholders.
+    linked_policies:
+      - POL-DOCS-001

--- a/examples/docs-first/docs/syu/policies/policies.yaml
+++ b/examples/docs-first/docs/syu/policies/policies.yaml
@@ -1,0 +1,14 @@
+category: Policies
+version: 1
+language: en
+
+policies:
+  - id: POL-DOCS-001
+    title: Pattern-based adapters should stay explicit about what they can and cannot promise
+    summary: Use shell, YAML, and markdown traces for explicit ownership without pretending they support doc inspection.
+    description: Require docs-first examples to demonstrate named symbols where available and wildcard ownership only for files that clearly belong to one feature.
+    linked_philosophies:
+      - PHIL-DOCS-001
+    linked_requirements:
+      - REQ-DOCS-001
+      - REQ-DOCS-002

--- a/examples/docs-first/docs/syu/requirements/core/docs.yaml
+++ b/examples/docs-first/docs/syu/requirements/core/docs.yaml
@@ -1,0 +1,32 @@
+category: Docs-first Example Requirements
+prefix: REQ-DOCS
+
+requirements:
+  - id: REQ-DOCS-001
+    title: Release-note publishing should stay traceable through a supported shell mapping
+    description: The example should show that shell-backed workflows can use explicit symbol ownership without doc inspection.
+    priority: high
+    status: implemented
+    linked_policies:
+      - POL-DOCS-001
+    linked_features:
+      - FEAT-DOCS-001
+    tests:
+      markdown:
+        - file: README.md
+          symbols:
+            - DocsFirstAcceptanceChecklist
+  - id: REQ-DOCS-002
+    title: Whole-file config ownership should stay explicit when one YAML file belongs to one feature
+    description: The example should show when wildcard ownership is appropriate for a dedicated configuration file.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-DOCS-001
+    linked_features:
+      - FEAT-DOCS-002
+    tests:
+      markdown:
+        - file: README.md
+          symbols:
+            - DocsFirstNavigationChecklist

--- a/examples/docs-first/scripts/publish-docs.sh
+++ b/examples/docs-first/scripts/publish-docs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+publish_release_notes() {
+  printf '%s\n' "publishing release notes"
+}
+
+publish_release_notes

--- a/examples/docs-first/syu.yaml
+++ b/examples/docs-first/syu.yaml
@@ -1,0 +1,12 @@
+version: 0.0.1-alpha.7
+spec:
+  root: docs/syu
+validate:
+  default_fix: false
+  allow_planned: true
+  require_symbol_trace_coverage: false
+runtimes:
+  python:
+    command: auto
+  node:
+    command: auto

--- a/tests/example_workspaces.rs
+++ b/tests/example_workspaces.rs
@@ -11,6 +11,29 @@ fn example_path(name: &str) -> PathBuf {
 
 #[test]
 // REQ-CORE-012
+fn docs_first_example_validates() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(example_path("docs-first"))
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("definitions: philosophies=1 policies=1 requirements=2 features=2"));
+    assert!(stdout.contains(
+        "traceability: requirements=2/2 traces validated; features=2/2 traces validated"
+    ));
+}
+
+#[test]
+// REQ-CORE-012
 fn rust_only_example_validates() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -450,6 +450,7 @@ fn repository_declares_documentation_guides() {
     assert!(trace_adapter_support.contains("| Go | `go`, `golang`, `gotest` / `.go` |"));
     assert!(examples_and_templates.contains("starter templates"));
     assert!(examples_and_templates.contains("checked-in examples"));
+    assert!(examples_and_templates.contains("examples/docs-first"));
     assert!(examples_and_templates.contains("`syu init . --template rust-only`"));
     assert!(examples_and_templates.contains("examples/polyglot"));
     assert!(merge_queue_playbook.contains("merge_group"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -596,6 +596,8 @@ fn repository_ships_example_workspaces() {
     let rust_example_config = read_file("examples/rust-only/syu.yaml");
     let python_example_requirement =
         read_file("examples/python-only/docs/syu/requirements/core/python.yaml");
+    let docs_first_requirement =
+        read_file("examples/docs-first/docs/syu/requirements/core/docs.yaml");
     let go_example_requirement = read_file("examples/go-only/docs/syu/requirements/core/go.yaml");
     let go_example_readme = read_file("examples/go-only/README.md");
     let polyglot_feature = read_file("examples/polyglot/docs/syu/features/languages/polyglot.yaml");
@@ -604,11 +606,14 @@ fn repository_ships_example_workspaces() {
     assert!(rust_example_requirement.contains("REQ-RUST-001"));
     assert!(rust_example_config.contains(&format!("version: {current_version}")));
     assert!(python_example_requirement.contains("REQ-PY-001"));
+    assert!(docs_first_requirement.contains("REQ-DOCS-001"));
+    assert!(docs_first_requirement.contains("DocsFirstAcceptanceChecklist"));
     assert!(go_example_requirement.contains("REQ-GO-001"));
     assert!(go_example_readme.contains("TestGoRequirement"));
     assert!(go_example_readme.contains("GoFeatureImpl"));
     assert!(polyglot_feature.contains("FEAT-MIX-001"));
     assert!(polyglot_feature.contains("status: implemented"));
+    assert!(example_tests.contains("docs_first_example_validates"));
     assert!(example_tests.contains("rust_only_example_validates"));
     assert!(example_tests.contains("python_only_example_validates"));
     assert!(example_tests.contains("go_only_example_validates"));


### PR DESCRIPTION
## Summary
- add a checked-in docs-first example workspace for shell, markdown, and YAML pattern-based adapters
- link the trace adapter guide to the new runnable example
- cover the new example in repository-quality and example-workspace validation

## Linked issue or specification
- Closes #402