### PR TITLE
docs: add a browser UI journey to the docs-site home

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -50,6 +50,12 @@ const journeys = [
     to: '/docs/guide/getting-started'
   },
   {
+    title: 'Explore the browser UI',
+    description:
+      'Take the visual-first path through `syu app` when you want tabs, trace links, and validation context in one browser view.',
+    to: '/docs/guide/app'
+  },
+  {
     title: 'Follow a full tutorial',
     description: 'Build a realistic four-layer example from scratch when you want the full repository story.',
     to: '/docs/guide/tutorial'


### PR DESCRIPTION
## Summary
- add a browser UI journey card to the docs-site landing page
- point homepage readers directly at the syu app guide

## Linked issue or specification
- Closes #421
