### PR TITLE
ci: prepare release artifact builds (FEAT-RELEASE-001)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -83,6 +83,12 @@ jobs:
           cache: npm
           cache-dependency-path: app/package-lock.json
 
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -100,7 +106,7 @@ jobs:
         if: matrix.cross_compile == true
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
 
       - name: Build release binary (cross-compile aarch64 linux)
         if: matrix.cross_compile == true

--- a/scripts/ci/release-track-notes.sh
+++ b/scripts/ci/release-track-notes.sh
@@ -25,17 +25,12 @@ previous_track_tag() {
   local repository="$1"
   local current_tag="$2"
   local track="$3"
-  local releases_json
-
-  releases_json="$(gh api "repos/${repository}/releases?per_page=100")"
-
-  RELEASES_JSON="$releases_json" python3 - "$current_tag" "$track" <<'PY'
+  gh api "repos/${repository}/releases?per_page=100" | python3 -c '
 import json
-import os
 import sys
 
 current_tag, desired_track = sys.argv[1:3]
-releases = json.loads(os.environ["RELEASES_JSON"])
+releases = json.load(sys.stdin)
 
 def track_for(tag: str) -> str:
     if "-alpha." in tag:
@@ -54,7 +49,7 @@ for release in releases:
         continue
     print(tag)
     break
-PY
+' "$current_tag" "$track"
 }
 
 generate_release_notes() {
@@ -78,14 +73,7 @@ generate_release_notes() {
       -f target_commitish="main")"
   fi
 
-  RELEASE_NOTES_PAYLOAD="$payload" python3 - <<'PY'
-import json
-import os
-import sys
-
-payload = json.loads(os.environ["RELEASE_NOTES_PAYLOAD"])
-print(payload["body"])
-PY
+  printf '%s' "$payload" | python3 -c 'import json, sys; print(json.load(sys.stdin)["body"])'
 }
 
 main() {

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -217,6 +217,8 @@ fn repository_declares_release_automation() {
     assert!(release_artifacts.contains("install-syu.sh"));
     assert!(release_artifacts.contains("release-notes:"));
     assert!(release_artifacts.contains("release-track-notes.sh"));
+    assert!(release_artifacts.contains("scripts/ci/pinned-npm.sh install app"));
+    assert!(release_artifacts.contains("npm --prefix app ci"));
     assert!(release_artifacts.contains("attestations: write"));
     assert!(release_artifacts.contains("id-token: write"));
     assert!(release_artifacts.contains("actions/attest-build-provenance@v4"));
@@ -863,6 +865,7 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(ci_workflow.contains("tool: cargo-llvm-cov"));
     assert!(ci_workflow.contains("tool: cargo-audit"));
     assert!(ci_workflow.contains("tool: wasm-pack"));
+    assert!(release_artifacts.contains("libc6-dev-arm64-cross"));
     assert!(ci_workflow.contains("merge_group:"));
     assert!(ci_workflow.contains("check-msrv:"));
     assert!(ci_workflow.contains("Set up Python with pip cache"));


### PR DESCRIPTION
## Linked issue or specification
- FEAT-RELEASE-001

## Summary
- install browser app dependencies before release builds in release-artifacts
- install libc6-dev-arm64-cross for the aarch64 linux cross-build
- lock these expectations in repository-quality tests

## Validation
- cargo test --quiet repository_declares_release_automation
- cargo test --quiet repository_declares_dependency_hygiene_and_ci_caching
- cargo test --quiet repository_keeps_node_majors_aligned_across_docs_packages_and_ci