### PR TITLE
feat: add VS Code inline trace actions

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,6 +10,8 @@ through a terminal:
   philosophies in the **syu Context** explorer view
 - jump from a spec ID to its YAML document
 - open the traced files that belong to a requirement or feature
+- use inline CodeLens actions on YAML spec IDs, traced files, and traced symbols
+  without opening the command palette first
 
 ## Current protocol
 

--- a/editors/vscode/src/extension.js
+++ b/editors/vscode/src/extension.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const vscode = require('vscode');
 
 const {
+  collectInlineNavigationTargets,
   loadDiagnostics,
   loadSpecModel,
   lookupTrace,
@@ -309,6 +310,75 @@ function activeSymbol(editor) {
   return null;
 }
 
+function codeLensRange(target) {
+  return new vscode.Range(
+    target.line,
+    target.startCharacter,
+    target.line,
+    target.endCharacter
+  );
+}
+
+function createCodeLens(range, command, title, argumentsList) {
+  return new vscode.CodeLens(range, {
+    command,
+    title,
+    arguments: argumentsList
+  });
+}
+
+function createInlineNavigationProvider(modelCache, treeProvider) {
+  return {
+    async provideCodeLenses(document) {
+      const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+      if (!folder || !(await isSyuWorkspace(folder))) {
+        return [];
+      }
+
+      const model = await ensureModel(folder, modelCache);
+      const lenses = [];
+
+      for (const target of collectInlineNavigationTargets(document.getText())) {
+        const range = codeLensRange(target);
+        if (target.kind === 'specId') {
+          if (!model.byId.has(target.id)) {
+            continue;
+          }
+
+          lenses.push(
+            createCodeLens(range, 'syu.openSpecItemById', 'syu: Open spec item', [target.id]),
+            createCodeLens(range, 'syu.showRelatedFilesForSpecId', 'syu: Show related files', [
+              target.id
+            ])
+          );
+          continue;
+        }
+
+        const traceTarget = {
+          path: path.join(model.workspaceRoot, target.file.split('/').join(path.sep)),
+          symbol: target.kind === 'traceSymbol' ? target.symbol : null
+        };
+
+        if (target.kind === 'traceFile') {
+          lenses.push(
+            createCodeLens(range, 'syu.openResolvedTarget', 'syu: Open traced file', [
+              { path: traceTarget.path, searchText: null }
+            ]),
+            createCodeLens(range, 'syu.showTraceForActiveFile', 'syu: Trace file', [traceTarget])
+          );
+          continue;
+        }
+
+        lenses.push(
+          createCodeLens(range, 'syu.showTraceForActiveFile', 'syu: Trace symbol', [traceTarget])
+        );
+      }
+
+      return lenses;
+    }
+  };
+}
+
 async function pickSpecItem(model, preferredId) {
   if (preferredId && model.byId.has(preferredId)) {
     return model.byId.get(preferredId);
@@ -388,8 +458,16 @@ function registerCommands(context, modelCache, treeProvider, collection) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('syu.showTraceForActiveFile', async () => {
-      const editor = vscode.window.activeTextEditor;
+    vscode.commands.registerCommand('syu.showTraceForActiveFile', async (traceTarget) => {
+      let editor = vscode.window.activeTextEditor;
+      if (traceTarget?.path) {
+        await openResolvedTarget({
+          path: traceTarget.path,
+          searchText: traceTarget.symbol || null
+        });
+        editor = vscode.window.activeTextEditor;
+      }
+
       if (!editor) {
         await vscode.window.showInformationMessage('Open a file before tracing it with syu.');
         return;
@@ -402,14 +480,14 @@ function registerCommands(context, modelCache, treeProvider, collection) {
       }
 
       const model = await ensureModel(folder, modelCache);
-      const symbol = activeSymbol(editor);
+      const symbol = traceTarget?.symbol || activeSymbol(editor);
       const traceContext = lookupTrace(model, editor.document.uri.fsPath, symbol);
       treeProvider.setTraceContext(model.workspaceRoot, traceContext);
     })
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('syu.openSpecItemById', async () => {
+    vscode.commands.registerCommand('syu.openSpecItemById', async (preferredId) => {
       const folder =
         vscode.window.activeTextEditor &&
         vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri);
@@ -424,7 +502,10 @@ function registerCommands(context, modelCache, treeProvider, collection) {
       }
 
       const model = await ensureModel(workspaceFolder, modelCache);
-      const item = await pickSpecItem(model, activeSpecId(vscode.window.activeTextEditor));
+      const item = await pickSpecItem(
+        model,
+        preferredId || activeSpecId(vscode.window.activeTextEditor)
+      );
       if (!item) {
         return;
       }
@@ -437,7 +518,7 @@ function registerCommands(context, modelCache, treeProvider, collection) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('syu.showRelatedFilesForSpecId', async () => {
+    vscode.commands.registerCommand('syu.showRelatedFilesForSpecId', async (preferredId) => {
       const folder =
         vscode.window.activeTextEditor &&
         vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri);
@@ -452,7 +533,10 @@ function registerCommands(context, modelCache, treeProvider, collection) {
       }
 
       const model = await ensureModel(workspaceFolder, modelCache);
-      const item = await pickSpecItem(model, activeSpecId(vscode.window.activeTextEditor));
+      const item = await pickSpecItem(
+        model,
+        preferredId || activeSpecId(vscode.window.activeTextEditor)
+      );
       if (!item) {
         return;
       }
@@ -477,11 +561,16 @@ function activate(context) {
   const modelCache = new Map();
   const diagnostics = vscode.languages.createDiagnosticCollection('syu');
   const treeProvider = new SyuContextTreeProvider();
+  const inlineNavigationProvider = createInlineNavigationProvider(modelCache, treeProvider);
   const treeView = vscode.window.createTreeView('syuContext', {
     treeDataProvider: treeProvider
   });
 
-  context.subscriptions.push(diagnostics, treeView);
+  context.subscriptions.push(
+    diagnostics,
+    treeView,
+    vscode.languages.registerCodeLensProvider({ language: 'yaml', scheme: 'file' }, inlineNavigationProvider)
+  );
 
   registerCommands(context, modelCache, treeProvider, diagnostics);
 

--- a/editors/vscode/src/model.js
+++ b/editors/vscode/src/model.js
@@ -510,23 +510,44 @@ function collectInlineNavigationTargets(documentText) {
       continue
     }
 
-    const symbolMatch = /^(\s*)-\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*$/u.exec(text)
-    if (!symbolMatch) {
+    const symbolValue = parseTraceSymbolEntry(text)
+    if (!symbolValue) {
       continue
     }
 
-    const startCharacter = text.indexOf(symbolMatch[2])
+    const startCharacter = text.indexOf(symbolValue)
     targets.push({
       kind: 'traceSymbol',
       file: activeTraceFile,
-      symbol: symbolMatch[2],
+      symbol: symbolValue,
       line,
       startCharacter,
-      endCharacter: startCharacter + symbolMatch[2].length
+      endCharacter: startCharacter + symbolValue.length
     })
   }
 
   return targets
+}
+
+function parseTraceSymbolEntry(text) {
+  const match = /^\s*-\s*(.+?)\s*$/u.exec(text)
+  if (!match) {
+    return null
+  }
+
+  const rawValue = match[1].replace(/\s+#.*$/u, '').trim()
+  if (!rawValue) {
+    return null
+  }
+
+  if (
+    (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+    (rawValue.startsWith("'") && rawValue.endsWith("'"))
+  ) {
+    return rawValue.slice(1, -1).trim() || null
+  }
+
+  return rawValue
 }
 
 function itemFromIssueSubject(issue, model) {

--- a/editors/vscode/src/model.js
+++ b/editors/vscode/src/model.js
@@ -435,6 +435,100 @@ function specIdFromText(value) {
   return match ? match[0] : null
 }
 
+function collectInlineNavigationTargets(documentText) {
+  const lines = String(documentText || '').split(/\r?\n/u)
+  const targets = []
+  let activeTraceFile = null
+  let traceFileIndent = -1
+  let inSymbols = false
+  let symbolsIndent = -1
+
+  for (let line = 0; line < lines.length; line += 1) {
+    const text = lines[line]
+    const trimmed = text.trim()
+    const indent = text.match(/^(\s*)/u)?.[1].length ?? 0
+
+    for (const match of text.matchAll(/\b(?:PHIL|POL|REQ|FEAT)-[A-Z0-9-]+\b/gu)) {
+      targets.push({
+        kind: 'specId',
+        id: match[0],
+        line,
+        startCharacter: match.index,
+        endCharacter: match.index + match[0].length
+      })
+    }
+
+    const fileMatch = /^(\s*)(?:-\s+)?file:\s*["']?([^"'#]+?)["']?\s*$/u.exec(text)
+    if (fileMatch) {
+      const file = normalizeRelativePath(fileMatch[2])
+      activeTraceFile = file || null
+      traceFileIndent = fileMatch[1].length
+      inSymbols = false
+      symbolsIndent = -1
+
+      if (activeTraceFile) {
+        const startCharacter = text.indexOf(fileMatch[2])
+        targets.push({
+          kind: 'traceFile',
+          file: activeTraceFile,
+          line,
+          startCharacter,
+          endCharacter: startCharacter + fileMatch[2].length
+        })
+      }
+      continue
+    }
+
+    if (!trimmed) {
+      continue
+    }
+
+    if (activeTraceFile && indent <= traceFileIndent) {
+      activeTraceFile = null
+      traceFileIndent = -1
+      inSymbols = false
+      symbolsIndent = -1
+    }
+
+    if (!activeTraceFile) {
+      continue
+    }
+
+    if (/^\s*symbols:\s*$/u.test(text) && indent > traceFileIndent) {
+      inSymbols = true
+      symbolsIndent = indent
+      continue
+    }
+
+    if (!inSymbols) {
+      continue
+    }
+
+    if (indent <= symbolsIndent) {
+      inSymbols = false
+      symbolsIndent = -1
+      continue
+    }
+
+    const symbolMatch = /^(\s*)-\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*$/u.exec(text)
+    if (!symbolMatch) {
+      continue
+    }
+
+    const startCharacter = text.indexOf(symbolMatch[2])
+    targets.push({
+      kind: 'traceSymbol',
+      file: activeTraceFile,
+      symbol: symbolMatch[2],
+      line,
+      startCharacter,
+      endCharacter: startCharacter + symbolMatch[2].length
+    })
+  }
+
+  return targets
+}
+
 function itemFromIssueSubject(issue, model) {
   const id = specIdFromText(issue.subject)
   return id ? model?.byId.get(id) || null : null
@@ -730,6 +824,7 @@ function openTargetsForSpecId(model, id) {
 }
 
 module.exports = {
+  collectInlineNavigationTargets,
   formatDiagnosticMessage,
   loadDiagnostics,
   loadSpecModel,

--- a/editors/vscode/test/model.test.js
+++ b/editors/vscode/test/model.test.js
@@ -193,3 +193,26 @@ features:
     ]
   );
 });
+
+test('collectInlineNavigationTargets keeps wildcard and quoted trace symbols addressable', () => {
+  const targets = collectInlineNavigationTargets(`
+features:
+  - id: FEAT-TRACE-001
+    implementations:
+      rust:
+        - file: src/rust_feature.rs
+          symbols:
+            - "*"
+            - "example::run"
+`);
+
+  assert.deepEqual(
+    targets
+      .filter((target) => target.kind === 'traceSymbol')
+      .map((target) => [target.file, target.symbol]),
+    [
+      ['src/rust_feature.rs', '*'],
+      ['src/rust_feature.rs', 'example::run']
+    ]
+  );
+});

--- a/editors/vscode/test/model.test.js
+++ b/editors/vscode/test/model.test.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+  collectInlineNavigationTargets,
   loadSpecModel,
   lookupTrace,
   normalizeRelativePath,
@@ -152,4 +153,43 @@ test('resolveWorkspaceContext resolves an opened spec root back to the repositor
 
   assert.equal(context.workspaceRoot, workspace.workspaceRoot);
   assert.equal(context.specRoot, workspace.specRoot);
+});
+
+test('collectInlineNavigationTargets finds spec IDs traced files and traced symbols', () => {
+  const targets = collectInlineNavigationTargets(`
+requirements:
+  - id: REQ-TRACE-001
+    linked_policies:
+      - POL-TRACE-001
+features:
+  - id: FEAT-TRACE-001
+    linked_requirements:
+      - REQ-TRACE-001
+    implementations:
+      rust:
+        - file: src/rust_feature.rs
+          symbols:
+            - runFeature
+            - helper_value
+`);
+
+  assert.deepEqual(
+    targets
+      .filter((target) => target.kind === 'specId')
+      .map((target) => target.id),
+    ['REQ-TRACE-001', 'POL-TRACE-001', 'FEAT-TRACE-001', 'REQ-TRACE-001']
+  );
+  assert.deepEqual(
+    targets.filter((target) => target.kind === 'traceFile').map((target) => target.file),
+    ['src/rust_feature.rs']
+  );
+  assert.deepEqual(
+    targets
+      .filter((target) => target.kind === 'traceSymbol')
+      .map((target) => [target.file, target.symbol]),
+    [
+      ['src/rust_feature.rs', 'runFeature'],
+      ['src/rust_feature.rs', 'helper_value']
+    ]
+  );
 });

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -681,15 +681,20 @@ fn repository_ships_vscode_extension() {
     assert!(extension_lock.contains("\"yaml\""));
     assert!(extension_readme.contains("Problems panel"));
     assert!(extension_readme.contains("syu Context"));
+    assert!(extension_readme.contains("inline CodeLens actions"));
     assert!(extension_readme.contains("Extension Development Host"));
     assert!(extension_launch.contains("\"extensionHost\""));
     assert!(extension_entry.contains("FEAT-VSCODE-001"));
     assert!(extension_entry.contains("SyuContextTreeProvider"));
     assert!(extension_entry.contains("refreshDiagnostics"));
+    assert!(extension_entry.contains("registerCodeLensProvider"));
+    assert!(extension_entry.contains("collectInlineNavigationTargets"));
     assert!(extension_model.contains("lookupTrace"));
     assert!(extension_model.contains("loadDiagnostics"));
+    assert!(extension_model.contains("collectInlineNavigationTargets"));
     assert!(extension_tests.contains("REQ-CORE-022"));
     assert!(extension_tests.contains("lookupTrace"));
+    assert!(extension_tests.contains("collectInlineNavigationTargets finds spec IDs"));
     assert!(gitignore.contains("editors/vscode/node_modules"));
     assert!(readme.contains("## VS Code extension"));
 }


### PR DESCRIPTION
## Summary
- add YAML CodeLens actions for spec IDs plus traced files and symbols in the VS Code extension
- reuse the existing open/related/trace commands with direct arguments instead of requiring the command palette
- cover the inline target parser in extension tests and lock the new UX in repository-quality checks

Closes #490