### PR TITLE
fix: scope app onboarding dismissal per workspace (FEAT-APP-001)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -70,6 +70,7 @@ function App() {
 
   const applyWorkspace = useCallback((browserWorkspace: BrowserWorkspace) => {
     setWorkspace(browserWorkspace);
+    setShowOnboarding(shouldShowOnboarding(browserWorkspace.workspace_root));
 
     const hash = window.location.hash.replace(/^#\/?/, "");
     const hashParts = hash.split("/");
@@ -490,7 +491,7 @@ function App() {
 
   const dismissOnboarding = () => {
     setShowOnboarding(false);
-    persistOnboardingDismissal();
+    persistOnboardingDismissal(workspace?.workspace_root);
   };
 
   const goBack = () => {
@@ -1190,26 +1191,36 @@ function ratio(validated: number, declared: number): number {
   return Math.max(0, Math.min(1, validated / declared));
 }
 
-function shouldShowOnboarding(): boolean {
+function onboardingStorageKey(workspaceRoot: string | null | undefined): string {
+  const normalizedRoot = workspaceRoot?.trim();
+
+  if (!normalizedRoot) {
+    return ONBOARDING_STORAGE_KEY;
+  }
+
+  return `${ONBOARDING_STORAGE_KEY}:${normalizedRoot}`;
+}
+
+function shouldShowOnboarding(workspaceRoot?: string): boolean {
   if (typeof window === "undefined") {
     return true;
   }
 
   try {
-    return window.sessionStorage.getItem(ONBOARDING_STORAGE_KEY) !== "true";
+    return window.sessionStorage.getItem(onboardingStorageKey(workspaceRoot)) !== "true";
   } catch (error) {
     console.warn("syu app could not read onboarding dismissal state from sessionStorage.", error);
     return true;
   }
 }
 
-function persistOnboardingDismissal() {
+function persistOnboardingDismissal(workspaceRoot?: string) {
   if (typeof window === "undefined") {
     return;
   }
 
   try {
-    window.sessionStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
+    window.sessionStorage.setItem(onboardingStorageKey(workspaceRoot), "true");
   } catch (error) {
     console.warn("syu app could not persist onboarding dismissal in sessionStorage.", error);
   }

--- a/app/tests/browser-app.spec.ts
+++ b/app/tests/browser-app.spec.ts
@@ -7,6 +7,7 @@ const usesFailingWorkspace =
   process.env.SYU_APP_E2E_WORKSPACE?.includes("tests/fixtures/workspaces/failing") ?? false;
 
 type AppDataPayload = {
+  workspace_root?: string;
   source_documents: Array<{
     section: "philosophy" | "policies" | "features" | "requirements";
     path: string;
@@ -175,6 +176,38 @@ test("renders top tabs and linked spec content", async ({ page }) => {
     page.getByRole("heading", { name: /FEAT-CHECK-001 .* Unified validation command/i }),
   ).toBeVisible();
   await expect(page).toHaveURL(/#features\/FEAT-CHECK-001$/);
+});
+
+test("scopes welcome-banner dismissal to the current workspace root", async ({ page }) => {
+  let appDataRequests = 0;
+
+  await page.route("**/api/app-data.json", async (route) => {
+    appDataRequests += 1;
+
+    const response = await route.fetch();
+    const payload = (await response.json()) as AppDataPayload;
+    const workspaceRoot =
+      appDataRequests >= 2
+        ? "/tmp/other-workspace"
+        : (payload.workspace_root ?? "/tmp/current-workspace");
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify({
+        ...payload,
+        workspace_root: workspaceRoot,
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await expect(page.getByText("Welcome to syu.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Dismiss welcome banner" }).click();
+  await expect(page.getByText("Welcome to syu.")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByText("Welcome to syu.")).toBeVisible();
 });
 
 test("loads deep links and supports keyboard search navigation", async ({ page }) => {


### PR DESCRIPTION
## Summary
- scope the welcome-banner dismissal key by workspace root instead of sharing one global session key
- re-evaluate onboarding visibility after each workspace snapshot loads
- cover the cross-workspace case in Playwright

## Linked issue or specification
- Closes #467
- Requirement / feature IDs: FEAT-APP-001

## Validation
- [x] `scripts/ci/validate-app.sh --e2e`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed
