### PR TITLE
feat: add surface-specific validation wrappers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,9 @@ match your change:
    scripts/ci/validate-app.sh
    ```
 
-   Install the browser app dependencies first when you need the raw steps:
+   `scripts/ci/validate-app.sh` starts with the shared repository gates and then
+   runs the browser-specific checks below. Install the browser app dependencies
+   first when you need the raw follow-up steps only:
 
    ```bash
    npm --prefix app ci
@@ -108,10 +110,9 @@ match your change:
    npm --prefix app run test:e2e
    ```
 
-   `scripts/ci/validate-app.sh --e2e` installs Playwright Chromium and runs
-   `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to launch
-   `cargo run -- app .` automatically, so run it after the shared Rust gates
-   pass.
+   `scripts/ci/validate-app.sh --e2e` also installs Playwright Chromium and runs
+   `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to
+   launch `cargo run -- app .` automatically.
 
 4. **Documentation site** (`website/`)
 
@@ -121,7 +122,9 @@ match your change:
    scripts/ci/validate-website.sh
    ```
 
-   Install the docs-site dependencies first when you need the raw steps:
+   `scripts/ci/validate-website.sh` starts with the shared repository gates and
+   then runs the docs-site install/build sequence below. Install the docs-site
+   dependencies first when you need the raw follow-up steps only:
 
    ```bash
    npm --prefix website ci
@@ -139,8 +142,8 @@ match your change:
    npm --prefix website run build
    ```
 
-   `scripts/ci/validate-website.sh` runs the same install and build sequence as
-   `.github/actions/build-docs-site`.
+   After the shared gates, `scripts/ci/validate-website.sh` runs the same
+   install and build sequence as `.github/actions/build-docs-site`.
 
 5. **Docs-only edits outside `website/`, `app/`, or Rust logic**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,13 @@ match your change:
 3. **Browser app, WASM, or checked-in `app/dist` bundle** (`app/src`,
    `app/wasm`, browser build config, or generated browser assets)
 
-   Install the browser app dependencies first:
+   For the CI-aligned happy path, run:
+
+   ```bash
+   scripts/ci/validate-app.sh
+   ```
+
+   Install the browser app dependencies first when you need the raw steps:
 
    ```bash
    npm --prefix app ci
@@ -92,17 +98,30 @@ match your change:
    also install the local browser once and run the end-to-end suite:
 
    ```bash
+   scripts/ci/validate-app.sh --e2e
+   ```
+
+   The wrapper expands to:
+
+   ```bash
    npx --prefix app playwright install --with-deps chromium
    npm --prefix app run test:e2e
    ```
 
-   `npm run test:e2e` uses `app/playwright.config.ts` to launch
+   `scripts/ci/validate-app.sh --e2e` installs Playwright Chromium and runs
+   `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to launch
    `cargo run -- app .` automatically, so run it after the shared Rust gates
    pass.
 
 4. **Documentation site** (`website/`)
 
-   Install the docs-site dependencies first:
+   For the CI-aligned happy path, run:
+
+   ```bash
+   scripts/ci/validate-website.sh
+   ```
+
+   Install the docs-site dependencies first when you need the raw steps:
 
    ```bash
    npm --prefix website ci
@@ -120,7 +139,7 @@ match your change:
    npm --prefix website run build
    ```
 
-   `npm run build` regenerates the checked-in site docs first, matching
+   `scripts/ci/validate-website.sh` runs the same install and build sequence as
    `.github/actions/build-docs-site`.
 
 5. **Docs-only edits outside `website/`, `app/`, or Rust logic**

--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -61,6 +61,8 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
           - GitHub Flow
           - .worktrees/
           - scripts/ci/quality-gates.sh
+          - scripts/ci/validate-app.sh
+          - scripts/ci/validate-website.sh
       - **file**: .github/pull_request_template.md
         - **symbols**:
           - FEAT-CONTRIB-002
@@ -154,6 +156,8 @@ features:
             - GitHub Flow
             - .worktrees/
             - scripts/ci/quality-gates.sh
+            - scripts/ci/validate-app.sh
+            - scripts/ci/validate-website.sh
         - file: .github/pull_request_template.md
           symbols:
             - FEAT-CONTRIB-002

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -30,6 +30,13 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
       - **file**: scripts/ci/quality-gates.sh
         - **symbols**:
           - run_quality_gates
+      - **file**: scripts/ci/validate-app.sh
+        - **symbols**:
+          - run_optional_e2e
+          - validate_app
+      - **file**: scripts/ci/validate-website.sh
+        - **symbols**:
+          - validate_website
       - **file**: scripts/ci/coverage.sh
         - **symbols**:
           - configure_llvm_tools
@@ -103,6 +110,13 @@ features:
         - file: scripts/ci/quality-gates.sh
           symbols:
             - run_quality_gates
+        - file: scripts/ci/validate-app.sh
+          symbols:
+            - run_optional_e2e
+            - validate_app
+        - file: scripts/ci/validate-website.sh
+          symbols:
+            - validate_website
         - file: scripts/ci/coverage.sh
           symbols:
             - configure_llvm_tools

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 97/97
-- Feature-to-implementation traceability: 108/108
+- Feature-to-implementation traceability: 110/110
 
 ## Issues
 

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 96/96
-- Feature-to-implementation traceability: 108/108
+- Feature-to-implementation traceability: 110/110
 
 ## Issues
 

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -47,6 +47,8 @@ features:
             - GitHub Flow
             - .worktrees/
             - scripts/ci/quality-gates.sh
+            - scripts/ci/validate-app.sh
+            - scripts/ci/validate-website.sh
         - file: .github/pull_request_template.md
           symbols:
             - FEAT-CONTRIB-002

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -15,6 +15,13 @@ features:
         - file: scripts/ci/quality-gates.sh
           symbols:
             - run_quality_gates
+        - file: scripts/ci/validate-app.sh
+          symbols:
+            - run_optional_e2e
+            - validate_app
+        - file: scripts/ci/validate-website.sh
+          symbols:
+            - validate_website
         - file: scripts/ci/coverage.sh
           symbols:
             - configure_llvm_tools

--- a/scripts/ci/validate-app.sh
+++ b/scripts/ci/validate-app.sh
@@ -25,6 +25,7 @@ validate_app() {
     exit 1
   fi
 
+  bash scripts/ci/quality-gates.sh
   npm --prefix app ci
   bash scripts/ci/check-browser-app-freshness.sh
 

--- a/scripts/ci/validate-app.sh
+++ b/scripts/ci/validate-app.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+run_optional_e2e() {
+  npx --prefix app playwright install --with-deps chromium
+  npm --prefix app run test:e2e
+}
+
+validate_app() {
+  local repo_root
+  local run_e2e=0
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+
+  if [[ "${1:-}" == "--e2e" ]]; then
+    run_e2e=1
+    shift
+  fi
+
+  if [[ $# -ne 0 ]]; then
+    echo "usage: scripts/ci/validate-app.sh [--e2e]" >&2
+    exit 1
+  fi
+
+  npm --prefix app ci
+  bash scripts/ci/check-browser-app-freshness.sh
+
+  if [[ "$run_e2e" -eq 1 ]]; then
+    run_optional_e2e
+  fi
+}
+
+validate_app "$@"

--- a/scripts/ci/validate-website.sh
+++ b/scripts/ci/validate-website.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+validate_website() {
+  local repo_root
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+
+  npm --prefix website ci
+  npm --prefix website run build
+}
+
+validate_website "$@"

--- a/scripts/ci/validate-website.sh
+++ b/scripts/ci/validate-website.sh
@@ -9,6 +9,7 @@ validate_website() {
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   cd "$repo_root"
 
+  bash scripts/ci/quality-gates.sh
   npm --prefix website ci
   npm --prefix website run build
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -20,6 +20,8 @@ fn repository_declares_precommit_and_quality_gates() {
     let precommit = read_file(".pre-commit-config.yaml");
     let install_precommit = read_file("scripts/install-precommit.sh");
     let quality_script = read_file("scripts/ci/quality-gates.sh");
+    let validate_app_script = read_file("scripts/ci/validate-app.sh");
+    let validate_website_script = read_file("scripts/ci/validate-website.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
     let contributing = read_file("CONTRIBUTING.md");
     let repo_config = read_file("syu.yaml");
@@ -37,6 +39,14 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(quality_script.contains("cargo test"));
     assert!(quality_script.contains("cargo run -- validate ."));
     assert!(quality_script.contains("check-generated-docs-freshness.sh"));
+    assert!(validate_app_script.contains("FEAT-QUALITY-001"));
+    assert!(validate_app_script.contains("validate_app"));
+    assert!(validate_app_script.contains("check-browser-app-freshness.sh"));
+    assert!(validate_app_script.contains("npm --prefix app run test:e2e"));
+    assert!(validate_website_script.contains("FEAT-QUALITY-001"));
+    assert!(validate_website_script.contains("validate_website"));
+    assert!(validate_website_script.contains("npm --prefix website ci"));
+    assert!(validate_website_script.contains("npm --prefix website run build"));
     assert!(install_precommit.contains("site --user-base"));
     assert!(install_precommit.contains("pipx environment --value PIPX_BIN_DIR"));
     assert!(install_precommit.contains("Troubleshooting: compare"));
@@ -76,10 +86,13 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(contributing.contains("npm audit"));
     assert!(contributing.contains("Contributors do **not** need to run manual audits"));
     assert!(contributing.contains("check-generated-docs-freshness.sh"));
+    assert!(contributing.contains("scripts/ci/validate-app.sh"));
+    assert!(contributing.contains("scripts/ci/validate-website.sh"));
     assert!(contributing.contains("docs/generated/"));
     assert!(contributing.contains("python3 -m site --user-base"));
     assert!(contributing.contains("If you installed `pre-commit` with"));
     assert!(contributing.contains("pipx environment --value PIPX_BIN_DIR"));
+    assert!(contributing.contains("scripts/ci/check-browser-app-freshness.sh"));
 
     assert!(repo_config.contains("FEAT-CHECK-001"));
     assert!(repo_config.contains("FEAT-REPORT-001"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -41,10 +41,12 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(quality_script.contains("check-generated-docs-freshness.sh"));
     assert!(validate_app_script.contains("FEAT-QUALITY-001"));
     assert!(validate_app_script.contains("validate_app"));
+    assert!(validate_app_script.contains("scripts/ci/quality-gates.sh"));
     assert!(validate_app_script.contains("check-browser-app-freshness.sh"));
     assert!(validate_app_script.contains("npm --prefix app run test:e2e"));
     assert!(validate_website_script.contains("FEAT-QUALITY-001"));
     assert!(validate_website_script.contains("validate_website"));
+    assert!(validate_website_script.contains("scripts/ci/quality-gates.sh"));
     assert!(validate_website_script.contains("npm --prefix website ci"));
     assert!(validate_website_script.contains("npm --prefix website run build"));
     assert!(install_precommit.contains("site --user-base"));


### PR DESCRIPTION
## Summary
- add `scripts/ci/validate-app.sh` and `scripts/ci/validate-website.sh` for the common app and docs-site contributor flows
- document the new wrappers in `CONTRIBUTING.md` and trace them in the self-hosted repository spec
- extend repository-quality coverage so the scripts and docs stay wired together

Closes #448
