### PR TITLE
fix: skip ownership checks for ignored generated paths

### DIFF
--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -107,6 +107,10 @@ description: "Generated reference for docs/syu/config/validate.yaml"
       file to have an adjacent `&lt;file&gt;.syu-ownership.yaml` manifest with
       matching owner IDs and symbols. Autofix updates the sidecar manifest
       instead of inserting IDs into source when `sidecar` is enabled.
+      Repository-relative generated paths listed in
+      `validate.symbol_trace_coverage_ignored_paths` stay opted out of the
+      extra `SYU-trace-id-001` ownership requirement in `inline` and `sidecar`
+      mode so generated outputs do not need inline IDs or sidecar manifests.
 - **key**: validate.symbol_trace_coverage_ignored_paths
   - **type**: array&lt;path&gt;
   - **default**:
@@ -127,9 +131,13 @@ description: "Generated reference for docs/syu/config/validate.yaml"
       checks. The defaults skip common build outputs such as `app/dist`,
       repository-root `build/`, `coverage/`, `dist/`, and `target/`, plus the
       checked-in `tests/fixtures/workspaces/` sample repositories, without
-      hiding authored nested paths like `src/build/`. Set this list to `[]`
-      when you intentionally want generated artifacts to count toward strict
-      trace coverage too.
+      hiding authored nested paths like `src/build/`. The same list also opts
+      those generated paths out of the extra inline or sidecar ownership
+      breadcrumb enforced by `validate.trace_ownership_mode`, so generated
+      artifacts do not fail `SYU-trace-id-001` just because they lack checked-in
+      IDs or adjacent ownership manifests. Set this list to `[]` when you
+      intentionally want generated artifacts to count toward strict trace
+      coverage and ownership enforcement too.
 
 ## Source YAML
 
@@ -216,6 +224,10 @@ items:
       file to have an adjacent `<file>.syu-ownership.yaml` manifest with
       matching owner IDs and symbols. Autofix updates the sidecar manifest
       instead of inserting IDs into source when `sidecar` is enabled.
+      Repository-relative generated paths listed in
+      `validate.symbol_trace_coverage_ignored_paths` stay opted out of the
+      extra `SYU-trace-id-001` ownership requirement in `inline` and `sidecar`
+      mode so generated outputs do not need inline IDs or sidecar manifests.
   - key: validate.symbol_trace_coverage_ignored_paths
     type: array<path>
     default:
@@ -235,7 +247,11 @@ items:
       checks. The defaults skip common build outputs such as `app/dist`,
       repository-root `build/`, `coverage/`, `dist/`, and `target/`, plus the
       checked-in `tests/fixtures/workspaces/` sample repositories, without
-      hiding authored nested paths like `src/build/`. Set this list to `[]`
-      when you intentionally want generated artifacts to count toward strict
-      trace coverage too.
+      hiding authored nested paths like `src/build/`. The same list also opts
+      those generated paths out of the extra inline or sidecar ownership
+      breadcrumb enforced by `validate.trace_ownership_mode`, so generated
+      artifacts do not fail `SYU-trace-id-001` just because they lack checked-in
+      IDs or adjacent ownership manifests. Set this list to `[]` when you
+      intentionally want generated artifacts to count toward strict trace
+      coverage and ownership enforcement too.
 ```

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -162,6 +162,40 @@ without pretending unsupported `csharp:` mappings validate today. Use
 or `syu init . --template go-only` when you specifically want the built-in Go
 adapter and its symbol checks plus coverage ownership.
 
+### `validate.trace_ownership_mode`
+
+Controls whether traced files need an extra ownership breadcrumb beyond the
+checked-in requirement or feature trace mapping.
+
+- `mapping`: the YAML trace entries are enough on their own
+- `inline`: traced files must also mention their owning requirement or feature ID
+- `sidecar`: traced files must carry ownership in adjacent `<file>.syu-ownership.yaml` manifests
+
+Keep `mapping` when you want the lightest workflow. Use `inline` or `sidecar`
+when repositories want a second ownership signal close to the code as well.
+Generated paths listed in `validate.symbol_trace_coverage_ignored_paths` stay
+opted out of the extra `SYU-trace-id-001` ownership check in `inline` and
+`sidecar` mode so build outputs do not need checked-in IDs or sidecar manifests.
+Declared traces in those files are still validated for file readability and
+symbol existence.
+
+### `validate.symbol_trace_coverage_ignored_paths`
+
+Controls which repository-relative generated directories `syu` skips while
+building the strict symbol-coverage inventory.
+
+By default this list excludes common build outputs such as `build/`,
+`coverage/`, `dist/`, `target/`, `app/dist`, and the checked-in
+`tests/fixtures/workspaces/` repositories without hiding authored nested paths
+like `src/build/`.
+
+This same list also opts those generated paths out of the extra ownership
+breadcrumb enforced by `validate.trace_ownership_mode: inline` or `sidecar`.
+That keeps generated assets from failing `SYU-trace-id-001` just because they
+do not carry inline IDs or adjacent ownership manifests. Set the list to `[]`
+when you intentionally want generated outputs to participate in both strict
+coverage inventory and ownership enforcement.
+
 ### `app.bind`
 
 Controls the default address that `syu app` binds to.

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -80,6 +80,10 @@ items:
       file to have an adjacent `<file>.syu-ownership.yaml` manifest with
       matching owner IDs and symbols. Autofix updates the sidecar manifest
       instead of inserting IDs into source when `sidecar` is enabled.
+      Repository-relative generated paths listed in
+      `validate.symbol_trace_coverage_ignored_paths` stay opted out of the
+      extra `SYU-trace-id-001` ownership requirement in `inline` and `sidecar`
+      mode so generated outputs do not need inline IDs or sidecar manifests.
   - key: validate.symbol_trace_coverage_ignored_paths
     type: array<path>
     default:
@@ -99,6 +103,10 @@ items:
       checks. The defaults skip common build outputs such as `app/dist`,
       repository-root `build/`, `coverage/`, `dist/`, and `target/`, plus the
       checked-in `tests/fixtures/workspaces/` sample repositories, without
-      hiding authored nested paths like `src/build/`. Set this list to `[]`
-      when you intentionally want generated artifacts to count toward strict
-      trace coverage too.
+      hiding authored nested paths like `src/build/`. The same list also opts
+      those generated paths out of the extra inline or sidecar ownership
+      breadcrumb enforced by `validate.trace_ownership_mode`, so generated
+      artifacts do not fail `SYU-trace-id-001` just because they lack checked-in
+      IDs or adjacent ownership manifests. Set this list to `[]` when you
+      intentionally want generated artifacts to count toward strict trace
+      coverage and ownership enforcement too.

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -15,7 +15,10 @@ use crate::{
     cli::{CheckArgs, OutputFormat, ValidationGenreFilter, ValidationSeverityFilter},
     command::shell_quote_path,
     config::{SyuConfig, TraceOwnershipMode},
-    coverage::{normalize_relative_path, validate_symbol_trace_coverage},
+    coverage::{
+        normalize_relative_path, normalized_symbol_trace_coverage_ignored_paths,
+        path_matches_ignored_generated_directory, validate_symbol_trace_coverage,
+    },
     inspect::{apply_symbol_doc_fix, inspect_symbol, supports_rich_inspection},
     language::adapter_for_language,
     model::{
@@ -2374,74 +2377,77 @@ fn verify_trace_reference(
         }
     };
 
-    match evaluate_trace_ownership(root, config, owner_id, &path, reference, &contents) {
-        OwnershipDeclaration::Satisfied => {}
-        OwnershipDeclaration::Missing { manifest_path } => {
-            let (message, suggestion) = match manifest_path {
-                Some(manifest_path) => {
-                    let manifest_display = manifest_path
-                        .strip_prefix(root)
-                        .unwrap_or(manifest_path.as_path());
-                    (
+    let ignored_paths = normalized_symbol_trace_coverage_ignored_paths(config);
+    if !path_matches_ignored_generated_directory(display_path, &ignored_paths) {
+        match evaluate_trace_ownership(root, config, owner_id, &path, reference, &contents) {
+            OwnershipDeclaration::Satisfied => {}
+            OwnershipDeclaration::Missing { manifest_path } => {
+                let (message, suggestion) = match manifest_path {
+                    Some(manifest_path) => {
+                        let manifest_display = manifest_path
+                            .strip_prefix(root)
+                            .unwrap_or(manifest_path.as_path());
+                        (
+                            format!(
+                                "Declared {} file `{}` does not declare ownership for `{owner_id}` in sidecar manifest `{}`.",
+                                role.label(),
+                                display_path.display(),
+                                manifest_display.display()
+                            ),
+                            format!(
+                                "Add `{owner_id}` with {} to `{}` so the {} remains explicitly traceable.",
+                                ownership_symbols_hint(reference),
+                                manifest_display.display(),
+                                role.label()
+                            ),
+                        )
+                    }
+                    None => (
                         format!(
-                            "Declared {} file `{}` does not declare ownership for `{owner_id}` in sidecar manifest `{}`.",
+                            "Declared {} file `{}` does not mention `{owner_id}`.",
                             role.label(),
-                            display_path.display(),
-                            manifest_display.display()
+                            display_path.display()
                         ),
                         format!(
-                            "Add `{owner_id}` with {} to `{}` so the {} remains explicitly traceable.",
-                            ownership_symbols_hint(reference),
-                            manifest_display.display(),
+                            "Add `{owner_id}` to `{}` so the {} remains explicitly traceable.",
+                            display_path.display(),
                             role.label()
                         ),
-                    )
-                }
-                None => (
+                    ),
+                };
+                issues.push(Issue::error(
+                    "SYU-trace-id-001",
+                    subject.clone(),
+                    Some(format_reference_location(language, reference)),
+                    message,
+                    Some(suggestion),
+                ));
+                success = false;
+            }
+            OwnershipDeclaration::Invalid {
+                manifest_path,
+                reason,
+            } => {
+                let manifest_display = manifest_path
+                    .strip_prefix(root)
+                    .unwrap_or(manifest_path.as_path());
+                issues.push(Issue::error(
+                    "SYU-trace-id-001",
+                    subject.clone(),
+                    Some(format_reference_location(language, reference)),
                     format!(
-                        "Declared {} file `{}` does not mention `{owner_id}`.",
+                        "Sidecar ownership manifest `{}` for declared {} file `{}` is invalid: {reason}",
+                        manifest_display.display(),
                         role.label(),
                         display_path.display()
                     ),
-                    format!(
-                        "Add `{owner_id}` to `{}` so the {} remains explicitly traceable.",
-                        display_path.display(),
-                        role.label()
-                    ),
-                ),
-            };
-            issues.push(Issue::error(
-                "SYU-trace-id-001",
-                subject.clone(),
-                Some(format_reference_location(language, reference)),
-                message,
-                Some(suggestion),
-            ));
-            success = false;
-        }
-        OwnershipDeclaration::Invalid {
-            manifest_path,
-            reason,
-        } => {
-            let manifest_display = manifest_path
-                .strip_prefix(root)
-                .unwrap_or(manifest_path.as_path());
-            issues.push(Issue::error(
-                "SYU-trace-id-001",
-                subject.clone(),
-                Some(format_reference_location(language, reference)),
-                format!(
-                    "Sidecar ownership manifest `{}` for declared {} file `{}` is invalid: {reason}",
-                    manifest_display.display(),
-                    role.label(),
-                    display_path.display()
-                ),
-                Some(format!(
-                    "Fix `{}` or switch `validate.trace_ownership_mode` to `mapping` or `inline`.",
-                    manifest_display.display()
-                )),
-            ));
-            success = false;
+                    Some(format!(
+                        "Fix `{}` or switch `validate.trace_ownership_mode` to `mapping` or `inline`.",
+                        manifest_display.display()
+                    )),
+                ));
+                success = false;
+            }
         }
     }
     if reference.symbols.is_empty() {
@@ -4112,6 +4118,77 @@ mod tests {
     }
 
     #[test]
+    fn verify_trace_reference_skips_inline_ownership_for_ignored_generated_paths() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let path = tempdir.path().join("app/dist/assets/generated.js");
+        fs::create_dir_all(path.parent().expect("generated dir")).expect("generated dir");
+        fs::write(
+            &path,
+            "export function generatedBundle() { return true; }\n",
+        )
+        .expect("generated file should exist");
+
+        let reference = TraceReference {
+            file: PathBuf::from("app/dist/assets/generated.js"),
+            symbols: vec!["generatedBundle".to_string()],
+            doc_contains: Vec::new(),
+        };
+        let mut config = SyuConfig::default();
+        config.validate.trace_ownership_mode = TraceOwnershipMode::Inline;
+        let mut issues = Vec::new();
+
+        assert!(verify_trace_reference(
+            tempdir.path(),
+            &config,
+            "FEAT-1",
+            TraceRole::FeatureImplementation,
+            "typescript",
+            &reference,
+            &mut issues,
+        ));
+        assert!(
+            issues.iter().all(|issue| issue.code != "SYU-trace-id-001"),
+            "issues: {issues:#?}"
+        );
+    }
+
+    #[test]
+    fn verify_trace_reference_can_opt_generated_paths_back_into_inline_ownership() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let path = tempdir.path().join("app/dist/assets/generated.js");
+        fs::create_dir_all(path.parent().expect("generated dir")).expect("generated dir");
+        fs::write(
+            &path,
+            "export function generatedBundle() { return true; }\n",
+        )
+        .expect("generated file should exist");
+
+        let reference = TraceReference {
+            file: PathBuf::from("app/dist/assets/generated.js"),
+            symbols: vec!["generatedBundle".to_string()],
+            doc_contains: Vec::new(),
+        };
+        let mut config = SyuConfig::default();
+        config.validate.trace_ownership_mode = TraceOwnershipMode::Inline;
+        config.validate.symbol_trace_coverage_ignored_paths.clear();
+        let mut issues = Vec::new();
+
+        assert!(!verify_trace_reference(
+            tempdir.path(),
+            &config,
+            "FEAT-1",
+            TraceRole::FeatureImplementation,
+            "typescript",
+            &reference,
+            &mut issues,
+        ));
+        assert!(
+            issues.iter().any(|issue| issue.code == "SYU-trace-id-001"),
+            "issues: {issues:#?}"
+        );
+    }
+
+    #[test]
     fn verify_trace_reference_reports_missing_symbol() {
         let tempdir = tempdir().expect("tempdir should exist");
         let path = tempdir.path().join("trace.rs");
@@ -4273,6 +4350,40 @@ mod tests {
             &mut issues,
         ));
         assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn verify_trace_reference_skips_sidecar_ownership_for_ignored_generated_paths() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let path = tempdir.path().join("app/dist/assets/generated.js");
+        fs::create_dir_all(path.parent().expect("generated dir")).expect("generated dir");
+        fs::write(
+            &path,
+            "export function generatedBundle() { return true; }\n",
+        )
+        .expect("generated file should exist");
+
+        let mut config = SyuConfig::default();
+        config.validate.trace_ownership_mode = TraceOwnershipMode::Sidecar;
+        let mut issues = Vec::new();
+
+        assert!(verify_trace_reference(
+            tempdir.path(),
+            &config,
+            "FEAT-1",
+            TraceRole::FeatureImplementation,
+            "typescript",
+            &TraceReference {
+                file: PathBuf::from("app/dist/assets/generated.js"),
+                symbols: vec!["generatedBundle".to_string()],
+                doc_contains: Vec::new(),
+            },
+            &mut issues,
+        ));
+        assert!(
+            issues.iter().all(|issue| issue.code != "SYU-trace-id-001"),
+            "issues: {issues:#?}"
+        );
     }
 
     #[test]

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -207,7 +207,9 @@ impl CoverageMap {
     }
 }
 
-fn normalized_symbol_trace_coverage_ignored_paths(config: &SyuConfig) -> BTreeSet<PathBuf> {
+pub(crate) fn normalized_symbol_trace_coverage_ignored_paths(
+    config: &SyuConfig,
+) -> BTreeSet<PathBuf> {
     config
         .validate
         .symbol_trace_coverage_ignored_paths
@@ -217,6 +219,16 @@ fn normalized_symbol_trace_coverage_ignored_paths(config: &SyuConfig) -> BTreeSe
             (!normalized.as_os_str().is_empty()).then_some(normalized)
         })
         .collect()
+}
+
+pub(crate) fn path_matches_ignored_generated_directory(
+    path: &Path,
+    ignored_paths: &BTreeSet<PathBuf>,
+) -> bool {
+    let normalized = normalize_relative_path(path);
+    ignored_paths
+        .iter()
+        .any(|ignored| normalized == *ignored || normalized.starts_with(ignored))
 }
 
 fn discover_rust_targets(
@@ -1097,8 +1109,7 @@ fn should_skip_generated_directory(
 ) -> bool {
     path.strip_prefix(workspace_root)
         .ok()
-        .map(normalize_relative_path)
-        .is_some_and(|relative| ignored_paths.contains(&relative))
+        .is_some_and(|relative| path_matches_ignored_generated_directory(relative, ignored_paths))
 }
 
 pub(crate) fn normalize_relative_path(path: &Path) -> PathBuf {
@@ -1173,9 +1184,9 @@ mod tests {
         collect_java_test_symbols, collect_requirement_coverage, discover_go_targets,
         discover_java_targets, discover_python_targets, discover_rust_targets,
         discover_typescript_targets, go_files_under, java_files_under, normalize_relative_path,
-        normalized_symbol_trace_coverage_ignored_paths, python_files_under, rust_files_under,
-        typescript_files_under, validate_symbol_trace_coverage,
-        validate_symbol_trace_coverage_with,
+        normalized_symbol_trace_coverage_ignored_paths, path_matches_ignored_generated_directory,
+        python_files_under, rust_files_under, typescript_files_under,
+        validate_symbol_trace_coverage, validate_symbol_trace_coverage_with,
     };
     use crate::{
         config::SyuConfig,
@@ -1660,6 +1671,32 @@ mod tests {
             normalize_relative_path(Path::new("../spec/trace.rs")),
             PathBuf::from("../spec/trace.rs")
         );
+    }
+
+    #[test]
+    fn ignored_generated_paths_match_nested_entries_without_hiding_authored_nested_dirs() {
+        let ignored_paths = BTreeSet::from([
+            PathBuf::from("app/dist"),
+            PathBuf::from("build"),
+            PathBuf::from("target"),
+        ]);
+
+        assert!(path_matches_ignored_generated_directory(
+            Path::new("app/dist/assets/index.js"),
+            &ignored_paths
+        ));
+        assert!(path_matches_ignored_generated_directory(
+            Path::new("target/debug/syu"),
+            &ignored_paths
+        ));
+        assert!(!path_matches_ignored_generated_directory(
+            Path::new("src/build/authored.rs"),
+            &ignored_paths
+        ));
+        assert!(!path_matches_ignored_generated_directory(
+            Path::new("app/src/distinct.ts"),
+            &ignored_paths
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue or specification
- Closes #278

## Summary
- skip inline and sidecar ownership enforcement for paths already excluded from generated-path coverage
- keep the ignore list configurable so repositories can opt generated paths back in
- add regression tests for ignored and opt-in ownership behavior

## Validation
- scripts/ci/quality-gates.sh
- cargo run -- validate .
- scripts/ci/coverage.sh summary