### PR TITLE
docs: add go-only and team-scale to the example matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ The repository ships working example projects:
 - [`examples/rust-only`](examples/rust-only)
 - [`examples/python-only`](examples/python-only)
 - [`examples/polyglot`](examples/polyglot)
+- [`examples/team-scale`](examples/team-scale)
 
 Each one is validated in the automated test suite. If you are deciding between a
 checked-in example and a scaffold template, start with

--- a/docs/guide/examples-and-templates.md
+++ b/docs/guide/examples-and-templates.md
@@ -26,9 +26,11 @@ whether you should scaffold a template or open one of the repository examples.
 | Path | Type | Best for | How to start |
 | --- | --- | --- | --- |
 | `generic` | Template only | the shortest neutral scaffold when you do not want language-specific starter copy yet | `syu init .` |
+| `go-only` | Example only | unsupported-language repositories that need a checked-in workaround shape today while direct Go tracing is still future work | `examples/go-only` |
 | `rust-only` | Template + example | Rust-first repositories that want starter IDs, file names, and copy tuned for Rust work | `syu init . --template rust-only` or `examples/rust-only` |
 | `python-only` | Template + example | Python-first repositories that want the same tuned starter shape for Python workflows | `syu init . --template python-only` or `examples/python-only` |
 | `polyglot` | Template + example | repositories that already expect multiple languages and want the starter text to say that from the first commit | `syu init . --template polyglot` or `examples/polyglot` |
+| `team-scale` | Example only | repositories that already outgrew the single-feature starter shape and want to inspect a larger split-by-area workspace | `examples/team-scale` |
 
 ## What templates give you
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -330,6 +330,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu app"));
     assert!(readme.contains("examples/go-only"));
     assert!(readme.contains("examples/polyglot"));
+    assert!(readme.contains("examples/team-scale"));
     assert!(readme.contains("examples-and-templates.md"));
     assert!(readme.contains("CONTRIBUTING.md"));
     assert!(readme.contains("Contributing and local development"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -451,7 +451,9 @@ fn repository_declares_documentation_guides() {
     assert!(examples_and_templates.contains("starter templates"));
     assert!(examples_and_templates.contains("checked-in examples"));
     assert!(examples_and_templates.contains("`syu init . --template rust-only`"));
+    assert!(examples_and_templates.contains("examples/go-only"));
     assert!(examples_and_templates.contains("examples/polyglot"));
+    assert!(examples_and_templates.contains("examples/team-scale"));
     assert!(merge_queue_playbook.contains("merge_group"));
     assert!(merge_queue_playbook.contains("gh api graphql"));
     assert!(merge_queue_playbook.contains("AWAITING_CHECKS"));


### PR DESCRIPTION
## Summary
- add go-only and team-scale rows to the examples-and-templates matrix
- cover the new guide entries in repository-quality expectations

## Linked issue or specification
- Closes #396