### PR TITLE
docs: fix stale README anchors in getting-started

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,7 +10,7 @@ layers before you start editing YAML.
 Need a different level of guidance?
 
 - Jump back to the
-  [README quick start on GitHub](https://github.com/ugoite/syu/blob/main/README.md#quick-start)
+  [README quick start on GitHub](https://github.com/ugoite/syu/blob/main/README.md#choose-your-path)
   when you want the shortest install-to-validate path and are happy with a
   compact command card.
 - Follow [existing repository adoption](./existing-repository.md) when the
@@ -27,7 +27,7 @@ Need a different level of guidance?
   already failing and you need to unblock a workspace.
 
 If you are still deciding whether to adopt `syu`, start with the
-[repository-fit guide in the README](https://github.com/ugoite/syu/blob/main/README.md#before-you-install-check-whether-syu-fits-this-repository)
+[repository-fit guide in the README](https://github.com/ugoite/syu/blob/main/README.md#is-syu-right-for-this-repository)
 before installing anything.
 
 ## Is syu right for this repository?

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -371,6 +371,11 @@ fn repository_declares_documentation_guides() {
         getting_started
             .contains("https://github.com/ugoite/syu/blob/main/README.md#choose-your-path")
     );
+    assert!(
+        getting_started.contains(
+            "https://github.com/ugoite/syu/blob/main/README.md#is-syu-right-for-this-repository"
+        )
+    );
     assert!(getting_started.contains("narrated first-run path"));
     assert!(getting_started.contains("first workspace setup explained step by"));
     assert!(getting_started.contains("first manual editing step"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -371,11 +371,9 @@ fn repository_declares_documentation_guides() {
         getting_started
             .contains("https://github.com/ugoite/syu/blob/main/README.md#choose-your-path")
     );
-    assert!(
-        getting_started.contains(
-            "https://github.com/ugoite/syu/blob/main/README.md#is-syu-right-for-this-repository"
-        )
-    );
+    assert!(getting_started.contains(
+        "https://github.com/ugoite/syu/blob/main/README.md#is-syu-right-for-this-repository"
+    ));
     assert!(getting_started.contains("narrated first-run path"));
     assert!(getting_started.contains("first workspace setup explained step by"));
     assert!(getting_started.contains("first manual editing step"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -368,7 +368,8 @@ fn repository_declares_documentation_guides() {
         getting_started.contains("[trace adapter capability matrix](./trace-adapter-support.md)")
     );
     assert!(
-        getting_started.contains("https://github.com/ugoite/syu/blob/main/README.md#quick-start")
+        getting_started
+            .contains("https://github.com/ugoite/syu/blob/main/README.md#choose-your-path")
     );
     assert!(getting_started.contains("narrated first-run path"));
     assert!(getting_started.contains("first workspace setup explained step by"));


### PR DESCRIPTION
## Summary
- point the getting-started README backlinks at anchors that still exist
- update repository-quality expectations to match the current README chooser anchor

## Linked issue or specification
- Closes #395