### PR TITLE
docs: add a csharp fallback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ missing files.
 
 The repository ships working example projects:
 
+- [`examples/csharp-fallback`](examples/csharp-fallback)
 - [`examples/docs-first`](examples/docs-first)
 - [`examples/go-only`](examples/go-only)
 - [`examples/rust-only`](examples/rust-only)
@@ -628,8 +629,10 @@ The repository ships working example projects:
 - [`examples/polyglot`](examples/polyglot)
 - [`examples/team-scale`](examples/team-scale)
 `rust-only`, `python-only`, `go-only`, and `polyglot` match
-`syu init --template ...` starters directly. `team-scale` remains a
-reference-only example for studying a larger split-by-area repository shape.
+`syu init --template ...` starters directly. `csharp-fallback` remains the
+reference-only example for repositories whose main implementation language is
+still unsupported, and `team-scale` remains a reference-only example for
+studying a larger split-by-area repository shape.
 
 Each one is validated in the automated test suite. If you are deciding between a
 checked-in example and a scaffold template, start with

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -155,9 +155,12 @@ coverage still skips configured repository-relative generated paths such as
 For an experimental strict run, use `syu validate . --require-symbol-trace-coverage`.
 If part of the repository still depends on a language without a built-in
 adapter, keep strict coverage off there and borrow the starter shape from the
+[`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback).
+That example keeps the higher-layer spec and adjacent supported traces explicit
+without pretending unsupported `csharp:` mappings validate today. Use
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
-or `syu init . --template go-only` as a reminder that Go currently supports
-symbol checks and coverage ownership, but not `doc_contains`.
+or `syu init . --template go-only` when you specifically want the built-in Go
+adapter and its symbol checks plus coverage ownership.
 
 ### `app.bind`
 

--- a/docs/guide/examples-and-templates.md
+++ b/docs/guide/examples-and-templates.md
@@ -25,6 +25,7 @@ whether you should scaffold a template or open one of the repository examples.
 
 | Path | Type | Best for | How to start |
 | --- | --- | --- | --- |
+| `csharp-fallback` | Example only | repositories whose main implementation language is still unsupported and need a truthful fallback reference | `examples/csharp-fallback` |
 | `docs-first` | Example only | documentation-heavy repositories that want a small reference for shell, markdown, and wildcard YAML traces | `examples/docs-first` |
 | `generic` | Template only | the shortest neutral scaffold when you do not want language-specific starter copy yet | `syu init .` |
 | `go-only` | Template + example | Go-first repositories that want starter IDs, file names, a minimal `go.mod`, and small Go source/test files from the first scaffold | `syu init . --template go-only` or `examples/go-only` |
@@ -66,10 +67,13 @@ scaffold wholesale.
 2. **I already know the repo is Rust-first / Python-first / Go-first / polyglot**: start
    with the matching template, then compare against the matching example when
    you want a fuller repository story.
-3. **I am Go-first and want to inspect native Go tracing before I scaffold
+3. **My main implementation language is still unsupported**: open
+   `examples/csharp-fallback` first to study the fallback pattern before you
+   invent placeholder `csharp:` traces that will not validate.
+4. **I am Go-first and want to inspect native Go tracing before I scaffold
    anything**: open `examples/go-only` first, then copy the shape you need into
    your own repository.
-4. **I am still deciding whether `syu` fits my repo**: read the example first so
+5. **I am still deciding whether `syu` fits my repo**: read the example first so
    you can inspect a working shape without creating files locally yet.
 
 ## Continue with these pages

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -247,9 +247,12 @@ What you should avoid for unsupported-language files today is adding
 language-specific `tests:` or `implementations:` entries such as `csharp:`.
 Those keys still fail validation before `doc_contains` support even becomes
 relevant. If you need code-level tracing immediately with `doc_contains`, stay
-with Rust, Python, or TypeScript/JavaScript for now. For Go-first repositories,
-use [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
-or `syu init . --template go-only`: both use real Go files plus symbol-level
+with Rust, Python, or TypeScript/JavaScript for now. For unsupported-language
+repositories, use the
+[`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback)
+to study the fallback pattern. For Go-first repositories, use
+[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
+or `syu init . --template go-only`: those use real Go files plus symbol-level
 trace mappings that validate today.
 
 Keep this adoption path in mind for mixed-language repositories too: start with

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -71,8 +71,8 @@ because `symbols: ["*"]` does not point to one inspectable symbol.
 Unsupported adapters such as `csharp` still raise `SYU-trace-language-001`.
 Keep those repositories connected through the spec layers first, and only add
 language-specific code traces once adapter support lands.
-If you need a Go-first starting point today, study the
-[`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
-or scaffold `syu init . --template go-only`. Both keep real Go files in the
-repository while relying on symbol checks and coverage ownership rather than
-`doc_contains`.
+If you need a concrete fallback shape today, study the
+[`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback).
+It keeps real C# files in the repository while validating supported shell and
+markdown evidence around them instead of inventing unsupported `csharp:` trace
+keys.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -298,9 +298,13 @@ removing `doc_contains` is not enough: those entries still raise
 `SYU-trace-language-001`. Keep the higher-layer spec link in place and wait for
 adapter support before adding the code-level trace.
 The
+[`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback)
+shows one concrete unsupported-language starting point that keeps real C#
+source files in the repository while validated traces stay in supported shell
+and markdown files. The
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
-and `syu init . --template go-only` show one concrete Go-first starting point
-with real source files plus symbol-level trace mappings.
+and `syu init . --template go-only` remain the concrete Go-first path with real
+source files plus symbol-level trace mappings.
 
 The [trace adapter capability matrix](./trace-adapter-support.md) shows which
 built-in adapters stop at symbol validation, which ones can inspect docs, and

--- a/examples/csharp-fallback/README.md
+++ b/examples/csharp-fallback/README.md
@@ -1,0 +1,63 @@
+# csharp-fallback example
+
+This example demonstrates the current fallback pattern for a repository whose
+main application language still does not have a built-in `syu` trace adapter.
+
+It keeps a real C# source file and test file in the repository, but it does
+not add unsupported `csharp:` trace mappings yet. Instead, the example keeps
+the higher-layer spec links explicit and validates the surrounding automation in
+supported lightweight adapters.
+
+## Files
+
+| Path | What it defines |
+|------|-----------------|
+| `docs/syu/philosophy/foundation.yaml` | `PHIL-CSHARP-001` — the guiding principle |
+| `docs/syu/policies/policies.yaml` | `POL-CSHARP-001` linked to `PHIL-CSHARP-001` |
+| `docs/syu/requirements/core/csharp.yaml` | `REQ-CSHARP-001` with a markdown-backed acceptance anchor |
+| `docs/syu/features/languages/csharp.yaml` | `FEAT-CSHARP-001` with a shell-backed implementation trace |
+| `scripts/check-workspace.sh` | shell implementation containing `verify_spec_links` |
+| `src/OrderSummary.cs` | real C# source kept visible but intentionally untraced for now |
+| `tests/OrderSummaryTests.cs` | real C# test kept visible but intentionally untraced for now |
+| `README.md` | explains why the C# files are not traced directly yet |
+
+## Try it
+
+```bash
+cd examples/csharp-fallback
+syu validate .
+syu list feature
+syu show REQ-CSHARP-001
+syu app .
+```
+
+A successful `syu validate .` produces output similar to:
+
+```text
+syu validate passed
+workspace: examples/csharp-fallback
+definitions: philosophies=1 policies=1 requirements=1 features=1
+traceability: requirements=1/1 traces validated; features=1/1 traces validated
+```
+
+## CsharpFallbackAcceptanceChecklist
+
+- `REQ-CSHARP-001` expects unsupported-language repositories to keep the spec
+  layers explicit from the first commit.
+- `FEAT-CSHARP-001` traces the supporting shell workflow with the named
+  `verify_spec_links` symbol.
+- The checked-in C# files stay visible to contributors, but this example does
+  **not** add `tests.csharp` or `implementations.csharp` entries yet because
+  those mappings still fail with `SYU-trace-language-001`.
+
+## Key things to notice
+
+- **Real unsupported-language files still belong in the repository** — `syu`
+  can help the team connect intent and workflow before the language adapter
+  exists.
+- **Supported lightweight traces are the bridge** — shell and markdown keep the
+  repository mechanically connected to the spec while code-level C# traces wait
+  for native support.
+- **Go is no longer the workaround** — use `examples/go-only` when you want the
+  built-in Go adapter, and use this example when your main implementation
+  language is still unsupported.

--- a/examples/csharp-fallback/docs/syu/features/features.yaml
+++ b/examples/csharp-fallback/docs/syu/features/features.yaml
@@ -1,0 +1,4 @@
+version: "0.0.1-alpha.7"
+files:
+  - kind: csharp
+    file: languages/csharp.yaml

--- a/examples/csharp-fallback/docs/syu/features/languages/csharp.yaml
+++ b/examples/csharp-fallback/docs/syu/features/languages/csharp.yaml
@@ -1,0 +1,15 @@
+category: C# Fallback Example Features
+version: 1
+
+features:
+  - id: FEAT-CSHARP-001
+    title: Trace the fallback workflow through an explicit shell symbol
+    summary: Demonstrate one concrete implementation trace that keeps the unsupported-language repository connected to the spec.
+    status: implemented
+    linked_requirements:
+      - REQ-CSHARP-001
+    implementations:
+      shell:
+        - file: scripts/check-workspace.sh
+          symbols:
+            - verify_spec_links

--- a/examples/csharp-fallback/docs/syu/philosophy/foundation.yaml
+++ b/examples/csharp-fallback/docs/syu/philosophy/foundation.yaml
@@ -1,0 +1,11 @@
+category: Philosophy
+version: 1
+language: en
+
+philosophies:
+  - id: PHIL-CSHARP-001
+    title: Unsupported-language repositories should still connect intent to reviewable evidence
+    product_design_principle: Keep the unsupported-language example honest about current adapter limits while still showing a low-friction adoption path.
+    coding_guideline: Trace the surrounding docs and automation with supported adapters until native language support lands.
+    linked_policies:
+      - POL-CSHARP-001

--- a/examples/csharp-fallback/docs/syu/policies/policies.yaml
+++ b/examples/csharp-fallback/docs/syu/policies/policies.yaml
@@ -1,0 +1,13 @@
+category: Policies
+version: 1
+language: en
+
+policies:
+  - id: POL-CSHARP-001
+    title: Unsupported-language adoption should keep real code visible without pretending it is traced already
+    summary: Demonstrate the fallback pattern for a C#-backed repository by validating supported shell and markdown evidence first.
+    description: Require the example to ship real C# source and test files while validated trace evidence stays in supported file types until a native adapter exists.
+    linked_philosophies:
+      - PHIL-CSHARP-001
+    linked_requirements:
+      - REQ-CSHARP-001

--- a/examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml
+++ b/examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml
@@ -1,0 +1,18 @@
+category: C# Fallback Example Requirements
+prefix: REQ-CSHARP
+
+requirements:
+  - id: REQ-CSHARP-001
+    title: Unsupported-language repositories should be able to adopt syu without fake code-level traces
+    description: The fallback example should keep real C# files in the repository while validating supported evidence around them.
+    priority: high
+    status: implemented
+    linked_policies:
+      - POL-CSHARP-001
+    linked_features:
+      - FEAT-CSHARP-001
+    tests:
+      markdown:
+        - file: README.md
+          symbols:
+            - CsharpFallbackAcceptanceChecklist

--- a/examples/csharp-fallback/scripts/check-workspace.sh
+++ b/examples/csharp-fallback/scripts/check-workspace.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+verify_spec_links() {
+  printf '%s\n' "verifying spec links before the unsupported-language code grows"
+}
+
+verify_spec_links

--- a/examples/csharp-fallback/src/OrderSummary.cs
+++ b/examples/csharp-fallback/src/OrderSummary.cs
@@ -1,0 +1,9 @@
+namespace Example.CsharpFallback;
+
+public sealed class OrderSummary
+{
+    public string Render(int openOrders)
+    {
+        return $"open orders: {openOrders}";
+    }
+}

--- a/examples/csharp-fallback/syu.yaml
+++ b/examples/csharp-fallback/syu.yaml
@@ -1,0 +1,12 @@
+version: 0.0.1-alpha.7
+spec:
+  root: docs/syu
+validate:
+  default_fix: false
+  allow_planned: true
+  require_symbol_trace_coverage: false
+runtimes:
+  python:
+    command: auto
+  node:
+    command: auto

--- a/examples/csharp-fallback/tests/OrderSummaryTests.cs
+++ b/examples/csharp-fallback/tests/OrderSummaryTests.cs
@@ -1,0 +1,8 @@
+namespace Example.CsharpFallback.Tests;
+
+public sealed class OrderSummaryTests
+{
+    public void Render_mentions_the_open_order_count()
+    {
+    }
+}

--- a/examples/go-only/docs/syu/philosophy/foundation.yaml
+++ b/examples/go-only/docs/syu/philosophy/foundation.yaml
@@ -4,8 +4,8 @@ language: en
 
 philosophies:
   - id: PHIL-GO-001
-    title: Go-first repositories should be able to adopt syu before native Go tracing lands
-    product_design_principle: Keep the Go example small, runnable, and honest about today's tracing limits.
-    coding_guideline: Use supported trace adapters as explicit temporary evidence until direct Go tracing is available.
+    title: Go-first repositories should be able to adopt syu with native Go tracing from the first commit
+    product_design_principle: Keep the Go example small, runnable, and explicit about the built-in adapter guarantees available today.
+    coding_guideline: Trace real Go symbols directly and reserve lighter-weight workaround patterns for languages that still lack native support.
     linked_policies:
       - POL-GO-001

--- a/examples/go-only/docs/syu/policies/policies.yaml
+++ b/examples/go-only/docs/syu/policies/policies.yaml
@@ -4,9 +4,9 @@ language: en
 
 policies:
   - id: POL-GO-001
-    title: Go-first adoption should keep real code visible while using supported trace anchors
-    summary: Demonstrate unsupported-language adoption without pretending that Go is fully inspected yet.
-    description: Require the example to ship real Go source and test files while validated trace evidence stays in a supported file type.
+    title: Go-first adoption should validate real Go source and test symbols directly
+    summary: Demonstrate the built-in Go adapter with real Go implementation and test traces.
+    description: Require the example to ship real Go source and test files and validate them through the native Go adapter instead of a workaround mapping.
     linked_philosophies:
       - PHIL-GO-001
     linked_requirements:

--- a/tests/example_workspaces.rs
+++ b/tests/example_workspaces.rs
@@ -34,6 +34,29 @@ fn docs_first_example_validates() {
 
 #[test]
 // REQ-CORE-012
+fn csharp_fallback_example_validates() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(example_path("csharp-fallback"))
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("definitions: philosophies=1 policies=1 requirements=1 features=1"));
+    assert!(stdout.contains(
+        "traceability: requirements=1/1 traces validated; features=1/1 traces validated"
+    ));
+}
+
+#[test]
+// REQ-CORE-012
 fn rust_only_example_validates() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -698,6 +698,7 @@ fn repository_ships_example_workspaces() {
         read_file("examples/python-only/docs/syu/requirements/core/python.yaml");
     let csharp_fallback_requirement =
         read_file("examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml");
+    let csharp_fallback_config = read_file("examples/csharp-fallback/syu.yaml");
     let csharp_fallback_readme = read_file("examples/csharp-fallback/README.md");
     let docs_first_requirement =
         read_file("examples/docs-first/docs/syu/requirements/core/docs.yaml");
@@ -710,6 +711,7 @@ fn repository_ships_example_workspaces() {
     assert!(rust_example_config.contains(&format!("version: {current_version}")));
     assert!(python_example_requirement.contains("REQ-PY-001"));
     assert!(csharp_fallback_requirement.contains("REQ-CSHARP-001"));
+    assert!(csharp_fallback_config.contains(&format!("version: {current_version}")));
     assert!(csharp_fallback_readme.contains("CsharpFallbackAcceptanceChecklist"));
     assert!(csharp_fallback_readme.contains("SYU-trace-language-001"));
     assert!(docs_first_requirement.contains("REQ-DOCS-001"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -408,6 +408,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu show REQ-001"));
     assert!(!readme.contains("syu show REQ-CORE-015"));
     assert!(readme.contains("syu app"));
+    assert!(readme.contains("examples/csharp-fallback"));
     assert!(readme.contains("examples/go-only"));
     assert!(readme.contains("examples/polyglot"));
     assert!(readme.contains("examples/team-scale"));
@@ -505,6 +506,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("Keep exploring"));
     assert!(getting_started.contains("examples/rust-only"));
     assert!(getting_started.contains("examples/python-only"));
+    assert!(getting_started.contains("examples/csharp-fallback"));
     assert!(getting_started.contains("examples/go-only"));
     assert!(getting_started.contains("examples/polyglot"));
     assert!(
@@ -535,6 +537,7 @@ fn repository_declares_documentation_guides() {
     assert!(trace_adapter_support.contains("| Go | `go`, `golang`, `gotest` / `.go` |"));
     assert!(examples_and_templates.contains("starter templates"));
     assert!(examples_and_templates.contains("checked-in examples"));
+    assert!(examples_and_templates.contains("examples/csharp-fallback"));
     assert!(examples_and_templates.contains("examples/docs-first"));
     assert!(examples_and_templates.contains("`syu init . --template rust-only`"));
     assert!(examples_and_templates.contains("`syu init . --template go-only`"));
@@ -693,6 +696,9 @@ fn repository_ships_example_workspaces() {
     let rust_example_config = read_file("examples/rust-only/syu.yaml");
     let python_example_requirement =
         read_file("examples/python-only/docs/syu/requirements/core/python.yaml");
+    let csharp_fallback_requirement =
+        read_file("examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml");
+    let csharp_fallback_readme = read_file("examples/csharp-fallback/README.md");
     let docs_first_requirement =
         read_file("examples/docs-first/docs/syu/requirements/core/docs.yaml");
     let go_example_requirement = read_file("examples/go-only/docs/syu/requirements/core/go.yaml");
@@ -703,6 +709,9 @@ fn repository_ships_example_workspaces() {
     assert!(rust_example_requirement.contains("REQ-RUST-001"));
     assert!(rust_example_config.contains(&format!("version: {current_version}")));
     assert!(python_example_requirement.contains("REQ-PY-001"));
+    assert!(csharp_fallback_requirement.contains("REQ-CSHARP-001"));
+    assert!(csharp_fallback_readme.contains("CsharpFallbackAcceptanceChecklist"));
+    assert!(csharp_fallback_readme.contains("SYU-trace-language-001"));
     assert!(docs_first_requirement.contains("REQ-DOCS-001"));
     assert!(docs_first_requirement.contains("DocsFirstAcceptanceChecklist"));
     assert!(go_example_requirement.contains("REQ-GO-001"));
@@ -711,6 +720,7 @@ fn repository_ships_example_workspaces() {
     assert!(polyglot_feature.contains("FEAT-MIX-001"));
     assert!(polyglot_feature.contains("status: implemented"));
     assert!(example_tests.contains("docs_first_example_validates"));
+    assert!(example_tests.contains("csharp_fallback_example_validates"));
     assert!(example_tests.contains("rust_only_example_validates"));
     assert!(example_tests.contains("python_only_example_validates"));
     assert!(example_tests.contains("go_only_example_validates"));


### PR DESCRIPTION
## Summary
- add a checked-in csharp-fallback example for unsupported-language adoption
- point unsupported-language docs to the new example and keep go-only focused on native Go support
- extend repository tests so the example stays validated

## Linked issue or specification
- Closing keyword issue: Closes #460
- Requirement / feature IDs:

## Validation
- [x] scripts/ci/quality-gates.sh
- [ ] scripts/ci/coverage.sh summary (required when Rust logic changes)
- [x] cargo run -- validate .
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed