### PR TITLE
docs: clarify reviewer validation filtering (FEAT-CHECK-001, REQ-CORE-004)

### DIFF
--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -110,7 +110,7 @@ syu log REQ-CORE-017 --kind test
 
 ## 5. Close the loop with a focused validation pass
 
-If the PR changes spec files, traced paths, or link structure, run a narrower
+If the PR changes spec files, traced paths, or link structure, run a focused
 validation pass before the full repository check:
 
 ```bash
@@ -120,7 +120,9 @@ syu validate . --id FEAT-CHECK-001
 
 Use `--genre trace` when you want trace-specific failures first. Use `--id`
 when the review is anchored on one concrete requirement or feature and you want
-the smallest relevant validation slice before expanding outward.
+the output filtered down to that item after the full workspace validation run.
+It is a review-focused view over the collected result, not a smaller or faster
+validation scope.
 
 ## Fast reviewer playbook
 

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -110,8 +110,8 @@ syu log REQ-CORE-017 --kind test
 
 ## 5. Close the loop with a focused validation pass
 
-If the PR changes spec files, traced paths, or link structure, run a focused
-validation pass before the full repository check:
+If the PR changes spec files, traced paths, or link structure, use the normal
+validation commands as a focused review view over the full repository result:
 
 ```bash
 syu validate . --genre trace

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -581,6 +581,8 @@ fn repository_declares_documentation_guides() {
     assert!(reviewer_workflow.contains("currently traced"));
     assert!(reviewer_workflow.contains("the whole PR diff is covered"));
     assert!(reviewer_workflow.contains("too-small log result with the PR diff"));
+    assert!(reviewer_workflow.contains("filtered down to that item"));
+    assert!(reviewer_workflow.contains("not a smaller or faster"));
     assert!(trace_adapter_support.contains("# Trace adapter capability matrix"));
     assert!(trace_adapter_support.contains("validate.require_symbol_trace_coverage"));
     assert!(trace_adapter_support.contains("TypeScript / JavaScript"));


### PR DESCRIPTION
## Summary
- describe `syu validate --id` as a filtered view over the full validation result
- keep the reviewer workflow wording aligned with the actual CLI behavior
- lock the clarified guidance in repository-quality docs assertions

## Linked issue or specification
- Closes #517
- Requirement / feature IDs: FEAT-CHECK-001, REQ-CORE-004

## Validation
- [x] `scripts/ci/quality-gates.sh`
- [ ] `scripts/ci/coverage.sh summary` (required when Rust logic changes)
- [x] `cargo run -- validate .`
- [x] Docs, examples, or self-spec updated when behavior changed

## Release notes
- [ ] This change should appear in the next release notes
- [x] No release note needed