### PR TITLE
fix: make docs-site validation installs repeatable

### DIFF
--- a/scripts/ci/validate-website.sh
+++ b/scripts/ci/validate-website.sh
@@ -10,7 +10,7 @@ validate_website() {
   cd "$repo_root"
 
   bash scripts/ci/quality-gates.sh
-  npm --prefix website ci
+  bash scripts/ci/install-docs-site-deps.sh
   npm --prefix website run build
 }
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -22,6 +22,7 @@ fn repository_declares_precommit_and_quality_gates() {
     let quality_script = read_file("scripts/ci/quality-gates.sh");
     let validate_app_script = read_file("scripts/ci/validate-app.sh");
     let validate_website_script = read_file("scripts/ci/validate-website.sh");
+    let install_docs_site_deps_script = read_file("scripts/ci/install-docs-site-deps.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
     let contributing = read_file("CONTRIBUTING.md");
     let repo_config = read_file("syu.yaml");
@@ -49,6 +50,10 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(validate_website_script.contains("scripts/ci/quality-gates.sh"));
     assert!(validate_website_script.contains("install-docs-site-deps.sh"));
     assert!(validate_website_script.contains("npm --prefix website run build"));
+    assert!(install_docs_site_deps_script.contains("Branch switches can leave behind"));
+    assert!(install_docs_site_deps_script.contains("website/node_modules"));
+    assert!(install_docs_site_deps_script.contains("shutil.rmtree"));
+    assert!(install_docs_site_deps_script.contains("npm --prefix website ci"));
     assert!(install_precommit.contains("site --user-base"));
     assert!(install_precommit.contains("pipx environment --value PIPX_BIN_DIR"));
     assert!(install_precommit.contains("Troubleshooting: compare"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -47,7 +47,7 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(validate_website_script.contains("FEAT-QUALITY-001"));
     assert!(validate_website_script.contains("validate_website"));
     assert!(validate_website_script.contains("scripts/ci/quality-gates.sh"));
-    assert!(validate_website_script.contains("npm --prefix website ci"));
+    assert!(validate_website_script.contains("install-docs-site-deps.sh"));
     assert!(validate_website_script.contains("npm --prefix website run build"));
     assert!(install_precommit.contains("site --user-base"));
     assert!(install_precommit.contains("pipx environment --value PIPX_BIN_DIR"));


### PR DESCRIPTION
## Summary
- route validate-website.sh through the cleanup-aware docs-site dependency installer
- keep the repository quality assertion aligned with the new validation path
- validate the docs-site wrapper twice in the same worktree to confirm repeated runs stay deterministic

Closes #439