### PR TITLE
feat: make app refresh polling adaptive (FEAT-APP-001)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -180,6 +180,9 @@ function App() {
       Math.min(REFRESH_POLL_MAX_MS, REFRESH_POLL_MIN_MS * 2 ** stablePollCount);
 
     const schedulePoll = (delay: number) => {
+      if (cancelled) {
+        return;
+      }
       if (timeoutId != null) {
         window.clearTimeout(timeoutId);
       }
@@ -227,6 +230,9 @@ function App() {
     };
 
     const handleVisibilityChange = () => {
+      if (cancelled) {
+        return;
+      }
       if (!document.hidden) {
         stablePollCount = 0;
         schedulePoll(REFRESH_POLL_MIN_MS);
@@ -241,6 +247,7 @@ function App() {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       if (timeoutId != null) {
         window.clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
   }, [isRefreshing, loadWorkspace, snapshotVersion]);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -35,6 +35,8 @@ type SearchResult = {
 
 const SECTION_ORDER: SectionKind[] = ["philosophy", "policies", "requirements", "features"];
 const SEARCH_RESULTS_LIST_ID = "spec-search-results-list";
+const REFRESH_POLL_MIN_MS = 2_000;
+const REFRESH_POLL_MAX_MS = 10_000;
 
 const SECTION_COPY: Record<SectionKind, string> = {
   philosophy: "Project intent and enduring values.",
@@ -171,8 +173,27 @@ function App() {
     }
 
     let cancelled = false;
-    const intervalId = window.setInterval(async () => {
+    let stablePollCount = 0;
+    let timeoutId: number | null = null;
+
+    const currentDelay = () =>
+      Math.min(REFRESH_POLL_MAX_MS, REFRESH_POLL_MIN_MS * 2 ** stablePollCount);
+
+    const schedulePoll = (delay: number) => {
+      if (timeoutId != null) {
+        window.clearTimeout(timeoutId);
+      }
+      timeoutId = window.setTimeout(() => {
+        void pollVersion();
+      }, delay);
+    };
+
+    const pollVersion = async () => {
+      if (cancelled) {
+        return;
+      }
       if (document.hidden || isRefreshing) {
+        schedulePoll(currentDelay());
         return;
       }
 
@@ -186,20 +207,41 @@ function App() {
           setRefreshError(null);
         }
         if (!cancelled && nextVersion.snapshot !== snapshotVersion) {
+          stablePollCount = 0;
           await loadWorkspace("refresh");
+          schedulePoll(REFRESH_POLL_MIN_MS);
+          return;
         }
+
+        stablePollCount = Math.min(stablePollCount + 1, 3);
+        schedulePoll(currentDelay());
       } catch (pollError) {
+        stablePollCount = 0;
         if (!cancelled) {
           // eslint-disable-next-line no-console
           console.error("Failed to poll app version for refresh", pollError);
           setRefreshError(formatRefreshFailure("check for workspace updates", pollError));
         }
+        schedulePoll(REFRESH_POLL_MIN_MS);
       }
-    }, 2000);
+    };
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        stablePollCount = 0;
+        schedulePoll(REFRESH_POLL_MIN_MS);
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    schedulePoll(REFRESH_POLL_MIN_MS);
 
     return () => {
       cancelled = true;
-      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (timeoutId != null) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, [isRefreshing, loadWorkspace, snapshotVersion]);
 


### PR DESCRIPTION
## Summary
- replace the fixed 2s refresh interval with an adaptive timeout-based poller
- back off when the workspace stays stable and reset to the fast cadence after updates, failures, or tab focus changes
- keep the existing visible-tab refresh behavior for active troubleshooting sessions

## Linked issue or specification
- Closes #465
- Requirement / feature IDs: FEAT-APP-001

## Validation
- [x] `scripts/ci/validate-app.sh --e2e`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed
