### PR TITLE
test: cover every example syu.yaml freshness

### DIFF
--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, fs, path::PathBuf};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use serde_json::Value;
 
@@ -12,6 +16,26 @@ fn read_file(path: &str) -> String {
 
 fn read_json(path: &str) -> Value {
     serde_json::from_str(&read_file(path)).expect("repository JSON should parse")
+}
+
+fn collect_named_files(root: &Path, file_name: &str, output: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(root).expect("directory should be readable") {
+        let entry = entry.expect("directory entry should exist");
+        let path = entry.path();
+
+        if path.is_dir() {
+            collect_named_files(&path, file_name, output);
+        } else if path.file_name().and_then(|name| name.to_str()) == Some(file_name) {
+            output.push(path);
+        }
+    }
+}
+
+fn checked_in_example_configs() -> Vec<PathBuf> {
+    let mut configs = Vec::new();
+    collect_named_files(&repo_root().join("examples"), "syu.yaml", &mut configs);
+    configs.sort();
+    configs
 }
 
 #[test]
@@ -720,48 +744,48 @@ fn repository_declares_devcontainer_configuration() {
 // REQ-CORE-012
 fn repository_ships_example_workspaces() {
     let current_version = env!("CARGO_PKG_VERSION");
+    let example_configs = checked_in_example_configs();
     let rust_example_requirement =
         read_file("examples/rust-only/docs/syu/requirements/core/rust.yaml");
-    let rust_example_config = read_file("examples/rust-only/syu.yaml");
-    let python_example_config = read_file("examples/python-only/syu.yaml");
     let python_example_requirement =
         read_file("examples/python-only/docs/syu/requirements/core/python.yaml");
     let csharp_fallback_requirement =
         read_file("examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml");
-    let csharp_fallback_config = read_file("examples/csharp-fallback/syu.yaml");
     let csharp_fallback_readme = read_file("examples/csharp-fallback/README.md");
-    let docs_first_config = read_file("examples/docs-first/syu.yaml");
     let docs_first_requirement =
         read_file("examples/docs-first/docs/syu/requirements/core/docs.yaml");
     let docs_first_readme = read_file("examples/docs-first/README.md");
-    let go_example_config = read_file("examples/go-only/syu.yaml");
     let go_example_requirement = read_file("examples/go-only/docs/syu/requirements/core/go.yaml");
     let go_example_readme = read_file("examples/go-only/README.md");
-    let polyglot_config = read_file("examples/polyglot/syu.yaml");
     let polyglot_feature = read_file("examples/polyglot/docs/syu/features/languages/polyglot.yaml");
-    let team_scale_config = read_file("examples/team-scale/syu.yaml");
     let example_tests = read_file("tests/example_workspaces.rs");
 
+    assert!(!example_configs.is_empty());
+    for config in &example_configs {
+        let relative = config
+            .strip_prefix(repo_root())
+            .expect("example config should stay under the repository root");
+        let rendered = fs::read_to_string(config).expect("example config should be readable");
+        assert!(
+            rendered.contains(&format!("version: {current_version}")),
+            "{} should use the current CLI version",
+            relative.display()
+        );
+    }
+
     assert!(rust_example_requirement.contains("REQ-RUST-001"));
-    assert!(rust_example_config.contains(&format!("version: {current_version}")));
-    assert!(python_example_config.contains(&format!("version: {current_version}")));
     assert!(python_example_requirement.contains("REQ-PY-001"));
     assert!(csharp_fallback_requirement.contains("REQ-CSHARP-001"));
-    assert!(csharp_fallback_config.contains(&format!("version: {current_version}")));
     assert!(csharp_fallback_readme.contains("CsharpFallbackAcceptanceChecklist"));
     assert!(csharp_fallback_readme.contains("SYU-trace-language-001"));
-    assert!(docs_first_config.contains(&format!("version: {current_version}")));
     assert!(docs_first_requirement.contains("REQ-DOCS-001"));
     assert!(docs_first_requirement.contains("DocsFirstAcceptanceChecklist"));
     assert!(docs_first_readme.contains("syu init --template docs-first"));
-    assert!(go_example_config.contains(&format!("version: {current_version}")));
     assert!(go_example_requirement.contains("REQ-GO-001"));
     assert!(go_example_readme.contains("TestGoRequirement"));
     assert!(go_example_readme.contains("GoFeatureImpl"));
-    assert!(polyglot_config.contains(&format!("version: {current_version}")));
     assert!(polyglot_feature.contains("FEAT-MIX-001"));
     assert!(polyglot_feature.contains("status: implemented"));
-    assert!(team_scale_config.contains(&format!("version: {current_version}")));
     assert!(example_tests.contains("docs_first_example_validates"));
     assert!(example_tests.contains("csharp_fallback_example_validates"));
     assert!(example_tests.contains("rust_only_example_validates"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashSet,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashSet, fs, path::PathBuf};
 
 use serde_json::Value;
 
@@ -18,22 +14,15 @@ fn read_json(path: &str) -> Value {
     serde_json::from_str(&read_file(path)).expect("repository JSON should parse")
 }
 
-fn collect_named_files(root: &Path, file_name: &str, output: &mut Vec<PathBuf>) {
-    for entry in fs::read_dir(root).expect("directory should be readable") {
-        let entry = entry.expect("directory entry should exist");
-        let path = entry.path();
-
-        if path.is_dir() {
-            collect_named_files(&path, file_name, output);
-        } else if path.file_name().and_then(|name| name.to_str()) == Some(file_name) {
-            output.push(path);
-        }
-    }
-}
-
 fn checked_in_example_configs() -> Vec<PathBuf> {
-    let mut configs = Vec::new();
-    collect_named_files(&repo_root().join("examples"), "syu.yaml", &mut configs);
+    let mut configs: Vec<_> = fs::read_dir(repo_root().join("examples"))
+        .expect("examples directory should be readable")
+        .filter_map(|entry| {
+            let path = entry.expect("directory entry should exist").path();
+            let config = path.join("syu.yaml");
+            (path.is_dir() && config.is_file()).then_some(config)
+        })
+        .collect();
     configs.sort();
     configs
 }


### PR DESCRIPTION
## Linked issue or specification
- Closes #485

## Summary
- replace per-example version assertions with a repository-wide scan of checked-in examples/**/syu.yaml files
- keep the existing example-specific content assertions alongside the broader freshness contract
- ensure future example workspaces automatically inherit current-version coverage

## Validation
- bash scripts/ci/pinned-npm.sh install app
- npm --prefix app ci
- cargo test --test repository_quality repository_ships_example_workspaces
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
