### PR TITLE
feat: make devcontainer browser setup opt-in (FEAT-CONTRIB-001, FEAT-CONTRIB-002)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -21,14 +21,6 @@ install_wasm_tooling() {
   cargo install wasm-pack --locked
 }
 
-install_browser_tooling() {
-  log_step "Installing browser-app dependencies for local app builds, scripts/ci/check-browser-app-freshness.sh, and npm --prefix app run test:e2e."
-  npm --prefix app ci
-
-  log_step "Installing Playwright Chromium for npm --prefix app run test:e2e."
-  npx --prefix app playwright install --with-deps chromium
-}
-
 install_precommit_tooling() {
   log_step "Installing local hooks with scripts/install-precommit.sh."
   bash scripts/install-precommit.sh
@@ -43,8 +35,8 @@ main() {
   log_step "Setting up the contributor toolchain. See CONTRIBUTING.md#local-checks for what this bootstrap installs and which workflows still stay opt-in."
   install_coverage_tooling
   install_wasm_tooling
-  install_browser_tooling
   install_precommit_tooling
+  log_step "Browser-app npm installs and Playwright browsers stay opt-in. Run bash .devcontainer/setup-browser-tooling.sh when you need app builds or end-to-end coverage."
   log_step "Devcontainer setup complete."
 }
 

--- a/.devcontainer/setup-browser-tooling.sh
+++ b/.devcontainer/setup-browser-tooling.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# FEAT-CONTRIB-001
+
+set -euo pipefail
+
+repo_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
+}
+
+log_step() {
+  printf "\n[devcontainer] %s\n" "$1"
+}
+
+main() {
+  local root
+  root="$(repo_root)"
+
+  cd "$root"
+
+  log_step "Installing browser-app dependencies for local app builds, scripts/ci/check-browser-app-freshness.sh, and npm --prefix app run test:e2e."
+  npm --prefix app ci
+
+  log_step "Installing Playwright Chromium for npm --prefix app run test:e2e."
+  npx --prefix app playwright install --with-deps chromium
+
+  log_step "Browser tooling setup complete."
+}
+
+main "$@"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,20 +77,20 @@ match your change:
    scripts/ci/validate-app.sh
    ```
 
-    `scripts/ci/validate-app.sh` starts with the shared repository gates and then
-    runs the browser-specific checks below. In the devcontainer or Codespaces,
-    install the browser tooling first with:
+   `scripts/ci/validate-app.sh` starts with the shared repository gates and then
+   runs the browser-specific checks below. In the devcontainer or Codespaces,
+   install the browser tooling first with:
 
-    ```bash
-    bash .devcontainer/setup-browser-tooling.sh
-    ```
+   ```bash
+   bash .devcontainer/setup-browser-tooling.sh
+   ```
 
-    Outside the devcontainer, or when you only need the raw follow-up steps,
-    install the browser app dependencies with:
+   Outside the devcontainer, or when you only need the raw follow-up steps,
+   install the browser app dependencies with:
 
-    ```bash
-    npm --prefix app ci
-    ```
+   ```bash
+   npm --prefix app ci
+   ```
 
    Then run the same freshness flow CI uses:
 
@@ -117,11 +117,11 @@ match your change:
    npm --prefix app run test:e2e
    ```
 
-    `scripts/ci/validate-app.sh --e2e` also installs Playwright Chromium and runs
-    `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to
-    launch `cargo run -- app .` automatically. The devcontainer/Codespaces
-    post-create step keeps this browser setup opt-in so docs-only or Rust-only
-    contributors do not pay for it by default.
+   `scripts/ci/validate-app.sh --e2e` also installs Playwright Chromium and runs
+   `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to
+   launch `cargo run -- app .` automatically. The devcontainer/Codespaces
+   post-create step keeps this browser setup opt-in so docs-only or Rust-only
+   contributors do not pay for it by default.
 
 4. **Documentation site** (`website/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,13 +77,20 @@ match your change:
    scripts/ci/validate-app.sh
    ```
 
-   `scripts/ci/validate-app.sh` starts with the shared repository gates and then
-   runs the browser-specific checks below. Install the browser app dependencies
-   first when you need the raw follow-up steps only:
+    `scripts/ci/validate-app.sh` starts with the shared repository gates and then
+    runs the browser-specific checks below. In the devcontainer or Codespaces,
+    install the browser tooling first with:
 
-   ```bash
-   npm --prefix app ci
-   ```
+    ```bash
+    bash .devcontainer/setup-browser-tooling.sh
+    ```
+
+    Outside the devcontainer, or when you only need the raw follow-up steps,
+    install the browser app dependencies with:
+
+    ```bash
+    npm --prefix app ci
+    ```
 
    Then run the same freshness flow CI uses:
 
@@ -110,9 +117,11 @@ match your change:
    npm --prefix app run test:e2e
    ```
 
-   `scripts/ci/validate-app.sh --e2e` also installs Playwright Chromium and runs
-   `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to
-   launch `cargo run -- app .` automatically.
+    `scripts/ci/validate-app.sh --e2e` also installs Playwright Chromium and runs
+    `npm --prefix app run test:e2e`, which uses `app/playwright.config.ts` to
+    launch `cargo run -- app .` automatically. The devcontainer/Codespaces
+    post-create step keeps this browser setup opt-in so docs-only or Rust-only
+    contributors do not pay for it by default.
 
 4. **Documentation site** (`website/`)
 

--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -36,8 +36,11 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
           - FEAT-CONTRIB-001
           - install_coverage_tooling
           - install_wasm_tooling
-          - install_browser_tooling
           - install_precommit_tooling
+          - main
+      - **file**: .devcontainer/setup-browser-tooling.sh
+        - **symbols**:
+          - FEAT-CONTRIB-001
           - main
     - **rust**:
       - **file**: tests/example_workspaces.rs
@@ -130,8 +133,11 @@ features:
             - FEAT-CONTRIB-001
             - install_coverage_tooling
             - install_wasm_tooling
-            - install_browser_tooling
             - install_precommit_tooling
+            - main
+        - file: .devcontainer/setup-browser-tooling.sh
+          symbols:
+            - FEAT-CONTRIB-001
             - main
       rust:
         - file: tests/example_workspaces.rs

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 97/97
-- Feature-to-implementation traceability: 110/110
+- Feature-to-implementation traceability: 111/111
 
 ## Issues
 

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -21,8 +21,11 @@ features:
             - FEAT-CONTRIB-001
             - install_coverage_tooling
             - install_wasm_tooling
-            - install_browser_tooling
             - install_precommit_tooling
+            - main
+        - file: .devcontainer/setup-browser-tooling.sh
+          symbols:
+            - FEAT-CONTRIB-001
             - main
       rust:
         - file: tests/example_workspaces.rs

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -658,18 +658,21 @@ fn repository_ships_vscode_extension() {
 fn repository_declares_devcontainer_configuration() {
     let devcontainer = read_file(".devcontainer/devcontainer.json");
     let post_create = read_file(".devcontainer/post-create.sh");
+    let browser_setup = read_file(".devcontainer/setup-browser-tooling.sh");
     assert!(devcontainer.contains("FEAT-CONTRIB-001"));
     assert!(devcontainer.contains("bash .devcontainer/post-create.sh"));
     assert!(devcontainer.contains("ghcr.io/devcontainers/features/python:1"));
     assert!(post_create.contains("FEAT-CONTRIB-001"));
     assert!(post_create.contains("cargo install cargo-llvm-cov --locked"));
     assert!(post_create.contains("cargo install wasm-pack --locked"));
-    assert!(post_create.contains("npm --prefix app ci"));
-    assert!(post_create.contains("playwright install --with-deps chromium"));
     assert!(post_create.contains("scripts/install-precommit.sh"));
     assert!(post_create.contains("CONTRIBUTING.md#local-checks"));
-    assert!(post_create.contains("local app builds"));
+    assert!(post_create.contains("bash .devcontainer/setup-browser-tooling.sh"));
     assert!(post_create.contains("stay opt-in"));
+    assert!(browser_setup.contains("FEAT-CONTRIB-001"));
+    assert!(browser_setup.contains("npm --prefix app ci"));
+    assert!(browser_setup.contains("playwright install --with-deps chromium"));
+    assert!(browser_setup.contains("local app builds"));
 }
 
 #[test]
@@ -737,6 +740,7 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(contributing.contains("requirement/feature coverage summary"));
     assert!(contributing.contains("Linked issue or specification"));
     assert!(contributing.contains("app/dist"));
+    assert!(contributing.contains("bash .devcontainer/setup-browser-tooling.sh"));
     assert!(contributing.contains("npm run build:wasm"));
     assert!(contributing.contains("npm run check"));
     assert!(contributing.contains("npx --prefix app playwright install --with-deps chromium"));


### PR DESCRIPTION
## Summary
- keep the default devcontainer bootstrap focused on shared contributor tooling
- move browser npm and Playwright setup into an explicit follow-up script
- document and trace the opt-in browser path in CONTRIBUTING and generated docs

## Linked issue or specification
- Closes #463
- Requirement / feature IDs: FEAT-CONTRIB-001, FEAT-CONTRIB-002

## Validation
- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] `npm --prefix website run build`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed
