### PR TITLE
docs: clarify opt-in browser app provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,9 @@ binaries without checking `app/dist/` into `main`.
 
 Use the checked-in Node 25 version from `app/package.json` and `app/.nvmrc`
 when working in `app/`; that is the local contributor expectation, not only a
-CI matrix detail.
+CI matrix detail. Before you run the install commands below, switch your shell
+to that Node major with a version manager such as `nvm`, `fnm`, or `Volta`
+using the checked-in `app/.nvmrc`.
 Before you run Cargo commands that embed the browser app, provision the app
 dependencies intentionally from the repository root:
 

--- a/README.md
+++ b/README.md
@@ -713,17 +713,29 @@ binaries without checking `app/dist/` into `main`.
 Use the checked-in Node 25 version from `app/package.json` and `app/.nvmrc`
 when working in `app/`; that is the local contributor expectation, not only a
 CI matrix detail.
+Before you run Cargo commands that embed the browser app, provision the app
+dependencies intentionally from the repository root:
+
+```bash
+scripts/ci/pinned-npm.sh install app
+npm --prefix app ci
+```
+
+Cargo no longer runs `npm ci` for you during normal builds. If `app/node_modules`
+is missing or stale, `build.rs` stops and points back to the commands above so
+offline, hermetic, and security-sensitive environments do not hide a networked
+package-manager install inside an ordinary Rust build.
+
 When contributors change browser app sources or build inputs, they should run
 `scripts/ci/check-browser-app-freshness.sh`. That flow regenerates the local
 `app/src/wasm` bridge, typechecks the browser app, and builds a fresh local
 `app/dist/` artifact the same way CI does before uploading it.
 
 ```bash
-cd app
-npm ci
-npm run build:wasm
-npm run build
-cd ..
+scripts/ci/pinned-npm.sh install app
+npm --prefix app ci
+npm --prefix app run build:wasm
+npm --prefix app run build
 cargo run -- app .
 ```
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1045,6 +1045,9 @@ fn repository_ships_browser_app() {
     assert!(pinned_npm.contains("npm install --global"));
     assert!(pinned_npm.contains("Run 'scripts/ci/pinned-npm.sh install"));
     assert!(readme.contains("generates the embedded"));
+    assert!(readme.contains("scripts/ci/pinned-npm.sh install app"));
+    assert!(readme.contains("Cargo no longer runs `npm ci` for you during normal builds."));
+    assert!(readme.contains("offline, hermetic, and security-sensitive environments"));
     assert!(readme.contains("check-browser-app-freshness.sh"));
     assert!(readme.contains("regenerates the local"));
     assert!(readme.contains("app/dist"));


### PR DESCRIPTION
## Summary
- document the explicit browser-app dependency provisioning flow before Cargo builds
- explain that normal Cargo builds no longer run `npm ci` implicitly
- lock the README guidance in repository-quality assertions

Closes #400