### PR TITLE
docs: add a trace adapter journey to the docs-site home

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -72,7 +72,7 @@ const journeys = [
   {
     title: 'Understand trace adapter support',
     description:
-      'Check which languages support rich inspection, which stay pattern-based, and how unsupported-language adoption works today.',
+      'Compare which languages support rich inspection, which stay pattern-based, and where `doc_contains` is still unavailable.',
     to: '/docs/guide/trace-adapter-support'
   },
   {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -70,6 +70,12 @@ const journeys = [
     to: '/docs/guide/configuration'
   },
   {
+    title: 'Understand trace adapter support',
+    description:
+      'Check which languages support rich inspection, which stay pattern-based, and how unsupported-language adoption works today.',
+    to: '/docs/guide/trace-adapter-support'
+  },
+  {
     title: 'Inspect the self-hosted spec',
     description: 'Browse the generated reference pages that explain how this repository uses syu on itself.',
     to: '/docs/generated/site-spec'


### PR DESCRIPTION
## Summary
- add a trace-adapter capability journey card to the docs-site landing page
- give homepage readers a direct path to adapter support and unsupported-language guidance

## Linked issue or specification
- Closes #420
