### PR TITLE
fix: resolve vscode workspaces from custom spec roots (FEAT-VSCODE-001)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -20,6 +20,7 @@
   "activationEvents": [
     "workspaceContains:syu.yaml",
     "workspaceContains:docs/syu/features/features.yaml",
+    "workspaceContains:features/features.yaml",
     "onCommand:syu.refreshDiagnostics",
     "onCommand:syu.showTraceForActiveFile",
     "onCommand:syu.openSpecItemById",

--- a/editors/vscode/src/extension.js
+++ b/editors/vscode/src/extension.js
@@ -10,6 +10,7 @@ const {
   loadSpecModel,
   lookupTrace,
   openTargetsForSpecId,
+  resolveWorkspaceContext,
   specIdFromText
 } = require('./model');
 
@@ -170,12 +171,12 @@ function fileExists(filePath) {
   );
 }
 
+async function resolveFolderWorkspace(folder) {
+  return resolveWorkspaceContext(folder.uri.fsPath);
+}
+
 async function isSyuWorkspace(folder) {
-  const workspaceRoot = folder.uri.fsPath;
-  return (
-    (await fileExists(path.join(workspaceRoot, 'syu.yaml'))) ||
-    (await fileExists(path.join(workspaceRoot, 'docs/syu/features/features.yaml')))
-  );
+  return (await resolveFolderWorkspace(folder)) != null;
 }
 
 async function syuWorkspaceFolders() {
@@ -197,19 +198,28 @@ function getAutoRefreshDiagnostics(folder) {
 }
 
 async function ensureModel(folder, modelCache) {
-  const workspaceRoot = folder.uri.fsPath;
-  const cached = modelCache.get(workspaceRoot);
+  const workspace = await resolveFolderWorkspace(folder);
+  if (!workspace) {
+    throw new Error('The selected folder is not inside a syu workspace.');
+  }
+
+  const cached = modelCache.get(workspace.workspaceRoot);
   if (cached && !cached.dirty) {
     return cached.model;
   }
 
-  const model = await loadSpecModel(workspaceRoot);
-  modelCache.set(workspaceRoot, { model, dirty: false });
+  const model = await loadSpecModel(workspace.workspaceRoot);
+  modelCache.set(workspace.workspaceRoot, { model, dirty: false });
   return model;
 }
 
-function invalidateModel(folder, modelCache) {
-  const entry = modelCache.get(folder.uri.fsPath);
+async function invalidateModel(folder, modelCache) {
+  const workspace = await resolveFolderWorkspace(folder);
+  if (!workspace) {
+    return;
+  }
+
+  const entry = modelCache.get(workspace.workspaceRoot);
   if (entry) {
     entry.dirty = true;
   }
@@ -222,8 +232,12 @@ async function refreshDiagnostics(modelCache, collection) {
   for (const folder of folders) {
     try {
       const model = await ensureModel(folder, modelCache);
+      const workspace = await resolveFolderWorkspace(folder);
+      if (!workspace) {
+        continue;
+      }
       const records = await loadDiagnostics({
-        workspaceRoot: folder.uri.fsPath,
+        workspaceRoot: workspace.workspaceRoot,
         binaryPath: getBinaryPath(folder),
         model
       });
@@ -353,7 +367,7 @@ async function refreshContextForActiveEditor(modelCache, treeProvider) {
   try {
     const model = await ensureModel(folder, modelCache);
     treeProvider.setTraceContext(
-      folder.uri.fsPath,
+      model.workspaceRoot,
       lookupTrace(model, editor.document.uri.fsPath, null)
     );
   } catch (error) {
@@ -390,7 +404,7 @@ function registerCommands(context, modelCache, treeProvider, collection) {
       const model = await ensureModel(folder, modelCache);
       const symbol = activeSymbol(editor);
       const traceContext = lookupTrace(model, editor.document.uri.fsPath, symbol);
-      treeProvider.setTraceContext(folder.uri.fsPath, traceContext);
+      treeProvider.setTraceContext(model.workspaceRoot, traceContext);
     })
   );
 
@@ -478,7 +492,7 @@ function activate(context) {
         return;
       }
 
-      invalidateModel(folder, modelCache);
+      await invalidateModel(folder, modelCache);
       if (getAutoRefreshDiagnostics(folder)) {
         await refreshDiagnostics(modelCache, diagnostics);
       }

--- a/editors/vscode/src/model.js
+++ b/editors/vscode/src/model.js
@@ -51,6 +51,16 @@ async function pathExists(filePath) {
   }
 }
 
+async function looksLikeSpecRoot(root) {
+  return (
+    (await pathExists(path.join(root, 'philosophy'))) &&
+    (await pathExists(path.join(root, 'policies'))) &&
+    (await pathExists(path.join(root, 'requirements'))) &&
+    (await pathExists(path.join(root, 'features'))) &&
+    (await pathExists(path.join(root, 'features', 'features.yaml')))
+  )
+}
+
 async function readWorkspaceConfig(workspaceRoot) {
   const configPath = path.join(workspaceRoot, 'syu.yaml')
   if (!(await pathExists(configPath))) {
@@ -67,6 +77,43 @@ async function readWorkspaceConfig(workspaceRoot) {
   } catch {
     return { specRoot: DEFAULT_SPEC_ROOT }
   }
+}
+
+async function resolveWorkspaceContext(startPath) {
+  const resolved = path.resolve(startPath)
+  const searchRoot = resolved
+  let current = searchRoot
+
+  while (true) {
+    const configPath = path.join(current, 'syu.yaml')
+    if (await pathExists(configPath)) {
+      const { specRoot } = await readWorkspaceConfig(current)
+      const absoluteSpecRoot = path.resolve(current, specRoot)
+      if (
+        (searchRoot === current || isWithinPath(searchRoot, absoluteSpecRoot)) &&
+        (await looksLikeSpecRoot(absoluteSpecRoot))
+      ) {
+        return { workspaceRoot: current, specRoot: absoluteSpecRoot }
+      }
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) {
+      break
+    }
+    current = parent
+  }
+
+  if (await looksLikeSpecRoot(searchRoot)) {
+    return { workspaceRoot: searchRoot, specRoot: searchRoot }
+  }
+
+  return null
+}
+
+function isWithinPath(candidate, parent) {
+  const relative = path.relative(parent, candidate)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
 }
 
 async function walkYamlFiles(root) {
@@ -152,8 +199,14 @@ function collectDocumentEntries(kind, items, documentPath, byId, byKind) {
 }
 
 async function loadSpecModel(workspaceRoot) {
-  const { specRoot } = await readWorkspaceConfig(workspaceRoot)
-  const absoluteSpecRoot = path.resolve(workspaceRoot, specRoot)
+  const context = await resolveWorkspaceContext(workspaceRoot)
+  const resolvedWorkspaceRoot = context?.workspaceRoot || workspaceRoot
+  const absoluteSpecRoot =
+    context?.specRoot ||
+    path.resolve(
+      resolvedWorkspaceRoot,
+      (await readWorkspaceConfig(resolvedWorkspaceRoot)).specRoot
+    )
   const yamlFiles = await walkYamlFiles(absoluteSpecRoot)
   const byId = new Map()
   const byKind = new Map(SPEC_KINDS.map((kind) => [kind, []]))
@@ -167,7 +220,7 @@ async function loadSpecModel(workspaceRoot) {
       continue
     }
 
-    const documentPath = normalizeRelativePath(path.relative(workspaceRoot, filePath))
+    const documentPath = normalizeRelativePath(path.relative(resolvedWorkspaceRoot, filePath))
     collectDocumentEntries('philosophy', parsed?.philosophies, documentPath, byId, byKind)
     collectDocumentEntries('policy', parsed?.policies, documentPath, byId, byKind)
     collectDocumentEntries('requirement', parsed?.requirements, documentPath, byId, byKind)
@@ -175,7 +228,7 @@ async function loadSpecModel(workspaceRoot) {
   }
 
   return {
-    workspaceRoot,
+    workspaceRoot: resolvedWorkspaceRoot,
     specRoot: absoluteSpecRoot,
     byId,
     byKind
@@ -683,6 +736,8 @@ module.exports = {
   lookupTrace,
   normalizeRelativePath,
   openTargetsForSpecId,
+  readWorkspaceConfig,
+  resolveWorkspaceContext,
   resolveIssueTarget,
   runSyuJson,
   specIdFromText

--- a/editors/vscode/test/model.test.js
+++ b/editors/vscode/test/model.test.js
@@ -3,6 +3,8 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
 const path = require('node:path');
 
 const {
@@ -10,6 +12,7 @@ const {
   lookupTrace,
   normalizeRelativePath,
   openTargetsForSpecId,
+  resolveWorkspaceContext,
   resolveIssueTarget
 } = require('../src/model');
 
@@ -17,13 +20,46 @@ function fixtureRoot(name) {
   return path.resolve(__dirname, '../../../tests/fixtures/workspaces', name);
 }
 
+async function createCustomSpecRootWorkspace() {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'syu-vscode-spec-root-'));
+  const specRoot = path.join(workspaceRoot, 'spec', 'contracts');
+
+  await fs.mkdir(path.join(specRoot, 'philosophy'), { recursive: true });
+  await fs.mkdir(path.join(specRoot, 'policies'), { recursive: true });
+  await fs.mkdir(path.join(specRoot, 'requirements'), { recursive: true });
+  await fs.mkdir(path.join(specRoot, 'features'), { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceRoot, 'syu.yaml'),
+    'version: 0.0.1-alpha.7\nspec:\n  root: spec/contracts\n'
+  );
+  await fs.writeFile(
+    path.join(specRoot, 'philosophy', 'foundation.yaml'),
+    'category: Philosophy\nphilosophies:\n  - id: PHIL-CUSTOM-001\n    title: Custom root\n'
+  );
+  await fs.writeFile(
+    path.join(specRoot, 'policies', 'policies.yaml'),
+    'category: Policies\npolicies:\n  - id: POL-CUSTOM-001\n    title: Custom policy\n    linked_philosophies:\n      - PHIL-CUSTOM-001\n'
+  );
+  await fs.writeFile(
+    path.join(specRoot, 'requirements', 'core.yaml'),
+    'category: Requirements\nrequirements:\n  - id: REQ-CUSTOM-001\n    title: Custom requirement\n    linked_policies:\n      - POL-CUSTOM-001\n'
+  );
+  await fs.writeFile(path.join(specRoot, 'features', 'features.yaml'), 'version: "1"\nfiles: []\n');
+  await fs.writeFile(
+    path.join(specRoot, 'features', 'core.yaml'),
+    'category: Features\nfeatures:\n  - id: FEAT-CUSTOM-001\n    title: Custom feature\n    linked_requirements:\n      - REQ-CUSTOM-001\n'
+  );
+
+  return { workspaceRoot, specRoot };
+}
+
 test('loadSpecModel indexes spec documents without syu yaml', async () => {
   const model = await loadSpecModel(fixtureRoot('passing'));
 
   assert.equal(model.byKind.get('philosophy').length, 1);
   assert.equal(model.byKind.get('policy').length, 2);
-  assert.equal(model.byKind.get('requirement').length, 4);
-  assert.equal(model.byKind.get('feature').length, 4);
+  assert.equal(model.byKind.get('requirement').length, 5);
+  assert.equal(model.byKind.get('feature').length, 5);
   assert.equal(
     model.byId.get('REQ-TRACE-001').documentPath,
     'docs/syu/requirements/traceability/core.yaml'
@@ -100,4 +136,20 @@ test('resolveIssueTarget preserves absolute issue locations', async () => {
 
 test('normalizeRelativePath keeps repository relative paths portable', () => {
   assert.equal(normalizeRelativePath('.\\src\\feature.js'), 'src/feature.js');
+});
+
+test('resolveWorkspaceContext honors configured workspace roots', async () => {
+  const workspace = await createCustomSpecRootWorkspace();
+  const context = await resolveWorkspaceContext(workspace.workspaceRoot);
+
+  assert.equal(context.workspaceRoot, workspace.workspaceRoot);
+  assert.equal(context.specRoot, workspace.specRoot);
+});
+
+test('resolveWorkspaceContext resolves an opened spec root back to the repository root', async () => {
+  const workspace = await createCustomSpecRootWorkspace();
+  const context = await resolveWorkspaceContext(workspace.specRoot);
+
+  assert.equal(context.workspaceRoot, workspace.workspaceRoot);
+  assert.equal(context.specRoot, workspace.specRoot);
 });


### PR DESCRIPTION
## Summary
- resolve VS Code workspaces through the configured `spec.root` instead of hard-coding `docs/syu`
- treat opened spec-root folders as part of the parent syu workspace when a matching `syu.yaml` exists
- add extension activation coverage and node tests for custom spec-root discovery

## Linked issue or specification
- Closes #466
- Requirement / feature IDs: FEAT-VSCODE-001

## Validation
- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] `npm --prefix editors/vscode test`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed
