### PR TITLE
fix: stop auto-installing browser app deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
         with:
           components: rustfmt,clippy
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/cache-cargo-install-action@v3
         with:
@@ -65,6 +78,19 @@ jobs:
         with:
           components: rustfmt,clippy
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
+
       - name: Run quality gates
         run: scripts/ci/quality-gates.sh
 
@@ -76,6 +102,19 @@ jobs:
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/cache-cargo-install-action@v3
@@ -255,6 +294,19 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
+
       - name: Set up Python with pip cache
         uses: actions/setup-python@v6
         with:
@@ -331,6 +383,12 @@ jobs:
           node-version: "25"
           cache: npm
           cache-dependency-path: app/package-lock.json
+
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
 
       - name: Install stable toolchain for wasm-pack bootstrap
         uses: dtolnay/rust-toolchain@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,11 @@ match your change:
    npm --prefix app ci
    ```
 
+   Normal Cargo-driven builds no longer run that install step for you. If the
+   embedded browser app dependencies are missing or stale, `build.rs` stops and
+   points back to the commands above so Rust-only or docs-only work does not
+   silently mutate your `app/node_modules` tree.
+
    Then run the same freshness flow CI uses:
 
    ```bash

--- a/build.rs
+++ b/build.rs
@@ -212,12 +212,9 @@ fn ensure_app_dependencies(app_dir: &Path, required_npm: &str) -> Result<(), Str
         return Ok(());
     }
 
-    run_npm(
-        app_dir,
-        required_npm,
-        &[String::from("ci")],
-        "install browser app dependencies with `npm ci`",
-    )
+    Err(format!(
+        "browser app dependencies are not ready; run `scripts/ci/pinned-npm.sh install app && npm --prefix app ci` from the repository root with npm {required_npm} before running Cargo commands that embed the browser app"
+    ))
 }
 
 fn remove_dir_if_exists(path: &Path, description: &str) -> Result<(), String> {

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -954,12 +954,14 @@ fn repository_ships_browser_app() {
         )
     );
     assert!(build_script.contains("syu-app-dist"));
-    assert!(build_script.contains("npm ci"));
+    assert!(build_script.contains("scripts/ci/pinned-npm.sh install app"));
+    assert!(build_script.contains("browser app dependencies are not ready"));
     assert!(build_script.contains("build:wasm"));
     assert!(build_script.contains("--outDir"));
     assert!(build_script.contains("shared_core_dir"));
     assert!(build_script.contains("scripts"));
     assert!(build_script.contains("remove_dir_if_exists"));
+    assert!(!build_script.contains("install browser app dependencies with `npm ci`"));
     assert!(app_package.contains("\"packageManager\": \"npm@11.8.0\""));
     assert!(app_package.contains("\"vite-plus\""));
     assert!(app_package.contains("\"@playwright/test\""));


### PR DESCRIPTION
## Summary
- stop build.rs from running npm ci automatically when app dependencies are missing or stale
- surface explicit setup commands that point contributors to pinned npm installation from the repo root
- lock the behavior in repository quality coverage and document it in CONTRIBUTING

## Validation
- cargo fmt --all --check
- cargo test --test repository_quality repository_ships_browser_app -- --exact
- cargo run -- validate .
