### PR TITLE
docs: clarify which examples match starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,10 @@ The repository ships working example projects:
 - [`examples/python-only`](examples/python-only)
 - [`examples/polyglot`](examples/polyglot)
 
+`rust-only`, `python-only`, and `polyglot` match `syu init --template ...`
+starters directly. `go-only` is a reference-only workaround example for an
+unsupported implementation language.
+
 Each one is validated in the automated test suite. If you are deciding between a
 checked-in example and a scaffold template, start with
 [`docs/guide/examples-and-templates.md`](docs/guide/examples-and-templates.md).

--- a/README.md
+++ b/README.md
@@ -586,10 +586,12 @@ The repository ships working example projects:
 - [`examples/rust-only`](examples/rust-only)
 - [`examples/python-only`](examples/python-only)
 - [`examples/polyglot`](examples/polyglot)
+- [`examples/team-scale`](examples/team-scale)
 
 `rust-only`, `python-only`, and `polyglot` match `syu init --template ...`
 starters directly. `go-only` is a reference-only workaround example for an
-unsupported implementation language.
+unsupported implementation language, and `team-scale` is a reference-only
+example for studying a larger split-by-area repository shape.
 
 Each one is validated in the automated test suite. If you are deciding between a
 checked-in example and a scaffold template, start with

--- a/examples/go-only/README.md
+++ b/examples/go-only/README.md
@@ -8,6 +8,9 @@ one Go source file and one Go test file. The current workaround keeps the
 validated trace evidence in this README so `syu validate .` can still prove the
 links today while the real Go files stay visible in the repository.
 
+This workspace is reference-only: it does not correspond to a
+`syu init --template ...` starter.
+
 ## Files
 
 | Path | What it defines |

--- a/examples/polyglot/README.md
+++ b/examples/polyglot/README.md
@@ -4,7 +4,8 @@ This example demonstrates a multi-language workspace where a single
 requirement and feature are traced across **Rust**, **Python**, and
 **TypeScript** source files simultaneously.
 
-It is the checked-in reference workspace that matches `syu init . --template polyglot`.
+It is the checked-in reference workspace that matches
+`syu init . --template polyglot` exactly.
 
 ## Files
 

--- a/examples/python-only/README.md
+++ b/examples/python-only/README.md
@@ -4,7 +4,8 @@ This example demonstrates a minimal single-language Python workspace.
 It contains one philosophy, one policy, one requirement, and one feature —
 all mutually linked and traced to a Python test file.
 
-It is the checked-in reference workspace that matches `syu init . --template python-only`.
+It is the checked-in reference workspace that matches
+`syu init . --template python-only` exactly.
 
 ## Files
 

--- a/examples/rust-only/README.md
+++ b/examples/rust-only/README.md
@@ -4,7 +4,8 @@ This example demonstrates a minimal single-language Rust workspace.
 It contains one philosophy, one policy, one requirement, and one feature —
 all mutually linked and traced to a Rust source file.
 
-It is the checked-in reference workspace that matches `syu init . --template rust-only`.
+It is the checked-in reference workspace that matches
+`syu init . --template rust-only` exactly.
 
 ## Files
 

--- a/examples/team-scale/README.md
+++ b/examples/team-scale/README.md
@@ -6,7 +6,8 @@ requirements, and four features split across nested documents and traced into
 separate Rust source and test files.
 
 Unlike the smaller language-focused examples, this workspace is reference-only:
-it does not correspond to a `syu init --template ...` starter.
+it does not correspond to a `syu init --template ...` starter and is meant for
+studying a larger repository shape rather than matching a scaffold one-for-one.
 
 ## What this example demonstrates
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -330,6 +330,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu app"));
     assert!(readme.contains("examples/go-only"));
     assert!(readme.contains("examples/polyglot"));
+    assert!(readme.contains("examples/team-scale"));
     assert!(readme.contains("examples-and-templates.md"));
     assert!(readme.contains("CONTRIBUTING.md"));
     assert!(readme.contains("Contributing and local development"));


### PR DESCRIPTION
## Summary
- explain in the README which checked-in examples map directly to starter templates
- label each example README as template-backed or reference-only

## Linked issue or specification
- Closes #375