### PR TITLE
docs: consolidate README browser-app guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,13 +486,18 @@ with `scripts/ci/check-generated-docs-freshness.sh`.
 
 ## Browser app
 
-Start with [`syu app`](#syu-app) when you want richer browser-based exploration
-than the terminal-first `syu browse` flow. For a visual tour with annotated
-screenshots, see the [browser UI guide](docs/guide/app.md).
+Use [`syu app`](#syu-app) when you want a local browser UI for searching the
+four-layer graph, following links across related documents, and sharing the
+same live workspace data that `syu browse` exposes in the terminal.
 
-If you are deciding whether to use the browser UI or only need the CLI command,
-this section is the overview. The implementation and contributor build details
-live under [Browser app development](#browser-app-development).
+```bash
+syu app .
+syu app . --bind 127.0.0.1 --port 3000
+```
+
+For a visual tour with annotated screenshots, see the
+[browser UI guide](docs/guide/app.md). Contributor-only implementation and
+build details live under [Browser app development](#browser-app-development).
 
 ## VS Code extension
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ The browser app serves a VitePlus / React / Tailwind UI and uses Rust plus
 WebAssembly to build the layered browser view from the live workspace data.
 When `syu.yaml` defines `app.bind` or `app.port`, `syu app` uses those defaults
 unless the CLI flags override them.
+Choose `syu app` when you want a browser-first view of the same workspace graph
+that `syu browse` shows in the terminal.
 
 ### `syu report`
 
@@ -484,24 +486,13 @@ with `scripts/ci/check-generated-docs-freshness.sh`.
 
 ## Browser app
 
-The installed CLI can launch a local browser app for richer spec exploration:
+Start with [`syu app`](#syu-app) when you want richer browser-based exploration
+than the terminal-first `syu browse` flow. For a visual tour with annotated
+screenshots, see the [browser UI guide](docs/guide/app.md).
 
-```bash
-syu app .
-syu app . --bind 127.0.0.1 --port 3000
-```
-
-The repository keeps the source UI in `app/` and generates the embedded
-production bundle during Rust builds, so `syu app` still works from installed
-binaries without checking `app/dist/` into `main`.
-
-When contributors change browser app sources or build inputs, they should run
-`scripts/ci/check-browser-app-freshness.sh`. That flow regenerates the local
-`app/src/wasm` bridge, typechecks the browser app, and builds a fresh local
-`app/dist/` artifact the same way CI does before uploading it.
-
-Want the visual tour first? See the [browser UI guide with annotated
-screenshots](docs/guide/app.md).
+If you are deciding whether to use the browser UI or only need the CLI command,
+this section is the overview. The implementation and contributor build details
+live under [Browser app development](#browser-app-development).
 
 ## VS Code extension
 
@@ -657,6 +648,15 @@ If you prefer to install `pre-commit` manually, `pipx install pre-commit` or
 `python -m pip install --user pre-commit` also work.
 
 ### Browser app development
+
+The repository keeps the source UI in `app/` and generates the embedded
+production bundle during Rust builds, so `syu app` still works from installed
+binaries without checking `app/dist/` into `main`.
+
+When contributors change browser app sources or build inputs, they should run
+`scripts/ci/check-browser-app-freshness.sh`. That flow regenerates the local
+`app/src/wasm` bridge, typechecks the browser app, and builds a fresh local
+`app/dist/` artifact the same way CI does before uploading it.
 
 ```bash
 cd app


### PR DESCRIPTION
## Summary
- keep the newcomer-facing browser-app overview in one README section instead of repeating command details
- move source/bundle and contributor build details into the development section where they belong
- keep the command reference and browser UI guide cross-linked so readers can choose the right depth

Closes #445
