### PR TITLE
docs: align getting-started language support guidance

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -210,8 +210,9 @@ For a genuinely mixed-language repository, keep the first adoption step small:
   only in supported lightweight adapters that `syu` cannot inspect deeply yet
 - keep unsupported implementation-language areas connected through the spec
   layers until adapter support lands
-- turn stricter symbol coverage on later for the Rust, Python, and
-  TypeScript/JavaScript areas once those traces are stable
+- turn stricter symbol coverage on later for the supported implementation
+  languages you are tracing (Rust, Python, Go, Java, or
+  TypeScript/JavaScript) once those traces are stable
 
 That keeps the repository connected to the spec from day one without forcing a
 polyglot team to fake symbol-level coverage before the current adapters are

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -222,11 +222,17 @@ until you are ready to declare real tests and implementation traces.
 
 ### Unsupported implementation languages can still adopt the spec layers first
 
-`syu` can validate code-level traces today in Rust, Python, and
+`syu` can validate code-level traces today in Rust, Python, Go, Java, and
 TypeScript/JavaScript, plus lighter file/symbol ownership in `shell`, `yaml`,
-`json`, `markdown`, and `gitignore`. Repositories that are mostly Go, Java,
-C#, or another unsupported implementation language can still adopt `syu` today,
-but they should treat code-level mappings for those files as future work.
+`json`, `markdown`, and `gitignore`. Repositories that are mostly C# or another
+unsupported implementation language can still adopt `syu` today, but they
+should treat code-level mappings for those files as future work.
+
+Go and Java already have built-in pattern-based symbol validation and
+participate in strict `validate.require_symbol_trace_coverage` inventory, even
+though they do not support `doc_contains` checks yet. The
+[trace adapter capability matrix](./trace-adapter-support.md) summarizes that
+language-by-language support.
 
 Today you can still:
 


### PR DESCRIPTION
## Summary
- update getting-started so Go and Java match the current built-in adapter support
- call out the remaining doc_contains limitation and point readers to the capability matrix

## Linked issue or specification
- Closes #416
