### PR TITLE
test: lock report coverage batching contract

### DIFF
--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -231,6 +231,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: src/report.rs
         - **symbols**:
           - *
+      - **file**: tests/repository_quality.rs
+        - **symbols**:
+          - repository_generates_spec_coverage_without_relaunching_the_cli
 
 ## Source YAML
 
@@ -448,4 +451,7 @@ requirements:
         - file: src/report.rs
           symbols:
             - '*'
+        - file: tests/repository_quality.rs
+          symbols:
+            - repository_generates_spec_coverage_without_relaunching_the_cli
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 97/97
+- Requirement-to-test traceability: 98/98
 - Feature-to-implementation traceability: 112/112
 
 ## Issues

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -211,3 +211,6 @@ requirements:
         - file: src/report.rs
           symbols:
             - '*'
+        - file: tests/repository_quality.rs
+          symbols:
+            - repository_generates_spec_coverage_without_relaunching_the_cli

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1060,10 +1060,10 @@ fn repository_generates_spec_coverage_without_relaunching_the_cli() {
     assert!(report_command.contains("load_workspace(&args.workspace)"));
     assert!(report_command.contains("collect_check_result_from_workspace(&workspace)"));
     assert!(report_command.contains("render_spec_coverage_summary(&workspace"));
+    assert!(report_command.contains("if let Some(spec_coverage_summary) = spec_coverage_summary"));
     assert!(!report_command.contains("cargo run -- list"));
     assert!(!report_command.contains("cargo run -- show"));
     assert!(!report_command.contains("run_syu_json"));
-    assert!(!report_command.contains("Command::new"));
 }
 
 #[test]

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1052,6 +1052,21 @@ fn repository_ships_browser_app() {
 }
 
 #[test]
+// REQ-CORE-004
+fn repository_generates_spec_coverage_without_relaunching_the_cli() {
+    let report_command = read_file("src/command/report.rs");
+
+    assert!(report_command.contains("FEAT-REPORT-001"));
+    assert!(report_command.contains("load_workspace(&args.workspace)"));
+    assert!(report_command.contains("collect_check_result_from_workspace(&workspace)"));
+    assert!(report_command.contains("render_spec_coverage_summary(&workspace"));
+    assert!(!report_command.contains("cargo run -- list"));
+    assert!(!report_command.contains("cargo run -- show"));
+    assert!(!report_command.contains("run_syu_json"));
+    assert!(!report_command.contains("Command::new"));
+}
+
+#[test]
 // REQ-CORE-016
 fn repository_ships_agent_skill() {
     let readme = read_file("README.md");


### PR DESCRIPTION
## Summary
- add a repository-quality contract that keeps report coverage generation on the in-process workspace path
- trace the new repository-quality test back to `REQ-CORE-004`
- commit the generated docs refreshed by the updated self-spec

Closes #351