### PR TITLE
docs: separate quick start from the guided walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,10 @@ verified.
 
 Pick the newcomer path that matches what you need next:
 
-- **Getting started**: if you are using `syu` for the first time and want the
-  shortest install-to-validate path, the in-page four-layer refresher is the
-  fastest path through first workspace setup explained step by step.
-- **Quick start**: stay in this README when you want the shortest path from install
-  to `syu validate .` and only need a short layer refresher before the first
-  commands.
+- **Getting started**: if you are using `syu` for the first time, the in-page four-layer refresher is the hand-off into the guided walkthrough that keeps the first workspace setup explained step by step, including why the manual YAML edits matter before validation.
+- **Quick start**: stay in this README when you want the shortest path from
+  install to `syu validate .`, prefer a compact command card, and only need a
+  short layer refresher before the first commands.
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   want a realistic end-to-end repository story instead of a short scaffold flow.
 - **Trace adapter matrix**: open
@@ -178,6 +176,9 @@ Stay in this README for the shortest install-to-validate path. If you skipped
 [`docs/guide/concepts.md`](docs/guide/concepts.md), use the
 [Why four layers?](#why-four-layers) section above as the refresher on
 `philosophy`, `policy`, `requirements`, and `features`.
+If you want the same flow narrated step by step with more context around the
+manual edits, switch to
+[`docs/guide/getting-started.md`](docs/guide/getting-started.md) instead.
 
 The first manual edit in this quick start happens in the generated requirement
 YAML: add `linked_policies:` and `linked_features:` there, then update the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,22 +2,24 @@
 
 <!-- FEAT-DOCS-001 -->
 
-:::tip New to syu?
-New to `syu`? Read [syu concepts](./concepts.md) first to understand the four
-layers before you start editing YAML.
+:::tip New to `syu`?
+Read [syu concepts](./concepts.md) first when you want the fuller mental model
+before you start editing YAML. If you already understand the four layers, this
+guide is the narrated first-run path.
 :::
 
 Need a different level of guidance?
 
 - Jump back to the
   [README quick start on GitHub](https://github.com/ugoite/syu/blob/main/README.md#quick-start)
-  when you want the shortest install-to-validate path and are happy with a
-  compact command card.
+  when you want the same install-to-validate flow collapsed into a compact
+  command card.
 - Follow [existing repository adoption](./existing-repository.md) when the
   repository already has code and history and you want to add `syu` without
   treating it like a blank workspace.
 - Stay on this page when you want the first workspace setup explained step by
-  step, including why the manual YAML edits matter before validation.
+  step, including why the manual YAML edits matter before validation and how the
+  same commands fit together as one guided story.
 - Follow the [end-to-end tutorial](./tutorial.md) when you want a realistic,
   worked repository story instead of the shortest setup path.
 - Use the [trace adapter capability matrix](./trace-adapter-support.md) when


### PR DESCRIPTION
## Summary
- sharpen the chooser copy so README quick start and getting-started serve different newcomer needs
- describe the README path as the compact command-card flow and the guide as the narrated walkthrough

## Linked issue or specification
- Closes #256