### PR TITLE
docs: link the app guide back to both onboarding homes

### DIFF
--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -6,9 +6,11 @@
 
 If you started from the README newcomer chooser, this guide is the visual-first
 path back into the same onboarding flow. Return to the
+[`site landing page`](/) when you want the hosted-docs home with task-oriented
+journeys, or jump back to the
 [`README chooser on GitHub`](https://github.com/ugoite/syu/blob/main/README.md#choose-your-path)
-when you want the text-first install, tutorial, migration, or troubleshooting
-entry points instead.
+when you want the checked-in text-first install, tutorial, migration, or
+troubleshooting entry points instead.
 
 ```bash
 syu app .

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -6,8 +6,8 @@
 
 If you started from the README newcomer chooser, this guide is the visual-first
 path back into the same onboarding flow. Return to the
-[`site landing page`](/) when you want the hosted-docs home with task-oriented
-journeys, or jump back to the
+[`site landing page`](https://ugoite.github.io/syu/) when you want the
+hosted-docs home with task-oriented journeys, or jump back to the
 [`README chooser on GitHub`](https://github.com/ugoite/syu/blob/main/README.md#choose-your-path)
 when you want the checked-in text-first install, tutorial, migration, or
 troubleshooting entry points instead.


### PR DESCRIPTION
## Summary
- add a site-home backlink to the app guide intro
- keep the README chooser link while clarifying which surface each entry point serves

## Linked issue or specification
- Closes #422
