### PR TITLE
feat: extend syu log to all spec layers (REQ-CORE-024, FEAT-LOG-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,20 +422,21 @@ syu search FEAT-CHECK-001 --format json
 
 ### `syu log`
 
-Project one traced requirement or feature onto checked-in Git history:
+Project one philosophy, policy, requirement, or feature onto checked-in Git history:
 
 ```bash
 syu log REQ-CORE-002
+syu log POL-004 --kind definition
 syu log FEAT-CHECK-001 --kind implementation --path src/command
 syu log REQ-CORE-019 --format json
 ```
 
-`syu log` works from the current trace graph. It looks up the checked-in
-definition path plus the traced test or implementation files for one requirement
-or feature, then shows the commits that touched those paths and why each commit
-matched. Use `--kind` when you only want definition, test, or implementation
-history, and `--path` when you want to narrow the traced paths to one
-repository-relative file or directory prefix.
+`syu log` works from the current trace graph. It always includes the checked-in
+definition path, and for requirements or features it also includes traced test
+or implementation files. Then it shows the commits that touched those paths and
+why each commit matched. Use `--kind` when you only want definition, test, or
+implementation history, and `--path` when you want to narrow the traced paths
+to one repository-relative file or directory prefix.
 ### `syu relate`
 
 Inspect the connected graph around one definition, repository path, or traced

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,7 +320,9 @@ impl HistoryKind {
 
 #[derive(Debug, Clone, Args)]
 pub struct LogArgs {
-    #[arg(help = "Requirement or feature ID whose traced history should be inspected")]
+    #[arg(
+        help = "Philosophy, policy, requirement, or feature ID whose traced history should be inspected"
+    )]
     pub id: String,
 
     #[arg(help = WORKSPACE_HELP)]

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -149,11 +149,16 @@ fn build_history_target(
             item.title.clone(),
             tracked_paths_for_feature(item, kind, &definition_path)?,
         ),
-        WorkspaceEntity::Philosophy(_) | WorkspaceEntity::Policy(_) => {
-            bail!(
-                "`syu log` currently supports requirement and feature IDs only; `{id}` belongs to a non-trace layer."
-            );
-        }
+        WorkspaceEntity::Philosophy(item) => (
+            "philosophy",
+            item.title.clone(),
+            tracked_paths_for_non_trace_layer(&item.id, "philosophy", kind, &definition_path)?,
+        ),
+        WorkspaceEntity::Policy(item) => (
+            "policy",
+            item.title.clone(),
+            tracked_paths_for_non_trace_layer(&item.id, "policy", kind, &definition_path)?,
+        ),
     };
 
     let mut tracked_paths = traces;
@@ -286,6 +291,25 @@ fn tracked_paths_for_feature(
         HistoryKind::Implementation => {
             Ok(collect_trace_paths("implementation", &item.implementations))
         }
+    }
+}
+
+fn tracked_paths_for_non_trace_layer(
+    id: &str,
+    layer_label: &str,
+    kind: HistoryKind,
+    definition_path: &str,
+) -> Result<Vec<TrackedPath>> {
+    match kind {
+        HistoryKind::All | HistoryKind::Definition => {
+            Ok(vec![TrackedPath::definition(definition_path)])
+        }
+        HistoryKind::Test => bail!(
+            "`{id}` is a {layer_label}, so `--kind test` is not available. Use `--kind definition` or omit the flag."
+        ),
+        HistoryKind::Implementation => bail!(
+            "`{id}` is a {layer_label}, so `--kind implementation` is not available. Use `--kind definition` or omit the flag."
+        ),
     }
 }
 

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -78,6 +78,7 @@ fn log_help_mentions_kind_path_and_json_output() {
     assert!(stdout.contains("--kind"));
     assert!(stdout.contains("--path"));
     assert!(stdout.contains("--format"));
+    assert!(stdout.contains("Philosophy, policy, requirement, or feature ID"));
     assert!(stdout.contains("syu log FEAT-CHECK-001 --kind implementation --path src/command"));
 }
 

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -506,7 +506,7 @@ fn log_command_rejects_unknown_ids() {
 }
 
 #[test]
-fn log_command_rejects_non_trace_layers() {
+fn log_command_renders_philosophy_definition_history() {
     let workspace = write_history_workspace();
     let output = Command::cargo_bin("syu")
         .expect("binary should build")
@@ -518,8 +518,13 @@ fn log_command_rejects_non_trace_layers() {
         .output()
         .expect("command should run");
 
-    assert_eq!(output.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("requirement and feature IDs only"));
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("History: philosophy PHIL-HIST-001"));
+    assert!(stdout.contains("definition\tdocs/syu/philosophy/foundation.yaml"));
+    assert!(stdout.contains("chore: initial history fixture"));
+    assert!(!stdout.contains("test: adjust traced requirement coverage"));
 }
 
 #[test]
@@ -558,6 +563,25 @@ fn log_command_rejects_incompatible_feature_kinds() {
 
     assert_eq!(output.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&output.stderr).contains("--kind test"));
+}
+
+#[test]
+fn log_command_rejects_incompatible_policy_kinds() {
+    let workspace = write_history_workspace();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "POL-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+            "--kind",
+            "implementation",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--kind implementation"));
 }
 
 #[test]

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -528,6 +528,28 @@ fn log_command_renders_philosophy_definition_history() {
 }
 
 #[test]
+fn log_command_renders_policy_definition_history() {
+    let workspace = write_history_workspace();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "POL-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("History: policy POL-HIST-001"));
+    assert!(stdout.contains("definition\tdocs/syu/policies/policies.yaml"));
+    assert!(stdout.contains("chore: initial history fixture"));
+    assert!(!stdout.contains("feat: update traced implementation"));
+}
+
+#[test]
 fn log_command_rejects_incompatible_requirement_kinds() {
     let workspace = write_history_workspace();
     let output = Command::cargo_bin("syu")

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -607,6 +607,25 @@ fn log_command_rejects_incompatible_policy_kinds() {
 }
 
 #[test]
+fn log_command_rejects_incompatible_philosophy_kinds() {
+    let workspace = write_history_workspace();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "PHIL-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+            "--kind",
+            "test",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--kind test"));
+}
+
+#[test]
 fn log_command_rejects_empty_path_selections() {
     let workspace = write_history_workspace();
     let output = Command::cargo_bin("syu")


### PR DESCRIPTION
## Summary
- let `syu log` inspect philosophy and policy IDs by their checked-in definition history
- keep `--kind` validation explicit for layers that do not expose traced test or implementation paths
- update help text, README examples, and command tests for the wider reviewer workflow

## Linked issue or specification
- Closes #468
- Requirement / feature IDs: REQ-CORE-024, FEAT-LOG-001

## Validation
- [x] `scripts/ci/quality-gates.sh`
- [x] `scripts/ci/coverage.sh summary`
- [x] `cargo run -- validate .`
- [x] `npm --prefix website run build`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed
