### PR TITLE
docs: add a migration journey to the docs-site home

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -50,12 +50,6 @@ const journeys = [
     to: '/docs/guide/getting-started'
   },
   {
-    title: 'Upgrade an existing workspace',
-    description:
-      'Jump straight to the migration guide when a new alpha release changes config, validation defaults, or guide structure.',
-    to: '/docs/guide/migration'
-  },
-  {
     title: 'Follow a full tutorial',
     description: 'Build a realistic four-layer example from scratch when you want the full repository story.',
     to: '/docs/guide/tutorial'
@@ -64,6 +58,12 @@ const journeys = [
     title: 'Troubleshoot a broken workspace',
     description: 'Jump straight to the common validation, traceability, and workflow failure patterns.',
     to: '/docs/guide/troubleshooting'
+  },
+  {
+    title: 'Upgrade an existing workspace',
+    description:
+      'Jump straight to the migration guide when a new alpha release changes config, validation defaults, or guide structure.',
+    to: '/docs/guide/migration'
   },
   {
     title: 'Stay in VS Code',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -50,6 +50,12 @@ const journeys = [
     to: '/docs/guide/getting-started'
   },
   {
+    title: 'Upgrade an existing workspace',
+    description:
+      'Jump straight to the migration guide when a new alpha release changes config, validation defaults, or guide structure.',
+    to: '/docs/guide/migration'
+  },
+  {
     title: 'Follow a full tutorial',
     description: 'Build a realistic four-layer example from scratch when you want the full repository story.',
     to: '/docs/guide/tutorial'


### PR DESCRIPTION
## Summary
- add a migration journey card to the docs-site landing page common journeys section
- point homepage readers directly at the checked-in migration guide

## Linked issue or specification
- Closes #419
