### PR TITLE
test: lock coverage summary metadata loading

### DIFF
--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -130,10 +130,11 @@ fn repository_declares_coverage_gate_at_one_hundred_percent() {
     assert!(spec_summary_script.contains("list\", \"--with-path\", \"--format\", \"json\""));
     assert!(spec_summary_script.contains("yaml.safe_load"));
     assert!(spec_summary_script.contains("Rust implementation coverage"));
-    assert_eq!(
-        spec_summary_script.matches("run_syu_json(").count(),
-        2,
-        "expected one helper definition and one metadata-loading call"
+    assert!(
+        spec_summary_script.contains(
+            "items = run_syu_json(repo_root, \"list\", \"--with-path\", \"--format\", \"json\")"
+        ),
+        "expected the coverage summary to load workspace metadata with one `syu list --with-path --format json` call"
     );
     assert!(
         !spec_summary_script.contains("\"show\","),

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -130,6 +130,15 @@ fn repository_declares_coverage_gate_at_one_hundred_percent() {
     assert!(spec_summary_script.contains("list\", \"--with-path\", \"--format\", \"json\""));
     assert!(spec_summary_script.contains("yaml.safe_load"));
     assert!(spec_summary_script.contains("Rust implementation coverage"));
+    assert_eq!(
+        spec_summary_script.matches("run_syu_json(").count(),
+        2,
+        "expected one helper definition and one metadata-loading call"
+    );
+    assert!(
+        !spec_summary_script.contains("\"show\","),
+        "coverage summary generation should not shell out through repeated `syu show` calls"
+    );
 
     assert!(ci_workflow.contains("coverage:"));
     assert!(ci_workflow.contains("scripts/ci/coverage.sh lcov"));


### PR DESCRIPTION
## Linked issue or specification
- Closes #351

## Summary
- add a repository-quality contract that locks spec-aware coverage summary generation to the current single metadata-load path
- assert the helper uses `run_syu_json(...)` exactly once beyond its definition and does not shell out through repeated `syu show` calls
- keep the existing coverage-summary script contract while making the performance-sensitive behavior explicit

## Validation
- bash scripts/ci/pinned-npm.sh install app
- npm --prefix app ci
- cargo test --test repository_quality repository_declares_coverage_gate_at_one_hundred_percent
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
