### PR TITLE
feat: add a docs-first init template

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,12 @@ That renders `PHIL-STORE-001`, `POL-STORE-001`, `REQ-STORE-001`, and
 `--feature-prefix`.
 
 Want a closer starting point for a repository that is already clearly
-Rust-first, Python-first, or polyglot? Start with a lightweight template:
+docs-first, Rust-first, Python-first, Go-first, or polyglot? Start with a
+lightweight template:
 
 ```bash
 syu templates
+syu init . --template docs-first
 syu init . --template rust-only
 syu init . --template go-only
 syu init . --template python-only
@@ -308,6 +310,7 @@ Bootstrap a new workspace:
 syu init .
 syu init path/to/workspace --name my-project
 syu init . --id-prefix store
+syu init . --template docs-first
 syu init . --template rust-only
 syu init . --template go-only
 syu init . --spec-root docs/spec
@@ -627,7 +630,7 @@ The repository ships working example projects:
 - [`examples/python-only`](examples/python-only)
 - [`examples/polyglot`](examples/polyglot)
 - [`examples/team-scale`](examples/team-scale)
-`rust-only`, `python-only`, `go-only`, and `polyglot` match
+`docs-first`, `rust-only`, `python-only`, `go-only`, and `polyglot` match
 `syu init --template ...` starters directly. `team-scale` remains a
 reference-only example for studying a larger split-by-area repository shape.
 

--- a/docs/guide/examples-and-templates.md
+++ b/docs/guide/examples-and-templates.md
@@ -25,7 +25,7 @@ whether you should scaffold a template or open one of the repository examples.
 
 | Path | Type | Best for | How to start |
 | --- | --- | --- | --- |
-| `docs-first` | Example only | documentation-heavy repositories that want a small reference for shell, markdown, and wildcard YAML traces | `examples/docs-first` |
+| `docs-first` | Template + example | documentation-heavy repositories that want starter markdown acceptance anchors, one shell trace, and one wildcard-owned YAML file | `syu init . --template docs-first` or `examples/docs-first` |
 | `generic` | Template only | the shortest neutral scaffold when you do not want language-specific starter copy yet | `syu init .` |
 | `go-only` | Template + example | Go-first repositories that want starter IDs, file names, a minimal `go.mod`, and small Go source/test files from the first scaffold | `syu init . --template go-only` or `examples/go-only` |
 | `rust-only` | Template + example | Rust-first repositories that want starter IDs, file names, and copy tuned for Rust work | `syu init . --template rust-only` or `examples/rust-only` |
@@ -63,7 +63,7 @@ scaffold wholesale.
 
 1. **Fastest path into your own repository**: run `syu init .`, then switch to a
    language-specific template only if the generic starter feels too abstract.
-2. **I already know the repo is Rust-first / Python-first / Go-first / polyglot**: start
+2. **I already know the repo is docs-first / Rust-first / Python-first / Go-first / polyglot**: start
    with the matching template, then compare against the matching example when
    you want a fuller repository story.
 3. **I am Go-first and want to inspect native Go tracing before I scaffold

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -149,11 +149,12 @@ Need stable project-specific starter IDs from the first command?
 syu init . --id-prefix store
 ```
 
-Need a closer starting point for a repository that is already Rust-first,
-Python-first, Go-first, or polyglot?
+Need a closer starting point for a repository that is already docs-first,
+Rust-first, Python-first, Go-first, or polyglot?
 
 ```bash
 syu templates
+syu init . --template docs-first
 syu init . --template rust-only
 syu init . --template go-only
 ```
@@ -490,6 +491,9 @@ If one of those examples is already close to your repository, use the matching
 shape. `syu templates` prints the same mapping directly in the CLI, including
 which starter is template-only (`generic`) versus backed by a checked-in
 example.
+Use `syu init . --template docs-first` when your repository is documentation-led:
+it scaffolds the same markdown, shell, and YAML starter shape as the checked-in
+example without forcing a language-specific code scaffold first.
 Use `syu init . --template go-only` when your repository is Go-first today: it
 scaffolds the same minimal spec plus `go.mod`, `go/app.go`, and
 `go/app_test.go`, while the checked-in example shows the same shape in a

--- a/examples/docs-first/README.md
+++ b/examples/docs-first/README.md
@@ -10,6 +10,10 @@ adapter shapes:
 - an explicit shell symbol trace for a single script function
 - wildcard YAML ownership for a file that intentionally belongs to one feature
 
+This workspace now matches the built-in `syu init --template docs-first`
+starter, so you can either inspect the checked-in example first or generate the
+same shape directly in your own repository.
+
 ## Files
 
 | Path | What it defines |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -519,7 +519,7 @@ pub struct InitArgs {
     pub spec_root: Option<PathBuf>,
 
     #[arg(
-        help = "Starter layout to scaffold (generic, rust-only, python-only, go-only, or polyglot)"
+        help = "Starter layout to scaffold (generic, docs-first, rust-only, python-only, go-only, or polyglot)"
     )]
     #[arg(long, value_enum, default_value_t = StarterTemplate::Generic)]
     pub template: StarterTemplate,
@@ -603,6 +603,7 @@ pub struct AddArgs {
 pub enum StarterTemplate {
     #[default]
     Generic,
+    DocsFirst,
     RustOnly,
     PythonOnly,
     GoOnly,
@@ -613,6 +614,7 @@ impl StarterTemplate {
     pub const fn label(self) -> &'static str {
         match self {
             Self::Generic => "generic",
+            Self::DocsFirst => "docs-first",
             Self::RustOnly => "rust-only",
             Self::PythonOnly => "python-only",
             Self::GoOnly => "go-only",
@@ -677,6 +679,7 @@ mod tests {
         assert_eq!(LookupKind::Requirement.label(), "requirement");
         assert_eq!(LookupKind::Feature.label(), "feature");
         assert_eq!(StarterTemplate::Generic.label(), "generic");
+        assert_eq!(StarterTemplate::DocsFirst.label(), "docs-first");
         assert_eq!(StarterTemplate::RustOnly.label(), "rust-only");
         assert_eq!(StarterTemplate::PythonOnly.label(), "python-only");
         assert_eq!(StarterTemplate::GoOnly.label(), "go-only");

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -64,12 +64,18 @@ pub(crate) struct StarterTemplateCatalogEntry {
     pub(crate) related_example: Option<&'static str>,
 }
 
-const STARTER_TEMPLATE_CATALOG: [StarterTemplateCatalogEntry; 5] = [
+const STARTER_TEMPLATE_CATALOG: [StarterTemplateCatalogEntry; 6] = [
     StarterTemplateCatalogEntry {
         template: StarterTemplate::Generic,
         name: "generic",
         description: "Starter with minimal four-layer files, neutral IDs, and core file names.",
         related_example: None,
+    },
+    StarterTemplateCatalogEntry {
+        template: StarterTemplate::DocsFirst,
+        name: "docs-first",
+        description: "Starter for documentation-heavy repos with markdown acceptance anchors, a shell trace, and a wildcard-owned YAML file.",
+        related_example: Some("examples/docs-first"),
     },
     StarterTemplateCatalogEntry {
         template: StarterTemplate::RustOnly,
@@ -299,10 +305,11 @@ fn prompt_for_starter_template(
 fn parse_starter_template_prompt(raw: &str) -> Option<StarterTemplate> {
     match raw.trim().to_ascii_lowercase().as_str() {
         "generic" | "1" => Some(StarterTemplate::Generic),
-        "rust" | "rust-only" | "2" => Some(StarterTemplate::RustOnly),
-        "python" | "python-only" | "3" => Some(StarterTemplate::PythonOnly),
-        "go" | "go-only" | "4" => Some(StarterTemplate::GoOnly),
-        "polyglot" | "mixed" | "5" => Some(StarterTemplate::Polyglot),
+        "docs" | "docs-first" | "2" => Some(StarterTemplate::DocsFirst),
+        "rust" | "rust-only" | "3" => Some(StarterTemplate::RustOnly),
+        "python" | "python-only" | "4" => Some(StarterTemplate::PythonOnly),
+        "go" | "go-only" | "5" => Some(StarterTemplate::GoOnly),
+        "polyglot" | "mixed" | "6" => Some(StarterTemplate::Polyglot),
         _ => None,
     }
 }
@@ -464,6 +471,12 @@ fn default_id_prefixes(template: StarterTemplate) -> StarterIdPrefixes {
             requirement: "REQ".to_string(),
             feature: "FEAT".to_string(),
         },
+        StarterTemplate::DocsFirst => StarterIdPrefixes {
+            philosophy: "PHIL-DOCS".to_string(),
+            policy: "POL-DOCS".to_string(),
+            requirement: "REQ-DOCS".to_string(),
+            feature: "FEAT-DOCS".to_string(),
+        },
         StarterTemplate::RustOnly => StarterIdPrefixes {
             philosophy: "PHIL-RUST".to_string(),
             policy: "POL-RUST".to_string(),
@@ -573,6 +586,23 @@ fn scaffold_files(
 
 fn starter_source_files(project_name: &str, template: StarterTemplate) -> Vec<(String, String)> {
     match template {
+        StarterTemplate::DocsFirst => vec![
+            (
+                "README.md".to_string(),
+                "# docs-first starter\n\nUse this starter when documentation, shell automation, and checked-in\nconfiguration are the first repository artifacts you want to keep traceable.\n\n## DocsFirstAcceptanceChecklist\n\n- `REQ-DOCS-001` expects the release-note publishing flow to stay explicit.\n- `FEAT-DOCS-001` traces directly to the shell symbol `publish_release_notes`.\n- This mapping is valid without `doc_contains` because shell only supports\n  pattern-based symbol existence today.\n\n## DocsFirstNavigationChecklist\n\n- `REQ-DOCS-002` expects one checked-in navigation file to stay easy to inspect.\n- `FEAT-DOCS-002` owns `config/navigation.yaml` with `symbols: [\"*\"]`.\n- Use wildcard ownership carefully: it works best when one file intentionally\n  belongs to one feature instead of collecting unrelated concerns.\n"
+                    .to_string(),
+            ),
+            (
+                "scripts/publish-docs.sh".to_string(),
+                "#!/usr/bin/env bash\n\npublish_release_notes() {\n  printf '%s\\n' \"publishing release notes\"\n}\n\npublish_release_notes\n"
+                    .to_string(),
+            ),
+            (
+                "config/navigation.yaml".to_string(),
+                "sections:\n  - id: intro\n    title: Introduction\n  - id: release-notes\n    title: Release notes\n  - id: troubleshooting\n    title: Troubleshooting\n"
+                    .to_string(),
+            ),
+        ],
         StarterTemplate::GoOnly => vec![
             ("go.mod".to_string(), render_go_module_file(project_name)),
             (
@@ -646,6 +676,9 @@ fn philosophy_template(
         StarterTemplate::Generic => format!(
             "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should turn intent into executable agreements\n    product_design_principle: |\n      The project should keep philosophy, policy, requirements, and features\n      explicit enough that contributors can validate changes mechanically.\n    coding_guideline: |\n      Prefer stable IDs, typed data, and explicit traceability over conventions\n      that live only in contributor memory.\n    linked_policies:\n      - {policy_id}\n"
         ),
+        StarterTemplate::DocsFirst => format!(
+            "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should keep documentation-first work traceable from the files people read first\n    product_design_principle: |\n      The project should keep documentation, scripts, and checked-in\n      configuration explicit enough that contributors can validate intent\n      without a large code scaffold first.\n    coding_guideline: |\n      Prefer explicit file or symbol ownership over vague repository-level\n      documentation promises.\n    linked_policies:\n      - {policy_id}\n"
+        ),
         StarterTemplate::RustOnly => format!(
             "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: {philosophy_id}\n    title: {project_name} should keep Rust traces explicit\n    product_design_principle: |\n      The project should keep Rust-first traceability small, reviewable, and\n      obvious to contributors reading the code.\n    coding_guideline: |\n      Prefer stable IDs and Rust doc comments on traced symbols from the first\n      requirement onward.\n    linked_policies:\n      - {policy_id}\n"
         ),
@@ -669,9 +702,13 @@ fn policy_template(
     let philosophy_id = id_prefixes.philosophy_id();
     let policy_id = id_prefixes.policy_id();
     let requirement_id = id_prefixes.requirement_id();
+    let requirement_id_two = format!("{}-002", id_prefixes.requirement);
     match template {
         StarterTemplate::Generic => format!(
             "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Every change in {project_name} should remain traceable\n    summary: Define rules that turn philosophy into a verifiable workflow.\n    description: |\n      A specification entry is only useful when contributors can trace it to\n      concrete requirements, features, code, and tests inside the repository.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
+        ),
+        StarterTemplate::DocsFirst => format!(
+            "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Documentation-first traces must stay explicit in {project_name}\n    summary: Use markdown, shell, and YAML traces for explicit ownership without pretending they provide rich code inspection.\n    description: |\n      The starter workspace should demonstrate named shell symbols where\n      possible and wildcard YAML ownership only for files that intentionally\n      belong to one feature.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n      - {requirement_id_two}\n"
         ),
         StarterTemplate::RustOnly => format!(
             "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: {policy_id}\n    title: Rust requirement and feature traces must stay documented in {project_name}\n    summary: Start with a Rust-first workflow that stays explicit in code review.\n    description: |\n      Rust requirement and feature traces should point to symbols whose doc\n      comments carry both the stable ID and a short explanation.\n    linked_philosophies:\n      - {philosophy_id}\n    linked_requirements:\n      - {requirement_id}\n"
@@ -694,11 +731,17 @@ fn requirement_template(
     id_prefixes: &StarterIdPrefixes,
 ) -> String {
     let requirement_id = id_prefixes.requirement_id();
+    let requirement_id_two = format!("{}-002", id_prefixes.requirement);
     let policy_id = id_prefixes.policy_id();
     let feature_id = id_prefixes.feature_id();
+    let feature_id_two = format!("{}-002", id_prefixes.feature);
     match template {
         StarterTemplate::Generic => format!(
             "category: Core Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Bootstrap {project_name} with a four-layer specification\n    description: |\n      The project should keep philosophy, policy, requirements, and features in\n      YAML so contributors can evolve behavior deliberately.\n    priority: high\n    status: planned\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests: {{}}\n",
+            id_prefixes.requirement
+        ),
+        StarterTemplate::DocsFirst => format!(
+            "category: Docs-first Requirements\nprefix: {}\n\nrequirements:\n  - id: {requirement_id}\n    title: Release-note publishing should stay traceable through a supported shell mapping\n    description: The starter should show that shell-backed workflows can use explicit symbol ownership without doc inspection.\n    priority: high\n    status: implemented\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id}\n    tests:\n      markdown:\n        - file: README.md\n          symbols:\n            - DocsFirstAcceptanceChecklist\n  - id: {requirement_id_two}\n    title: Whole-file config ownership should stay explicit when one YAML file belongs to one feature\n    description: The starter should show when wildcard ownership is appropriate for a dedicated configuration file.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - {policy_id}\n    linked_features:\n      - {feature_id_two}\n    tests:\n      markdown:\n        - file: README.md\n          symbols:\n            - DocsFirstNavigationChecklist\n",
             id_prefixes.requirement
         ),
         StarterTemplate::RustOnly => format!(
@@ -739,9 +782,14 @@ fn feature_template(
 ) -> String {
     let feature_id = id_prefixes.feature_id();
     let requirement_id = id_prefixes.requirement_id();
+    let feature_id_two = format!("{}-002", id_prefixes.feature);
+    let requirement_id_two = format!("{}-002", id_prefixes.requirement);
     match template {
         StarterTemplate::Generic => format!(
             "category: Core Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} spec workspace\n    summary: Provide a starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
+        ),
+        StarterTemplate::DocsFirst => format!(
+            "category: Docs-first Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Trace the release-note publishing script with an explicit shell symbol\n    summary: Demonstrate a named shell function trace for documentation-heavy repositories.\n    status: implemented\n    linked_requirements:\n      - {requirement_id}\n    implementations:\n      shell:\n        - file: scripts/publish-docs.sh\n          symbols:\n            - publish_release_notes\n  - id: {feature_id_two}\n    title: Trace one dedicated navigation file with wildcard YAML ownership\n    summary: Demonstrate that wildcard ownership is acceptable when one YAML file intentionally belongs to one feature.\n    status: implemented\n    linked_requirements:\n      - {requirement_id_two}\n    implementations:\n      yaml:\n        - file: config/navigation.yaml\n          symbols:\n            - \"*\"\n"
         ),
         StarterTemplate::RustOnly => format!(
             "category: Rust Features\nversion: 1\n\nfeatures:\n  - id: {feature_id}\n    title: Bootstrap the {project_name} Rust spec workspace\n    summary: Provide a Rust-oriented starter structure that contributors can extend.\n    status: planned\n    linked_requirements:\n      - {requirement_id}\n    implementations: {{}}\n"
@@ -761,6 +809,7 @@ fn feature_template(
 fn requirement_document_path(template: StarterTemplate) -> &'static str {
     match template {
         StarterTemplate::Generic => "requirements/core/core.yaml",
+        StarterTemplate::DocsFirst => "requirements/core/docs.yaml",
         StarterTemplate::RustOnly => "requirements/core/rust.yaml",
         StarterTemplate::PythonOnly => "requirements/core/python.yaml",
         StarterTemplate::GoOnly => "requirements/core/go.yaml",
@@ -771,6 +820,7 @@ fn requirement_document_path(template: StarterTemplate) -> &'static str {
 fn feature_document_path(template: StarterTemplate) -> &'static str {
     match template {
         StarterTemplate::Generic => "features/core/core.yaml",
+        StarterTemplate::DocsFirst => "features/documentation/docs.yaml",
         StarterTemplate::RustOnly => "features/languages/rust.yaml",
         StarterTemplate::PythonOnly => "features/languages/python.yaml",
         StarterTemplate::GoOnly => "features/languages/go.yaml",
@@ -781,6 +831,7 @@ fn feature_document_path(template: StarterTemplate) -> &'static str {
 fn feature_kind(template: StarterTemplate) -> &'static str {
     match template {
         StarterTemplate::Generic => "core",
+        StarterTemplate::DocsFirst => "documentation",
         StarterTemplate::RustOnly => "rust",
         StarterTemplate::PythonOnly => "python",
         StarterTemplate::GoOnly => "go",
@@ -1171,7 +1222,7 @@ mod tests {
     fn prompt_for_starter_template_retries_invalid_values() {
         let mut prompt_io = FakePromptIo {
             terminal: true,
-            lines: VecDeque::from(["unknown".to_string(), "5".to_string()]),
+            lines: VecDeque::from(["unknown".to_string(), "6".to_string()]),
             ..Default::default()
         };
 
@@ -1184,6 +1235,10 @@ mod tests {
 
     #[test]
     fn parse_starter_template_prompt_accepts_remaining_aliases() {
+        assert_eq!(
+            parse_starter_template_prompt("docs"),
+            Some(StarterTemplate::DocsFirst)
+        );
         assert_eq!(
             parse_starter_template_prompt("python"),
             Some(StarterTemplate::PythonOnly)
@@ -1484,6 +1539,7 @@ mod tests {
     fn scaffold_files_support_language_oriented_templates() {
         let spec_root = std::path::Path::new(DEFAULT_SPEC_ROOT);
         for template in [
+            StarterTemplate::DocsFirst,
             StarterTemplate::RustOnly,
             StarterTemplate::PythonOnly,
             StarterTemplate::Polyglot,
@@ -1509,6 +1565,10 @@ mod tests {
                 .find(|(path, _)| path == "docs/syu/features/features.yaml")
                 .expect("feature registry should exist");
             assert!(registry.1.contains(feature_kind(template)));
+            if template == StarterTemplate::DocsFirst {
+                assert!(paths.contains(&"scripts/publish-docs.sh"));
+                assert!(paths.contains(&"config/navigation.yaml"));
+            }
         }
     }
 

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -6,6 +6,8 @@
 // FEAT-INIT-002
 
 use anyhow::{Result, bail};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
     path::{Component, Path, PathBuf},
@@ -156,7 +158,7 @@ fn run_init_command_with_prompt_io(args: &InitArgs, prompt_io: &mut impl PromptI
             .parent()
             .expect("generated scaffold paths should always have a parent");
         fs::create_dir_all(parent)?;
-        fs::write(full_path, contents)?;
+        write_scaffold_file(&full_path, contents)?;
     }
 
     let created_paths: Vec<&str> = files.iter().map(|(path, _)| path.as_str()).collect();
@@ -216,6 +218,34 @@ fn run_init_command_with_prompt_io(args: &InitArgs, prompt_io: &mut impl PromptI
     }
 
     Ok(0)
+}
+
+fn write_scaffold_file(full_path: &Path, contents: &str) -> Result<()> {
+    fs::write(full_path, contents)?;
+    maybe_mark_scaffold_file_executable(full_path, contents)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn maybe_mark_scaffold_file_executable(full_path: &Path, contents: &str) -> Result<()> {
+    if is_executable_shell_scaffold(full_path, contents) {
+        let mut permissions = fs::metadata(full_path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(full_path, permissions)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn maybe_mark_scaffold_file_executable(_full_path: &Path, _contents: &str) -> Result<()> {
+    Ok(())
+}
+
+fn is_executable_shell_scaffold(full_path: &Path, contents: &str) -> bool {
+    matches!(
+        full_path.extension().and_then(|ext| ext.to_str()),
+        Some("sh")
+    ) && contents.starts_with("#!")
 }
 
 fn resolve_init_options_with_prompt_io(

--- a/src/command/templates.rs
+++ b/src/command/templates.rs
@@ -96,12 +96,13 @@ mod tests {
     #[test]
     fn starter_template_catalog_lists_every_supported_template() {
         let templates = template_catalog_entries();
-        assert_eq!(templates.len(), 5);
+        assert_eq!(templates.len(), 6);
         assert_eq!(templates[0].name, "generic");
-        assert_eq!(templates[1].name, "rust-only");
-        assert_eq!(templates[2].name, "python-only");
-        assert_eq!(templates[3].name, "go-only");
-        assert_eq!(templates[4].name, "polyglot");
+        assert_eq!(templates[1].name, "docs-first");
+        assert_eq!(templates[2].name, "rust-only");
+        assert_eq!(templates[3].name, "python-only");
+        assert_eq!(templates[4].name, "go-only");
+        assert_eq!(templates[5].name, "polyglot");
     }
 
     #[test]
@@ -110,9 +111,10 @@ mod tests {
         assert_eq!(templates[0].relationship_label(), "starter-only");
         assert_eq!(templates[1].relationship_label(), "template-and-example");
         assert_eq!(templates[0].related_example, None);
-        assert_eq!(templates[1].related_example, Some("examples/rust-only"));
-        assert_eq!(templates[2].related_example, Some("examples/python-only"));
-        assert_eq!(templates[3].related_example, Some("examples/go-only"));
-        assert_eq!(templates[4].related_example, Some("examples/polyglot"));
+        assert_eq!(templates[1].related_example, Some("examples/docs-first"));
+        assert_eq!(templates[2].related_example, Some("examples/rust-only"));
+        assert_eq!(templates[3].related_example, Some("examples/python-only"));
+        assert_eq!(templates[4].related_example, Some("examples/go-only"));
+        assert_eq!(templates[5].related_example, Some("examples/polyglot"));
     }
 }

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -202,6 +202,7 @@ fn init_help_lists_starter_templates() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("syu templates"));
     assert!(stdout.contains("--template"));
+    assert!(stdout.contains("docs-first"));
     assert!(stdout.contains("rust-only"));
     assert!(stdout.contains("python-only"));
     assert!(stdout.contains("go-only"));

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -1,5 +1,7 @@
 use assert_cmd::cargo::CommandCargoExt;
 use serde_yaml::Value;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{fs, process::Command};
 use tempfile::tempdir;
 
@@ -173,6 +175,18 @@ fn init_command_bootstraps_language_templates_that_validate_accept() {
             assert!(requirement.contains("DocsFirstAcceptanceChecklist"));
             assert!(feature.contains("status: implemented"));
             assert!(feature.contains("publish_release_notes"));
+            #[cfg(unix)]
+            {
+                let mode = fs::metadata(workspace.join("scripts/publish-docs.sh"))
+                    .expect("script metadata should exist")
+                    .permissions()
+                    .mode();
+                assert_ne!(
+                    mode & 0o111,
+                    0,
+                    "docs-first starter script should be executable"
+                );
+            }
         } else if template == "go-only" {
             assert!(workspace.join("go.mod").exists(), "missing go.mod");
             assert!(workspace.join("go/app.go").exists(), "missing go/app.go");

--- a/tests/init_command.rs
+++ b/tests/init_command.rs
@@ -95,6 +95,13 @@ fn init_command_interactive_requires_a_terminal() {
 fn init_command_bootstraps_language_templates_that_validate_accept() {
     for (template, requirement_path, feature_path, requirement_id, feature_id) in [
         (
+            "docs-first",
+            "docs/syu/requirements/core/docs.yaml",
+            "docs/syu/features/documentation/docs.yaml",
+            "REQ-DOCS-001",
+            "FEAT-DOCS-001",
+        ),
+        (
             "rust-only",
             "docs/syu/requirements/core/rust.yaml",
             "docs/syu/features/languages/rust.yaml",
@@ -159,7 +166,14 @@ fn init_command_bootstraps_language_templates_that_validate_accept() {
             "missing {requirement_id}"
         );
         assert!(feature.contains(feature_id), "missing {feature_id}");
-        if template == "go-only" {
+        if template == "docs-first" {
+            assert!(workspace.join("scripts/publish-docs.sh").exists());
+            assert!(workspace.join("config/navigation.yaml").exists());
+            assert!(requirement.contains("status: implemented"));
+            assert!(requirement.contains("DocsFirstAcceptanceChecklist"));
+            assert!(feature.contains("status: implemented"));
+            assert!(feature.contains("publish_release_notes"));
+        } else if template == "go-only" {
             assert!(workspace.join("go.mod").exists(), "missing go.mod");
             assert!(workspace.join("go/app.go").exists(), "missing go/app.go");
             assert!(

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -394,6 +394,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu init ."));
     assert!(readme.contains("syu add"));
     assert!(readme.contains("--id-prefix"));
+    assert!(readme.contains("--template docs-first"));
     assert!(readme.contains("--template rust-only"));
     assert!(readme.contains("--template go-only"));
     assert!(readme.contains("syu templates"));
@@ -476,6 +477,7 @@ fn repository_declares_documentation_guides() {
     assert!(!getting_started.contains("$asset.sha256"));
     assert!(getting_started.contains("current checked-in release"));
     assert!(getting_started.contains("latest published alpha"));
+    assert!(getting_started.contains("--template docs-first"));
     assert!(getting_started.contains("--template rust-only"));
     assert!(getting_started.contains("--template go-only"));
     assert!(getting_started.contains("syu templates"));
@@ -536,6 +538,7 @@ fn repository_declares_documentation_guides() {
     assert!(examples_and_templates.contains("starter templates"));
     assert!(examples_and_templates.contains("checked-in examples"));
     assert!(examples_and_templates.contains("examples/docs-first"));
+    assert!(examples_and_templates.contains("`syu init . --template docs-first`"));
     assert!(examples_and_templates.contains("`syu init . --template rust-only`"));
     assert!(examples_and_templates.contains("`syu init . --template go-only`"));
     assert!(examples_and_templates.contains("examples/go-only"));
@@ -695,6 +698,7 @@ fn repository_ships_example_workspaces() {
         read_file("examples/python-only/docs/syu/requirements/core/python.yaml");
     let docs_first_requirement =
         read_file("examples/docs-first/docs/syu/requirements/core/docs.yaml");
+    let docs_first_readme = read_file("examples/docs-first/README.md");
     let go_example_requirement = read_file("examples/go-only/docs/syu/requirements/core/go.yaml");
     let go_example_readme = read_file("examples/go-only/README.md");
     let polyglot_feature = read_file("examples/polyglot/docs/syu/features/languages/polyglot.yaml");
@@ -705,6 +709,7 @@ fn repository_ships_example_workspaces() {
     assert!(python_example_requirement.contains("REQ-PY-001"));
     assert!(docs_first_requirement.contains("REQ-DOCS-001"));
     assert!(docs_first_requirement.contains("DocsFirstAcceptanceChecklist"));
+    assert!(docs_first_readme.contains("syu init --template docs-first"));
     assert!(go_example_requirement.contains("REQ-GO-001"));
     assert!(go_example_readme.contains("TestGoRequirement"));
     assert!(go_example_readme.contains("GoFeatureImpl"));

--- a/tests/templates_command.rs
+++ b/tests/templates_command.rs
@@ -24,6 +24,9 @@ fn templates_command_lists_all_supported_templates_in_text_output() {
         "generic\tstarter-only\t-\tStarter with minimal four-layer files, neutral IDs, and core file names."
     ));
     assert!(stdout.contains(
+        "docs-first\ttemplate-and-example\texamples/docs-first\tStarter for documentation-heavy repos with markdown acceptance anchors, a shell trace, and a wildcard-owned YAML file."
+    ));
+    assert!(stdout.contains(
         "rust-only\ttemplate-and-example\texamples/rust-only\tStarter for Rust-first repos"
     ));
     assert!(stdout.contains(
@@ -59,12 +62,14 @@ fn templates_command_supports_json_output() {
     let templates = json["templates"]
         .as_array()
         .expect("templates should be an array");
-    assert_eq!(templates.len(), 5);
+    assert_eq!(templates.len(), 6);
     assert_eq!(templates[0]["name"], "generic");
     assert_eq!(templates[0]["relationship"], "starter-only");
-    assert_eq!(templates[1]["name"], "rust-only");
-    assert_eq!(templates[1]["related_example"], "examples/rust-only");
-    assert_eq!(templates[3]["name"], "go-only");
-    assert_eq!(templates[3]["related_example"], "examples/go-only");
-    assert_eq!(templates[4]["name"], "polyglot");
+    assert_eq!(templates[1]["name"], "docs-first");
+    assert_eq!(templates[1]["related_example"], "examples/docs-first");
+    assert_eq!(templates[2]["name"], "rust-only");
+    assert_eq!(templates[2]["related_example"], "examples/rust-only");
+    assert_eq!(templates[4]["name"], "go-only");
+    assert_eq!(templates[4]["related_example"], "examples/go-only");
+    assert_eq!(templates[5]["name"], "polyglot");
 }


### PR DESCRIPTION
## Summary
- add a built-in docs-first starter template that scaffolds the same markdown, shell, and YAML shape as the checked-in example
- surface docs-first anywhere starter-template choices are documented in the CLI and guides
- extend init/template/repository tests so the docs-first starter stays aligned with the example

## Linked issue or specification
- Closing keyword issue: Closes #447
- Requirement / feature IDs:

## Validation
- [x] scripts/ci/quality-gates.sh
- [ ] scripts/ci/coverage.sh summary (required when Rust logic changes)
- [x] cargo run -- validate .
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [x] This change should appear in the next release notes
- [ ] No release note needed