### PR TITLE
docs: cross-link unsupported-language guidance to go-only

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -153,6 +153,10 @@ coverage still skips configured repository-relative generated paths such as
 `build/`, `coverage/`, `dist/`, and `target/` so authored files nested under
 `src/` or `tests/` keep counting.
 For an experimental strict run, use `syu validate . --require-symbol-trace-coverage`.
+If part of the repository still depends on an unsupported language, keep strict
+coverage off there and borrow the workaround shape from the
+[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
+until a dedicated adapter lands.
 
 ### `app.bind`
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -264,7 +264,10 @@ language-specific `tests:` or `implementations:` entries such as `csharp:`.
 Those keys still fail validation before `doc_contains` support even becomes
 relevant. If you need code-level tracing immediately with `doc_contains`, stay
 with Rust, Python, or TypeScript/JavaScript for now; otherwise, keep the spec
-layers connected and add the source mappings once adapter support lands.
+layers connected and add the source mappings once adapter support lands. The
+[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
+shows one checked-in version of that workaround with real Go files plus
+markdown-backed trace anchors.
 
 Keep this adoption path in mind for mixed-language repositories too: start with
 declared traces, keep `validate.require_symbol_trace_coverage: false`, then turn

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -67,3 +67,7 @@ because `symbols: ["*"]` does not point to one inspectable symbol.
 Unsupported adapters such as `csharp` still raise `SYU-trace-language-001`.
 Keep those repositories connected through the spec layers first, and only add
 language-specific code traces once adapter support lands.
+If you need a checked-in workaround shape today, study the
+[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only),
+which keeps real Go files in the repository while validated trace evidence stays
+anchored in a supported markdown file.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -297,6 +297,10 @@ If the mapping uses an unsupported implementation language such as `csharp`,
 removing `doc_contains` is not enough: those entries still raise
 `SYU-trace-language-001`. Keep the higher-layer spec link in place and wait for
 adapter support before adding the code-level trace.
+The
+[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
+shows one concrete version of that workaround with real source files plus
+markdown-backed trace anchors.
 
 The [trace adapter capability matrix](./trace-adapter-support.md) shows which
 built-in adapters stop at symbol validation, which ones can inspect docs, and


### PR DESCRIPTION
## Summary
- link unsupported-language guidance pages to the checked-in go-only workaround example
- make the migration path from unsupported languages more concrete for readers

## Linked issue or specification
- Closes #397