### PR TITLE
docs: add a task-based command chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,21 @@ keeping error-bearing runs on exit code 1.
 For a plain-English guide to common validation errors, see the
 [troubleshooting guide](docs/guide/troubleshooting.md).
 
+### Command chooser
+
+Use this quick chooser when you know the task but not yet the subcommand:
+
+| If you want to... | Start with... | Why |
+| --- | --- | --- |
+| inspect the whole workspace interactively in a terminal | `syu browse .` | shows the layered graph plus current validation errors in one terminal-first view |
+| render one layer or emit automation-friendly lists | `syu list ...` | keeps the output list-shaped instead of opening the browser-style explorer |
+| open one specific philosophy, policy, requirement, or feature by ID | `syu show ID` | jumps straight to the matched definition |
+| look up IDs or keywords when you do not know the exact item yet | `syu search QUERY` | searches IDs, titles, summaries, and descriptions across layers |
+| start from code or a test file and walk back to the owning spec item | `syu trace path/to/file --symbol name` | begins from traced implementation or test evidence instead of from YAML |
+| inspect everything connected to one ID, symbol, or file | `syu relate TARGET` | expands upstream/downstream links plus traced files and symbols for review |
+| review what changed for one spec item in Git history | `syu log ID` | projects the traced definition and implementation paths onto checked-in commits |
+| prefer a browser-first view for demos or visual navigation | `syu app .` | serves the same workspace graph in the local browser UI |
+
 ### `syu browse`
 
 Browse philosophies, policies, features, requirements, and current validation

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Use this quick chooser when you know the task but not yet the subcommand:
 
 | If you want to... | Start with... | Why |
 | --- | --- | --- |
+| check whether your workspace currently validates | `syu validate .` | runs the full repository checks and points you to concrete errors before deeper browsing |
 | inspect the whole workspace interactively in a terminal | `syu browse .` | shows the layered graph plus current validation errors in one terminal-first view |
 | render one layer or emit automation-friendly lists | `syu list ...` | keeps the output list-shaped instead of opening the browser-style explorer |
 | open one specific philosophy, policy, requirement, or feature by ID | `syu show ID` | jumps straight to the matched definition |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -424,6 +424,7 @@ If you only remember the task and not the command name yet, use this chooser:
 
 | If you want to... | Start with... | Why |
 | --- | --- | --- |
+| check whether the workspace is healthy before deeper exploration | `syu validate .` | runs the validation pass first so you can fix structural problems before navigating the graph |
 | inspect the whole workspace interactively in a terminal | `syu browse .` | best first stop when you want the layered graph and current validation state together |
 | render one layer or emit machine-friendly lists | `syu list ...` | keeps the output list-shaped and scriptable |
 | open one exact definition by ID | `syu show ID` | jumps directly to the matched philosophy, policy, requirement, or feature |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -420,6 +420,19 @@ layer or emitted as JSON for automation. Use `syu browse --non-interactive`
 when you want the browse snapshot instead: workspace metadata, per-layer
 counts, and the current validation errors in plain text.
 
+If you only remember the task and not the command name yet, use this chooser:
+
+| If you want to... | Start with... | Why |
+| --- | --- | --- |
+| inspect the whole workspace interactively in a terminal | `syu browse .` | best first stop when you want the layered graph and current validation state together |
+| render one layer or emit machine-friendly lists | `syu list ...` | keeps the output list-shaped and scriptable |
+| open one exact definition by ID | `syu show ID` | jumps directly to the matched philosophy, policy, requirement, or feature |
+| search when you only know a keyword or partial ID | `syu search QUERY` | searches titles, summaries, descriptions, and IDs across the spec |
+| start from a traced file or symbol during review | `syu trace path --symbol name` | works code-first instead of spec-first |
+| inspect everything connected to one ID, file, or symbol | `syu relate TARGET` | expands nearby links, traced files, and symbols to show the surrounding context |
+| review change history for one requirement or feature | `syu log ID` | follows the checked-in definition plus traced evidence through Git history |
+| switch to a browser-first workflow | `syu app .` | shows the same workspace graph in the local browser UI |
+
 Use JSON when integrating with automation:
 
 ```bash

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -496,7 +496,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("If you only remember the task and not the command name yet"));
     assert!(
-        getting_started.contains("check whether the workspace is healthy before deeper exploration")
+        getting_started
+            .contains("check whether the workspace is healthy before deeper exploration")
     );
     assert!(getting_started.contains("syu validate ."));
     assert!(getting_started.contains("emitted as JSON for automation"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -407,6 +407,8 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu validate"));
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
+    assert!(readme.contains("### Command chooser"));
+    assert!(readme.contains("review what changed for one spec item in Git history"));
     assert!(readme.contains("list-shaped output"));
     assert!(readme.contains("workspace metadata, per-layer"));
     assert!(readme.contains("current validation errors in plain text"));
@@ -490,9 +492,11 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("--id-prefix"));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
+    assert!(getting_started.contains("If you only remember the task and not the command name yet"));
     assert!(getting_started.contains("emitted as JSON for automation"));
     assert!(getting_started.contains("workspace metadata, per-layer"));
     assert!(getting_started.contains("current validation errors in plain text"));
+    assert!(getting_started.contains("review change history for one requirement or feature"));
     assert!(getting_started.contains("syu list feature"));
     assert!(getting_started.contains("syu show REQ-001"));
     assert!(getting_started.contains("syu app ."));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -495,7 +495,9 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("If you only remember the task and not the command name yet"));
-    assert!(getting_started.contains("check whether the workspace is healthy before deeper exploration"));
+    assert!(
+        getting_started.contains("check whether the workspace is healthy before deeper exploration")
+    );
     assert!(getting_started.contains("syu validate ."));
     assert!(getting_started.contains("emitted as JSON for automation"));
     assert!(getting_started.contains("workspace metadata, per-layer"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -408,6 +408,8 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
     assert!(readme.contains("### Command chooser"));
+    assert!(readme.contains("check whether your workspace currently validates"));
+    assert!(readme.contains("syu validate ."));
     assert!(readme.contains("review what changed for one spec item in Git history"));
     assert!(readme.contains("list-shaped output"));
     assert!(readme.contains("workspace metadata, per-layer"));
@@ -493,6 +495,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("If you only remember the task and not the command name yet"));
+    assert!(getting_started.contains("check whether the workspace is healthy before deeper exploration"));
+    assert!(getting_started.contains("syu validate ."));
     assert!(getting_started.contains("emitted as JSON for automation"));
     assert!(getting_started.contains("workspace metadata, per-layer"));
     assert!(getting_started.contains("current validation errors in plain text"));


### PR DESCRIPTION
## Summary
- add a task-based chooser to the README command reference
- mirror that chooser in the getting-started guide for newcomers who remember tasks before command names
- lock the new chooser wording into repository-quality docs assertions

## Testing
- bash scripts/ci/pinned-npm.sh install app
- npm --prefix app ci
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- npm --prefix website ci
- npm --prefix website run build

Closes #487