### PR TITLE
docs: surface the VS Code extension path (FEAT-VSCODE-001, FEAT-DOCS-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Pick the newcomer path that matches what you need next:
 - **Tutorial**: follow [`docs/guide/tutorial.md`](docs/guide/tutorial.md) when you
   learn best from a realistic repository story, want more narrative context than
   Quick start, and do not mind a longer walkthrough.
+- **Editor-first path**: start with
+  [`docs/guide/vscode-extension.md`](docs/guide/vscode-extension.md) when you
+  want diagnostics, spec navigation, and trace lookups inside VS Code before
+  you memorize the CLI or browser flows.
 - **Migration / upgrade**: open [`docs/guide/migration.md`](docs/guide/migration.md)
   when you already have a `syu` workspace and want the release-specific steps
   for moving between alpha versions safely.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,6 +25,9 @@ Need a different level of guidance?
   same commands fit together as one guided story.
 - Follow the [end-to-end tutorial](./tutorial.md) when you want a realistic,
   worked repository story instead of the shortest setup path.
+- Start with the [VS Code extension guide](./vscode-extension.md) when you want
+  diagnostics, spec navigation, and related-file lookups in the editor before
+  you settle into the terminal or browser flows.
 - Use the [trace adapter capability matrix](./trace-adapter-support.md) when
   you need to know which built-in languages support symbol validation only
   versus `doc_contains` and strict coverage.


### PR DESCRIPTION
## Summary
- add a VS Code extension path to the README newcomer chooser
- point getting-started readers to the editor-first route when it fits better

## Linked issue or specification
- Closes #461
- Requirement / feature IDs: FEAT-VSCODE-001, FEAT-DOCS-001

## Validation
- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed