### PR TITLE
docs: add a reviewer workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Pick the newcomer path that matches what you need next:
 - **Visual explorer**: start with [`docs/guide/app.md`](docs/guide/app.md) or run
   `syu app .` when you want graphical spec navigation before learning the full
   text-first CLI flow.
+- **Reviewer workflow**: open
+  [`docs/guide/reviewer-workflow.md`](docs/guide/reviewer-workflow.md) when a
+  PR already exists and you want one concrete loop for moving between spec IDs,
+  traced code, and recent Git history.
 - **Trace adapter matrix**: open
   [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
   when you already have a workspace and need a capability reference for which
@@ -67,6 +71,7 @@ Keep the detailed guides close:
 - [`docs/guide/tutorial.md`](docs/guide/tutorial.md)
 - [`docs/guide/migration.md`](docs/guide/migration.md)
 - [`docs/guide/app.md`](docs/guide/app.md)
+- [`docs/guide/reviewer-workflow.md`](docs/guide/reviewer-workflow.md)
 - [`docs/guide/trace-adapter-support.md`](docs/guide/trace-adapter-support.md)
 - [`docs/guide/configuration.md`](docs/guide/configuration.md)
 - [`docs/guide/spec-antipatterns.md`](docs/guide/spec-antipatterns.md)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -512,6 +512,7 @@ example-backed, or both, see the
 - Follow the [end-to-end tutorial](./tutorial.md) to build a complete four-layer spec from scratch
 - Read [syu concepts](./concepts.md) for the reasoning behind the four layers
 - Review [configuration](./configuration.md) before tightening validation in a real repository
+- Use the [reviewer workflow guide](./reviewer-workflow.md) when a PR already exists and you want one trace/relate/log loop to inspect it
 - Check the [trace adapter capability matrix](./trace-adapter-support.md) before depending on `doc_contains` or strict ownership coverage in a mixed-language codebase
 - Read the [syu app browser guide](./app.md) to learn how to navigate the browser UI
 - Check the [troubleshooting guide](./troubleshooting.md) when `syu validate` returns an unfamiliar error code

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -1,0 +1,143 @@
+# Reviewer workflow: trace, relate, and log together
+
+<!-- FEAT-DOCS-001 -->
+
+Use this guide when a pull request already exists and you want one concrete
+review loop that connects specification intent, traced code, and recent Git
+history.
+
+`syu`'s reviewer flow works best when you keep three questions in order:
+
+1. **What is this change supposed to satisfy?**
+2. **Which files and symbols currently claim that work?**
+3. **What changed recently in those traced paths?**
+
+The commands below answer those questions with `show`/`relate`, `trace`, and
+`log`.
+
+## Example review target
+
+This repository already ships a good self-hosted example in the validation
+command feature:
+
+- feature: `FEAT-CHECK-001`
+- implementation file: `src/command/check.rs`
+- implementation symbol: `run_check_command`
+
+You can follow the same flow in any repository by swapping in your own spec ID,
+file path, and symbol name.
+
+## 1. Start from the spec item under review
+
+Open the feature or requirement that the PR says it changed:
+
+```bash
+syu show FEAT-CHECK-001
+```
+
+Use `syu show` first when the PR description already names the exact ID. This
+gives you the title, summary, linked requirements, and declared traces before
+you jump into code.
+
+If the PR only gives you a keyword, search first:
+
+```bash
+syu search validation --kind feature
+```
+
+## 2. Expand the surrounding context
+
+Once you know the ID, inspect the nearby graph:
+
+```bash
+syu relate FEAT-CHECK-001
+```
+
+`syu relate` is the quickest reviewer command for answering questions like:
+
+- which requirement does this feature satisfy?
+- which policy or philosophy is above it?
+- which files and symbols are traced today?
+- are there obvious graph gaps such as missing reciprocal links?
+
+Use this output to decide whether the PR still matches the connected policy and
+requirement context, or whether it is changing the behavior in a way that
+should have updated adjacent YAML too.
+
+## 3. Jump from code back to the owning spec
+
+When review starts in a file diff instead of a spec ID, reverse the direction:
+
+```bash
+syu trace src/command/check.rs --symbol run_check_command
+```
+
+Use `syu trace` when you are already staring at code and need to answer:
+
+- which feature owns this symbol?
+- which requirement owns the related tests?
+- does this file participate in multiple traced spec items?
+
+That makes it easier to spot a common review smell: code changed in a traced
+symbol, but the linked requirement or feature in the PR body is incomplete.
+
+## 4. Pull the recent history for the same spec surface
+
+After you know the owning ID and traced files, inspect their recent Git history:
+
+```bash
+syu log FEAT-CHECK-001 --kind implementation --path src/command
+```
+
+Use `syu log` when review needs historical context:
+
+- has this area changed repeatedly in the same way?
+- did a recent commit rename the traced file or symbol?
+- is the PR fixing a regression in a path that already has relevant history?
+
+For requirement-oriented review, swap to definition or test history instead:
+
+```bash
+syu log REQ-CORE-017 --kind definition
+syu log REQ-CORE-017 --kind test
+```
+
+## 5. Close the loop with a focused validation pass
+
+If the PR changes spec files, traced paths, or link structure, run a narrower
+validation pass before the full repository check:
+
+```bash
+syu validate . --genre trace
+syu validate . --id FEAT-CHECK-001
+```
+
+Use `--genre trace` when you want trace-specific failures first. Use `--id`
+when the review is anchored on one concrete requirement or feature and you want
+the smallest relevant validation slice before expanding outward.
+
+## Fast reviewer playbook
+
+Use this sequence as the default review loop:
+
+```bash
+syu show FEAT-CHECK-001
+syu relate FEAT-CHECK-001
+syu trace src/command/check.rs --symbol run_check_command
+syu log FEAT-CHECK-001 --kind implementation --path src/command
+syu validate . --id FEAT-CHECK-001
+```
+
+That sequence keeps the review grounded in checked-in YAML, then confirms the
+claimed code evidence, then pulls the recent history that helps you judge
+whether the current change still fits the surrounding intent.
+
+## When to choose a different entry point
+
+- Start with [getting started](./getting-started.md) when you are still learning
+  the command names themselves.
+- Start with the [browser app guide](./app.md) when review is easier in a visual
+  graph than in terminal output.
+- Start with [troubleshooting](./troubleshooting.md) when validation is already
+  failing and you need rule-by-rule repair guidance more than review workflow
+  advice.

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -95,6 +95,12 @@ Use `syu log` when review needs historical context:
 - did a recent commit rename the traced file or symbol?
 - is the PR fixing a regression in a path that already has relevant history?
 
+Treat `syu log` as history for the **currently traced** surface, not proof that
+the whole PR diff is covered. A newly added implementation or test file can be
+missing from this history slice if the trace mapping was never updated, so pair
+an empty or too-small log result with the PR diff and `syu trace`/`syu relate`
+before concluding that review coverage is complete.
+
 For requirement-oriented review, swap to definition or test history instead:
 
 ```bash

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -11,6 +11,9 @@ Want a different entry point?
 - Use [existing repository adoption](./existing-repository.md) when the
   repository already has code and history and you want an incremental rollout
   instead of a from-scratch scaffold.
+- Use [reviewer workflow](./reviewer-workflow.md) when the repository already
+  has an open PR and you want to inspect the linked spec, traced code, and Git
+  history instead of creating new definitions.
 - Stay on this tutorial when you want the full repository story and the edits
   behind each command.
 - Jump to [troubleshooting](./troubleshooting.md) if you are already blocked on

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -374,6 +374,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("docs/guide/tutorial.md"));
     assert!(readme.contains("docs/guide/migration.md"));
     assert!(readme.contains("docs/guide/app.md"));
+    assert!(readme.contains("docs/guide/reviewer-workflow.md"));
     assert!(readme.contains("docs/guide/troubleshooting.md"));
     assert!(readme.contains("docs/guide/spec-antipatterns.md"));
     assert!(readme.contains("docs/guide/vscode-extension.md"));
@@ -382,6 +383,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("**Getting started**"));
     assert!(readme.contains("**Migration / upgrade**"));
     assert!(readme.contains("**Visual explorer**"));
+    assert!(readme.contains("**Reviewer workflow**"));
     assert!(readme.contains("new to `syu`"));
     assert!(readme.contains("already have a workspace"));
     assert!(readme.contains("10-15 minutes"));
@@ -511,6 +513,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("https://ugoite.github.io/syu/docs/generated/syu-report"));
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
+    assert!(getting_started.contains("[reviewer workflow guide](./reviewer-workflow.md)"));
     assert!(getting_started.contains("examples/rust-only"));
     assert!(getting_started.contains("examples/python-only"));
     assert!(getting_started.contains("examples/csharp-fallback"));
@@ -534,6 +537,7 @@ fn repository_declares_documentation_guides() {
     let tutorial = read_file("docs/guide/tutorial.md");
     assert!(tutorial.contains("Want a different entry point?"));
     assert!(tutorial.contains("[getting started](./getting-started.md)"));
+    assert!(tutorial.contains("[reviewer workflow](./reviewer-workflow.md)"));
     assert!(tutorial.contains("[troubleshooting](./troubleshooting.md)"));
     assert!(tutorial.contains("starter registry entry"));
     assert!(tutorial.contains("Only add another `files` entry"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -541,6 +541,10 @@ fn repository_declares_documentation_guides() {
     assert!(tutorial.contains("[troubleshooting](./troubleshooting.md)"));
     assert!(tutorial.contains("starter registry entry"));
     assert!(tutorial.contains("Only add another `files` entry"));
+    let reviewer_workflow = read_file("docs/guide/reviewer-workflow.md");
+    assert!(reviewer_workflow.contains("currently traced"));
+    assert!(reviewer_workflow.contains("the whole PR diff is covered"));
+    assert!(reviewer_workflow.contains("too-small log result with the PR diff"));
     assert!(trace_adapter_support.contains("# Trace adapter capability matrix"));
     assert!(trace_adapter_support.contains("validate.require_symbol_trace_coverage"));
     assert!(trace_adapter_support.contains("TypeScript / JavaScript"));


### PR DESCRIPTION
## Summary
- add a reviewer-focused guide that shows how to use show/relate/trace/log together during PR review
- link that guide from the README newcomer chooser, the tutorial entry-point chooser, and getting-started keep-exploring links
- lock the new reviewer workflow references into repository-quality documentation checks

## Testing
- bash scripts/ci/pinned-npm.sh install app
- npm --prefix app ci
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- npm --prefix website ci
- npm --prefix website run build

Closes #492