### PR TITLE
docs: strengthen release attestation verification guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,24 @@ resolves the Linux archive and installs to `~/.local/bin`.
 
 The checksum step above verifies the installer script itself. Published release
 archives also carry GitHub artifact attestations, so you can separately verify
-the platform archive that the installer downloads before it unpacks the binary:
+the platform archive that the installer downloads before it unpacks the binary.
+For a stronger authenticity check, download the archive you expect to install
+and pin the verification to this repository's release workflow plus the tag you
+selected:
 
 ```bash
-gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz --repo ugoite/syu
+gh release download "${RELEASE}" --repo ugoite/syu --pattern 'syu-x86_64-unknown-linux-gnu.tar.gz'
+gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz \
+  --repo ugoite/syu \
+  --signer-workflow ugoite/syu/.github/workflows/release-artifacts.yml \
+  --source-ref "refs/tags/${RELEASE}" \
+  --format json
 ```
+
+Replace the archive name with the platform asset you plan to install
+(`syu-x86_64-pc-windows-msvc.zip`, `syu-aarch64-apple-darwin.tar.gz`, and so
+on). `--format json` lets you keep the verified certificate and provenance
+details for your own policy checks.
 
 ### Shortcut: run the installer directly
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ and pin the verification to this repository's release workflow plus the tag you
 selected:
 
 ```bash
+RELEASE="$(git describe --tags --abbrev=0)"
 gh release download "${RELEASE}" --repo ugoite/syu --pattern 'syu-x86_64-unknown-linux-gnu.tar.gz'
 gh attestation verify syu-x86_64-unknown-linux-gnu.tar.gz \
   --repo ugoite/syu \

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -67,7 +67,9 @@ one maintained place. This is the best fit for security-sensitive environments.
 
 The getting-started path above verifies the installer script itself. If you need
 additional archive-level provenance checks, follow the same README section and
-then verify the platform archive separately before installation.
+then verify the platform archive separately before installation with
+`gh release download`, `gh attestation verify`, and the same
+`--signer-workflow` / `--source-ref` pinning the README shows.
 
 **Option B — Run the installer directly**
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -242,6 +242,12 @@ fn repository_declares_release_automation() {
     assert!(manifest.contains("\".\": \"0.0.0\""));
     assert!(readme.contains("gh attestation verify"));
     assert!(readme.contains("--repo ugoite/syu"));
+    assert!(readme.contains("gh release download"));
+    assert!(
+        readme.contains("--signer-workflow ugoite/syu/.github/workflows/release-artifacts.yml")
+    );
+    assert!(readme.contains("--source-ref \"refs/tags/${RELEASE}\""));
+    assert!(readme.contains("--format json"));
     assert!(
         !repo_root()
             .join("release-please-config.alpha.json")
@@ -479,6 +485,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("compact command card"));
     assert!(getting_started.contains("install-syu.sh"));
     assert!(getting_started.contains("checksums.sha256"));
+    assert!(getting_started.contains("--signer-workflow"));
+    assert!(getting_started.contains("--source-ref"));
     assert!(getting_started.contains("security-sensitive environments"));
     assert!(getting_started.contains("README installer verification flow"));
     assert!(getting_started.contains("SYU_VERSION=alpha"));


### PR DESCRIPTION
## Linked issue or specification
- Closes #491

## Summary
- expand the README verification flow to show release-archive provenance checks with `gh release download` and `gh attestation verify`
- pin the stronger verification path to the release workflow and selected tag via `--signer-workflow` and `--source-ref`
- lock the new guidance into repository-quality assertions and the getting-started guide

## Validation
- bash scripts/ci/pinned-npm.sh install app
- npm --prefix app ci
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- npm --prefix website run build
