### PR TITLE
docs: expose quick start from the docs-site hero

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -101,6 +101,12 @@ export default function Home() {
               Get started
             </Link>
             <Link
+              className="button button--secondary button--lg"
+              to="https://github.com/ugoite/syu/blob/main/README.md#quick-start"
+            >
+              Quick start in the README
+            </Link>
+            <Link
               className="button button--outline button--lg siteHeroOutlineButton"
               to="/docs/generated/site-spec"
             >

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -101,10 +101,10 @@ export default function Home() {
               Get started
             </Link>
             <Link
-              className="button button--secondary button--lg"
+              className="button button--outline button--lg siteHeroOutlineButton"
               to="https://github.com/ugoite/syu/blob/main/README.md#quick-start"
             >
-              Quick start in the README
+              Quick start for experienced users
             </Link>
             <Link
               className="button button--outline button--lg siteHeroOutlineButton"


### PR DESCRIPTION
## Summary
- add a README quick-start CTA to the docs-site hero
- keep the guided getting-started CTA while exposing the compact command-card path

## Linked issue or specification
- Closes #423
