### PR TITLE
feat: expand reviewer log history

### DIFF
--- a/docs/generated/site-spec/features/cli/log.md
+++ b/docs/generated/site-spec/features/cli/log.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/log.yaml"
 
 - **id**: FEAT-LOG-001
   - **title**: Trace-aware Git history lookup
-  - **summary**: Show the commit history behind one requirement or feature by projecting the current trace graph onto checked-in Git paths.
+  - **summary**: Show reviewer-friendly commit history behind one requirement or feature by projecting the current trace graph, related spec surface, and optional review range onto checked-in Git paths.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-024
@@ -53,7 +53,7 @@ version: 1
 features:
   - id: FEAT-LOG-001
     title: Trace-aware Git history lookup
-    summary: Show the commit history behind one requirement or feature by projecting the current trace graph onto checked-in Git paths.
+    summary: Show reviewer-friendly commit history behind one requirement or feature by projecting the current trace graph, related spec surface, and optional review range onto checked-in Git paths.
     status: implemented
     linked_requirements:
       - REQ-CORE-024

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -396,9 +396,12 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       test or implementation files from the workspace. The command MUST explain
       why each returned commit matched, SHOULD support narrowing the lookup to
       definition versus traced evidence and to one path subset, SHOULD offer
-      JSON output for audit or release automation, and SHOULD continue working
-      when validation issues exist so long as the workspace still loads and is
-      inside a Git repository.
+      a reviewer-oriented mode that can include related spec items and traced
+      files from the relation graph, SHOULD support scoping the returned history
+      to an explicit Git range or the current branch's merge-base with another
+      ref, SHOULD offer JSON output for audit or release automation, and SHOULD
+      continue working when validation issues exist so long as the workspace
+      still loads and is inside a Git repository.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -797,9 +800,12 @@ requirements:
       test or implementation files from the workspace. The command MUST explain
       why each returned commit matched, SHOULD support narrowing the lookup to
       definition versus traced evidence and to one path subset, SHOULD offer
-      JSON output for audit or release automation, and SHOULD continue working
-      when validation issues exist so long as the workspace still loads and is
-      inside a Git repository.
+      a reviewer-oriented mode that can include related spec items and traced
+      files from the relation graph, SHOULD support scoping the returned history
+      to an explicit Git range or the current branch's merge-base with another
+      ref, SHOULD offer JSON output for audit or release automation, and SHOULD
+      continue working when validation issues exist so long as the workspace
+      still loads and is inside a Git repository.
     priority: medium
     status: implemented
     linked_policies:

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -87,6 +87,7 @@ After you know the owning ID and traced files, inspect their recent Git history:
 
 ```bash
 syu log FEAT-CHECK-001 --kind implementation --path src/command
+syu log REQ-CORE-017 --include-related --merge-base-ref origin/main
 ```
 
 Use `syu log` when review needs historical context:
@@ -94,6 +95,8 @@ Use `syu log` when review needs historical context:
 - has this area changed repeatedly in the same way?
 - did a recent commit rename the traced file or symbol?
 - is the PR fixing a regression in a path that already has relevant history?
+- do I need the linked requirement/feature surface, not just one selected ID?
+- what changed on this review branch since it diverged from main?
 
 Treat `syu log` as history for the **currently traced** surface, not proof that
 the whole PR diff is covered. A newly added implementation or test file can be

--- a/docs/syu/features/cli/log.yaml
+++ b/docs/syu/features/cli/log.yaml
@@ -6,7 +6,7 @@ version: 1
 features:
   - id: FEAT-LOG-001
     title: Trace-aware Git history lookup
-    summary: Show the commit history behind one requirement or feature by projecting the current trace graph onto checked-in Git paths.
+    summary: Show reviewer-friendly commit history behind one requirement or feature by projecting the current trace graph, related spec surface, and optional review range onto checked-in Git paths.
     status: implemented
     linked_requirements:
       - REQ-CORE-024

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -370,9 +370,12 @@ requirements:
       test or implementation files from the workspace. The command MUST explain
       why each returned commit matched, SHOULD support narrowing the lookup to
       definition versus traced evidence and to one path subset, SHOULD offer
-      JSON output for audit or release automation, and SHOULD continue working
-      when validation issues exist so long as the workspace still loads and is
-      inside a Git repository.
+      a reviewer-oriented mode that can include related spec items and traced
+      files from the relation graph, SHOULD support scoping the returned history
+      to an explicit Git range or the current branch's merge-base with another
+      ref, SHOULD offer JSON output for audit or release automation, and SHOULD
+      continue working when validation issues exist so long as the workspace
+      still loads and is inside a Git repository.
     priority: medium
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,7 @@ const LOG_AFTER_HELP: &str = "\
 Examples:
   syu log REQ-CORE-002
   syu log FEAT-CHECK-001 --kind implementation --path src/command
+  syu log REQ-CORE-024 --include-related --merge-base-ref origin/main
   syu log REQ-CORE-019 --format json";
 
 const RELATE_AFTER_HELP: &str = "\
@@ -338,6 +339,18 @@ pub struct LogArgs {
     #[arg(help = "Limit traced paths to one repository-relative file or directory prefix")]
     #[arg(long, value_name = "PATH")]
     pub path: Option<PathBuf>,
+
+    #[arg(help = "Also include related spec definitions and traces from `syu relate`")]
+    #[arg(long)]
+    pub include_related: bool,
+
+    #[arg(help = "Limit history to commits after the merge-base between HEAD and the given ref")]
+    #[arg(long, value_name = "REF", conflicts_with = "range")]
+    pub merge_base_ref: Option<String>,
+
+    #[arg(help = "Limit history to an explicit git revision range such as origin/main..HEAD")]
+    #[arg(long, value_name = "RANGE", conflicts_with = "merge_base_ref")]
+    pub range: Option<String>,
 
     #[arg(help = "Maximum number of matching commits to show")]
     #[arg(long, default_value_t = 20)]

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -1194,6 +1194,57 @@ mod tests {
     }
 
     #[test]
+    fn collect_related_tracked_paths_excludes_selected_definition_from_related_set() {
+        let workspace_root = tempdir().expect("tempdir should exist");
+        write_related_workspace_fixture(workspace_root.path());
+        let workspace =
+            crate::workspace::load_workspace(workspace_root.path()).expect("workspace should load");
+
+        let tracked = super::collect_related_tracked_paths(
+            &workspace,
+            "REQ-HIST-001",
+            HistoryKind::Definition,
+            None,
+        )
+        .expect("related tracked paths should resolve");
+        assert!(tracked.iter().any(|entry| {
+            entry.owner_id == "FEAT-HIST-001"
+                && entry.owner_kind == "feature"
+                && entry.kind == "definition"
+                && entry.source == "related"
+        }));
+        assert!(
+            !tracked
+                .iter()
+                .any(|entry| entry.owner_id == "REQ-HIST-001" && entry.source == "related")
+        );
+    }
+
+    #[test]
+    fn run_log_command_supports_related_surface_and_merge_base_scope() {
+        let _lock = PATH_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+        let workspace_root = tempdir().expect("tempdir should exist");
+        write_related_workspace_fixture(workspace_root.path());
+        init_test_git_repository(workspace_root.path());
+        git(workspace_root.path(), &["branch", "review-base", "HEAD"]);
+
+        let exit = super::run_log_command(&crate::cli::LogArgs {
+            id: "REQ-HIST-001".to_string(),
+            workspace: workspace_root.path().to_path_buf(),
+            kind: HistoryKind::Test,
+            path: Some(PathBuf::from("src")),
+            include_related: true,
+            merge_base_ref: Some("review-base".to_string()),
+            range: None,
+            limit: 5,
+            format: crate::cli::OutputFormat::Json,
+        })
+        .expect("log command should succeed");
+
+        assert_eq!(exit, 0);
+    }
+
+    #[test]
     fn order_commits_by_repository_history_uses_candidate_ancestry() {
         let _lock = PATH_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         let repo = tempdir().expect("tempdir should exist");
@@ -1718,6 +1769,58 @@ mod tests {
             }],
         );
         traces
+    }
+
+    fn write_related_workspace_fixture(root: &Path) {
+        fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+        fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+        fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+        fs::create_dir_all(root.join("docs/syu/features/cli")).expect("features dir");
+        fs::create_dir_all(root.join("src")).expect("src dir");
+
+        fs::write(
+            root.join("syu.yaml"),
+            format!(
+                "version: {}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_symbol_trace_coverage: false\n",
+                env!("CARGO_PKG_VERSION")
+            ),
+        )
+        .expect("config");
+        fs::write(
+            root.join("docs/syu/philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-001\n    title: History should stay explorable.\n    product_design_principle: Keep commit history close to trace links.\n    coding_guideline: Prefer one-command repository history lookups.\n    linked_policies:\n      - POL-HIST-001\n",
+        )
+        .expect("philosophy file");
+        fs::write(
+            root.join("docs/syu/policies/policies.yaml"),
+            "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-HIST-001\n    title: History should be reachable from traces.\n    summary: Git history is useful when it is derived from checked-in trace metadata.\n    description: The repository history should be explorable from requirement and feature traces.\n    linked_philosophies:\n      - PHIL-HIST-001\n    linked_requirements:\n      - REQ-HIST-001\n",
+        )
+        .expect("policy file");
+        fs::write(
+            root.join("docs/syu/requirements/core.yaml"),
+            "category: Core\nprefix: REQ-HIST\n\nrequirements:\n  - id: REQ-HIST-001\n    title: Requirement history lookup\n    description: Requirement history should show the traced test and checked-in definition.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-HIST-001\n    linked_features:\n      - FEAT-HIST-001\n    tests:\n      rust:\n        - file: src/history_tests.rs\n          symbols:\n            - requirement_history_test\n",
+        )
+        .expect("requirement file");
+        fs::write(
+            root.join("docs/syu/features/features.yaml"),
+            "version: \"1\"\nfiles:\n  - kind: history\n    file: cli/history.yaml\n",
+        )
+        .expect("feature registry");
+        fs::write(
+            root.join("docs/syu/features/cli/history.yaml"),
+            "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-001\n    title: Feature history lookup\n    summary: Feature history should show the traced implementation and checked-in definition.\n    status: implemented\n    linked_requirements:\n      - REQ-HIST-001\n    implementations:\n      rust:\n        - file: src/history_feature.rs\n          symbols:\n            - feature_history\n",
+        )
+        .expect("feature file");
+        fs::write(
+            root.join("src/history_tests.rs"),
+            "// REQ-HIST-001\nfn requirement_history_test() {}\n",
+        )
+        .expect("history test file");
+        fs::write(
+            root.join("src/history_feature.rs"),
+            "// FEAT-HIST-001\nfn feature_history() {}\n",
+        )
+        .expect("history feature file");
     }
 
     fn init_test_git_repository(path: &Path) {

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -15,11 +15,12 @@ use crate::{
     cli::{HistoryKind, LogArgs, LookupKind, OutputFormat},
     coverage::normalize_relative_path,
     model::{Feature, Requirement, TraceReference},
-    workspace::load_workspace,
+    workspace::{Workspace, load_workspace},
 };
 
 use super::{
     lookup::{WorkspaceEntity, WorkspaceLookup},
+    relate::build_relation_report,
     shell_quote_path,
 };
 
@@ -42,6 +43,9 @@ struct JsonLogOutput {
     title: String,
     repository_root: String,
     kind: &'static str,
+    include_related: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<JsonHistoryScope>,
     #[serde(skip_serializing_if = "Option::is_none")]
     path_filter: Option<String>,
     tracked_paths: Vec<TrackedPath>,
@@ -49,9 +53,18 @@ struct JsonLogOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct JsonHistoryScope {
+    label: String,
+    revision_range: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct TrackedPath {
     kind: &'static str,
     path: String,
+    owner_kind: &'static str,
+    owner_id: String,
+    source: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -76,6 +89,12 @@ struct HistoryTarget {
     tracked_paths: Vec<TrackedPath>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HistoryScope {
+    label: String,
+    revision_range: String,
+}
+
 pub fn run_log_command(args: &LogArgs) -> Result<i32> {
     if args.limit == 0 {
         bail!("`--limit` must be greater than zero");
@@ -89,15 +108,34 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
         .map(|path| normalize_path_filter(&workspace.root, path))
         .transpose()?
         .filter(|path| !path.as_os_str().is_empty());
-    let target = build_history_target(
+    let mut target = build_history_target(
         lookup,
         &workspace.root,
         &args.id,
         args.kind,
         path_filter.as_deref(),
     )?;
+    if args.include_related {
+        target.tracked_paths.extend(collect_related_tracked_paths(
+            &workspace,
+            &args.id,
+            args.kind,
+            path_filter.as_deref(),
+        )?);
+        dedupe_tracked_paths(&mut target.tracked_paths);
+    }
     let repository_root = resolve_git_repository_root(&workspace.root)?;
-    let commits = load_git_history(&workspace.root, args.limit, &target.tracked_paths)?;
+    let scope = resolve_history_scope(
+        &workspace.root,
+        args.range.as_deref(),
+        args.merge_base_ref.as_deref(),
+    )?;
+    let commits = load_git_history(
+        &workspace.root,
+        args.limit,
+        &target.tracked_paths,
+        scope.as_ref(),
+    )?;
 
     match args.format {
         OutputFormat::Text => print!(
@@ -106,6 +144,8 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
                 &target,
                 &repository_root,
                 args.kind,
+                args.include_related,
+                scope.as_ref(),
                 path_filter.as_deref(),
                 &commits,
             )
@@ -118,6 +158,11 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
                 title: target.title.clone(),
                 repository_root: repository_root.display().to_string(),
                 kind: args.kind.label(),
+                include_related: args.include_related,
+                scope: scope.as_ref().map(|scope| JsonHistoryScope {
+                    label: scope.label.clone(),
+                    revision_range: scope.revision_range.clone(),
+                }),
                 path_filter: path_filter.map(|path| path.display().to_string()),
                 tracked_paths: target.tracked_paths.clone(),
                 commits,
@@ -263,12 +308,34 @@ fn tracked_paths_for_requirement(
             item.id
         ),
         HistoryKind::All => {
-            let mut tracked = vec![TrackedPath::definition(definition_path)];
-            tracked.extend(collect_trace_paths("test", &item.tests));
+            let mut tracked = vec![TrackedPath::definition(
+                "requirement",
+                &item.id,
+                "selected",
+                definition_path,
+            )];
+            tracked.extend(collect_trace_paths(
+                "requirement",
+                &item.id,
+                "selected",
+                "test",
+                &item.tests,
+            ));
             Ok(tracked)
         }
-        HistoryKind::Definition => Ok(vec![TrackedPath::definition(definition_path)]),
-        HistoryKind::Test => Ok(collect_trace_paths("test", &item.tests)),
+        HistoryKind::Definition => Ok(vec![TrackedPath::definition(
+            "requirement",
+            &item.id,
+            "selected",
+            definition_path,
+        )]),
+        HistoryKind::Test => Ok(collect_trace_paths(
+            "requirement",
+            &item.id,
+            "selected",
+            "test",
+            &item.tests,
+        )),
     }
 }
 
@@ -283,27 +350,50 @@ fn tracked_paths_for_feature(
             item.id
         ),
         HistoryKind::All => {
-            let mut tracked = vec![TrackedPath::definition(definition_path)];
-            tracked.extend(collect_trace_paths("implementation", &item.implementations));
+            let mut tracked = vec![TrackedPath::definition(
+                "feature",
+                &item.id,
+                "selected",
+                definition_path,
+            )];
+            tracked.extend(collect_trace_paths(
+                "feature",
+                &item.id,
+                "selected",
+                "implementation",
+                &item.implementations,
+            ));
             Ok(tracked)
         }
-        HistoryKind::Definition => Ok(vec![TrackedPath::definition(definition_path)]),
-        HistoryKind::Implementation => {
-            Ok(collect_trace_paths("implementation", &item.implementations))
-        }
+        HistoryKind::Definition => Ok(vec![TrackedPath::definition(
+            "feature",
+            &item.id,
+            "selected",
+            definition_path,
+        )]),
+        HistoryKind::Implementation => Ok(collect_trace_paths(
+            "feature",
+            &item.id,
+            "selected",
+            "implementation",
+            &item.implementations,
+        )),
     }
 }
 
 fn tracked_paths_for_non_trace_layer(
     id: &str,
-    layer_label: &str,
+    layer_label: &'static str,
     kind: HistoryKind,
     definition_path: &str,
 ) -> Result<Vec<TrackedPath>> {
     match kind {
-        HistoryKind::All | HistoryKind::Definition => {
-            Ok(vec![TrackedPath::definition(definition_path)])
-        }
+        HistoryKind::All | HistoryKind::Definition => Ok(vec![TrackedPath::definition(
+            layer_label,
+            id,
+            "selected",
+            definition_path,
+        )]),
         HistoryKind::Test => bail!(
             "`{id}` is a {layer_label}, so `--kind test` is not available. Use `--kind definition` or omit the flag."
         ),
@@ -314,6 +404,9 @@ fn tracked_paths_for_non_trace_layer(
 }
 
 fn collect_trace_paths(
+    owner_kind: &'static str,
+    owner_id: &str,
+    source: &'static str,
     kind: &'static str,
     traces: &std::collections::BTreeMap<String, Vec<TraceReference>>,
 ) -> Vec<TrackedPath> {
@@ -323,12 +416,76 @@ fn collect_trace_paths(
             tracked.push(TrackedPath {
                 kind,
                 path: reference.file.display().to_string(),
+                owner_kind,
+                owner_id: owner_id.to_string(),
+                source,
                 language: Some(language.clone()),
                 symbols: reference.symbols.clone(),
             });
         }
     }
     tracked
+}
+
+fn collect_related_tracked_paths(
+    workspace: &Workspace,
+    selector: &str,
+    kind: HistoryKind,
+    path_filter: Option<&Path>,
+) -> Result<Vec<TrackedPath>> {
+    let report = build_relation_report(workspace, selector)?;
+    let mut tracked = Vec::new();
+
+    if matches!(kind, HistoryKind::All | HistoryKind::Definition) {
+        for node in report
+            .philosophies
+            .iter()
+            .chain(report.policies.iter())
+            .chain(report.requirements.iter())
+            .chain(report.features.iter())
+        {
+            tracked.push(TrackedPath::definition(
+                node.kind,
+                &node.id,
+                "related",
+                &node.document_path,
+            ));
+        }
+        tracked.retain(|entry| !(entry.owner_id == selector && entry.source == "related"));
+    }
+
+    if !matches!(kind, HistoryKind::Definition) {
+        for trace in &report.traces {
+            if kind != HistoryKind::All && trace.relation_kind != kind.label() {
+                continue;
+            }
+            tracked.push(TrackedPath {
+                kind: trace.relation_kind,
+                path: trace.file.clone(),
+                owner_kind: trace.owner_kind,
+                owner_id: trace.owner_id.clone(),
+                source: "related",
+                language: Some(trace.language.clone()),
+                symbols: trace.symbols.clone(),
+            });
+        }
+    }
+
+    if let Some(path_filter) = path_filter {
+        tracked.retain(|tracked| normalized_tracked_path(&tracked.path).starts_with(path_filter));
+    }
+
+    Ok(tracked)
+}
+
+fn dedupe_tracked_paths(tracked_paths: &mut Vec<TrackedPath>) {
+    let mut deduped = Vec::with_capacity(tracked_paths.len());
+    for tracked in tracked_paths.drain(..) {
+        if !deduped.contains(&tracked) {
+            deduped.push(tracked);
+        }
+    }
+    *tracked_paths = deduped;
 }
 
 fn normalize_path_filter(workspace_root: &Path, path: &Path) -> Result<PathBuf> {
@@ -387,10 +544,59 @@ fn resolve_git_repository_root(workspace_root: &Path) -> Result<PathBuf> {
     Ok(PathBuf::from(repository_root))
 }
 
+fn resolve_history_scope(
+    workspace_root: &Path,
+    range: Option<&str>,
+    merge_base_ref: Option<&str>,
+) -> Result<Option<HistoryScope>> {
+    if let Some(range) = range {
+        return Ok(Some(HistoryScope {
+            label: format!("range `{range}`"),
+            revision_range: range.to_string(),
+        }));
+    }
+
+    let Some(reference) = merge_base_ref else {
+        return Ok(None);
+    };
+    let output = git_command(workspace_root)
+        .args(["merge-base", "HEAD", reference])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git merge-base HEAD {reference}` in `{}`",
+                workspace_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "failed to compute merge-base between `HEAD` and `{reference}` in `{}`: {}",
+            workspace_root.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let merge_base = String::from_utf8(output.stdout)
+        .context("git merge-base output should be valid UTF-8")?
+        .trim()
+        .to_string();
+    if merge_base.is_empty() {
+        bail!(
+            "failed to compute merge-base between `HEAD` and `{reference}` in `{}`: git returned an empty base SHA",
+            workspace_root.display()
+        );
+    }
+
+    Ok(Some(HistoryScope {
+        label: format!("merge-base({reference})..HEAD"),
+        revision_range: format!("{merge_base}..HEAD"),
+    }))
+}
+
 fn load_git_history(
     workspace_root: &Path,
     limit: usize,
     tracked_paths: &[TrackedPath],
+    scope: Option<&HistoryScope>,
 ) -> Result<Vec<MatchedCommit>> {
     if tracked_paths.is_empty() {
         return Ok(Vec::new());
@@ -406,7 +612,7 @@ fn load_git_history(
 
     let mut merged_commits = BTreeMap::<String, MatchedCommit>::new();
     for (path, reasons) in grouped_paths {
-        for commit in load_git_history_for_path(workspace_root, limit, &path)? {
+        for commit in load_git_history_for_path(workspace_root, limit, &path, scope)? {
             let entry = merged_commits
                 .entry(commit.sha.clone())
                 .or_insert_with(|| MatchedCommit {
@@ -428,6 +634,7 @@ fn load_git_history_for_path(
     workspace_root: &Path,
     limit: usize,
     path: &Path,
+    scope: Option<&HistoryScope>,
 ) -> Result<Vec<MatchedCommit>> {
     let mut command = git_command(workspace_root);
     command.args([
@@ -439,8 +646,11 @@ fn load_git_history_for_path(
         "--format=%x1E%H%x00%h%x00%an%x00%aI%x00%s",
         "--name-only",
         "-z",
-        "--",
     ]);
+    if let Some(scope) = scope {
+        command.arg(&scope.revision_range);
+    }
+    command.arg("--");
     command.arg(path);
 
     let output = command
@@ -644,6 +854,8 @@ fn render_history_text(
     target: &HistoryTarget,
     repository_root: &Path,
     kind: HistoryKind,
+    include_related: bool,
+    scope: Option<&HistoryScope>,
     path_filter: Option<&Path>,
     commits: &[MatchedCommit],
 ) -> String {
@@ -657,6 +869,19 @@ fn render_history_text(
     writeln!(output, "Repository: {}", repository_root.display())
         .expect("writing to String must succeed");
     writeln!(output, "Selection: {}", kind.label()).expect("writing to String must succeed");
+    writeln!(
+        output,
+        "Related surface: {}",
+        if include_related {
+            "included"
+        } else {
+            "selected only"
+        }
+    )
+    .expect("writing to String must succeed");
+    if let Some(scope) = scope {
+        writeln!(output, "Scope: {}", scope.label).expect("writing to String must succeed");
+    }
     if let Some(path_filter) = path_filter {
         writeln!(output, "Path filter: {}", path_filter.display())
             .expect("writing to String must succeed");
@@ -708,14 +933,28 @@ fn render_tracked_path(tracked: &TrackedPath) -> String {
         )
         .expect("writing to String must succeed");
     }
+    write!(
+        output,
+        "\t{} {} ({})",
+        tracked.owner_kind, tracked.owner_id, tracked.source
+    )
+    .expect("writing to String must succeed");
     output
 }
 
 impl TrackedPath {
-    fn definition(path: &str) -> Self {
+    fn definition(
+        owner_kind: &'static str,
+        owner_id: &str,
+        source: &'static str,
+        path: &str,
+    ) -> Self {
         Self {
             kind: "definition",
             path: path.to_string(),
+            owner_kind,
+            owner_id: owner_id.to_string(),
+            source,
             language: None,
             symbols: Vec::new(),
         }
@@ -740,10 +979,10 @@ mod tests {
     };
 
     use super::{
-        HistoryKind, MatchedCommit, TrackedPath, collect_trace_paths, commit_is_ancestor_of,
-        load_git_history, lookup_kind_for_id, normalize_path_filter,
+        HistoryKind, HistoryScope, MatchedCommit, TrackedPath, collect_trace_paths,
+        commit_is_ancestor_of, load_git_history, lookup_kind_for_id, normalize_path_filter,
         order_commits_by_repository_history, parse_git_history, render_history_text,
-        sort_commits_by_history_relationship, tracked_paths_for_feature,
+        resolve_history_scope, sort_commits_by_history_relationship, tracked_paths_for_feature,
         tracked_paths_for_requirement,
     };
 
@@ -842,9 +1081,17 @@ mod tests {
             }],
         );
 
-        let tracked = collect_trace_paths("implementation", &traces);
+        let tracked = collect_trace_paths(
+            "feature",
+            "FEAT-LOG-001",
+            "selected",
+            "implementation",
+            &traces,
+        );
         assert_eq!(tracked[0].kind, "implementation");
         assert_eq!(tracked[0].path, "src/log.rs");
+        assert_eq!(tracked[0].owner_kind, "feature");
+        assert_eq!(tracked[0].owner_id, "FEAT-LOG-001");
         assert_eq!(tracked[0].language.as_deref(), Some("rust"));
         assert_eq!(tracked[0].symbols, vec!["run_log_command"]);
     }
@@ -925,8 +1172,25 @@ mod tests {
     #[test]
     fn load_git_history_returns_empty_without_tracked_paths() {
         let history =
-            load_git_history(Path::new("."), 5, &[]).expect("empty tracked paths are okay");
+            load_git_history(Path::new("."), 5, &[], None).expect("empty tracked paths are okay");
         assert!(history.is_empty());
+    }
+
+    #[test]
+    fn resolve_history_scope_returns_none_without_filters() {
+        assert_eq!(
+            resolve_history_scope(Path::new("."), None, None).expect("scope should resolve"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_history_scope_keeps_explicit_ranges() {
+        let scope = resolve_history_scope(Path::new("."), Some("origin/main..HEAD"), None)
+            .expect("scope should resolve")
+            .expect("scope should exist");
+        assert_eq!(scope.label, "range `origin/main..HEAD`");
+        assert_eq!(scope.revision_range, "origin/main..HEAD");
     }
 
     #[test]
@@ -954,7 +1218,12 @@ mod tests {
                     summary: "feat: old history".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("history.txt")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "history.txt",
+                    )],
                 },
             ),
             (
@@ -965,7 +1234,12 @@ mod tests {
                     summary: "feat: new history".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("history.txt")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "history.txt",
+                    )],
                 },
             ),
         ]);
@@ -992,7 +1266,12 @@ mod tests {
                     summary: "old".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/old.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/old.yaml",
+                    )],
                 },
             ),
             (
@@ -1003,7 +1282,12 @@ mod tests {
                     summary: "new".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/new.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/new.yaml",
+                    )],
                 },
             ),
         ]);
@@ -1054,7 +1338,12 @@ mod tests {
                     summary: "old-a".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/old-a.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/old-a.yaml",
+                    )],
                 },
             ),
             (
@@ -1065,7 +1354,12 @@ mod tests {
                     summary: "old-b".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/old-b.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/old-b.yaml",
+                    )],
                 },
             ),
             (
@@ -1076,7 +1370,12 @@ mod tests {
                     summary: "new".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T02:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/new.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/new.yaml",
+                    )],
                 },
             ),
         ]);
@@ -1115,7 +1414,12 @@ mod tests {
                     summary: "root".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/root.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/root.yaml",
+                    )],
                 },
             ),
             (
@@ -1126,7 +1430,12 @@ mod tests {
                     summary: "mid-a".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/mid-a.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/mid-a.yaml",
+                    )],
                 },
             ),
             (
@@ -1137,7 +1446,12 @@ mod tests {
                     summary: "mid-b".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T02:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/mid-b.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/mid-b.yaml",
+                    )],
                 },
             ),
         ]);
@@ -1173,7 +1487,12 @@ mod tests {
                 summary: "old-a".to_string(),
                 author: "Tester".to_string(),
                 authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                reasons: vec![TrackedPath::definition("docs/old-a.yaml")],
+                reasons: vec![TrackedPath::definition(
+                    "feature",
+                    "FEAT-LOG-001",
+                    "selected",
+                    "docs/old-a.yaml",
+                )],
             },
             MatchedCommit {
                 sha: "old-b".to_string(),
@@ -1181,7 +1500,12 @@ mod tests {
                 summary: "old-b".to_string(),
                 author: "Tester".to_string(),
                 authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                reasons: vec![TrackedPath::definition("docs/old-b.yaml")],
+                reasons: vec![TrackedPath::definition(
+                    "feature",
+                    "FEAT-LOG-001",
+                    "selected",
+                    "docs/old-b.yaml",
+                )],
             },
             MatchedCommit {
                 sha: "old-c".to_string(),
@@ -1189,7 +1513,12 @@ mod tests {
                 summary: "old-c".to_string(),
                 author: "Tester".to_string(),
                 authored_at: "2026-04-13T02:00:00+00:00".to_string(),
-                reasons: vec![TrackedPath::definition("docs/old-c.yaml")],
+                reasons: vec![TrackedPath::definition(
+                    "feature",
+                    "FEAT-LOG-001",
+                    "selected",
+                    "docs/old-c.yaml",
+                )],
             },
         ];
 
@@ -1258,13 +1587,21 @@ mod tests {
                 id: "REQ-LOG-001".to_string(),
                 entity_kind: "requirement",
                 title: "Requirement history".to_string(),
-                tracked_paths: vec![TrackedPath::definition("docs/req.yaml")],
+                tracked_paths: vec![TrackedPath::definition(
+                    "requirement",
+                    "REQ-LOG-001",
+                    "selected",
+                    "docs/req.yaml",
+                )],
             },
             Path::new("/repo"),
             HistoryKind::Definition,
+            false,
+            None,
             Some(Path::new("docs")),
             &[],
         );
+        assert!(rendered.contains("Related surface: selected only"));
         assert!(rendered.contains("Path filter: docs"));
         assert!(rendered.contains("Commits:\n- none"));
     }
@@ -1279,12 +1616,20 @@ mod tests {
                 tracked_paths: vec![TrackedPath {
                     kind: "implementation",
                     path: "src/history.rs".to_string(),
+                    owner_kind: "feature",
+                    owner_id: "FEAT-LOG-001".to_string(),
+                    source: "selected",
                     language: Some("rust".to_string()),
                     symbols: vec!["history".to_string()],
                 }],
             },
             Path::new("/repo"),
             HistoryKind::Implementation,
+            true,
+            Some(&HistoryScope {
+                label: "merge-base(origin/main)..HEAD".to_string(),
+                revision_range: "abc123..HEAD".to_string(),
+            }),
             None,
             &[MatchedCommit {
                 sha: "abc".to_string(),
@@ -1295,13 +1640,20 @@ mod tests {
                 reasons: vec![TrackedPath {
                     kind: "implementation",
                     path: "src/history.rs".to_string(),
+                    owner_kind: "feature",
+                    owner_id: "FEAT-LOG-001".to_string(),
+                    source: "selected",
                     language: Some("rust".to_string()),
                     symbols: vec!["history".to_string()],
                 }],
             }],
         );
+        assert!(rendered.contains("Related surface: included"));
+        assert!(rendered.contains("Scope: merge-base(origin/main)..HEAD"));
         assert!(rendered.contains("feat: update history"));
-        assert!(rendered.contains("implementation\tsrc/history.rs\trust\t[`history`]"));
+        assert!(rendered.contains(
+            "implementation\tsrc/history.rs\trust\t[`history`]\tfeature FEAT-LOG-001 (selected)"
+        ));
     }
 
     #[test]
@@ -1324,7 +1676,12 @@ mod tests {
                     summary: "older".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T00:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/older.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/older.yaml",
+                    )],
                 },
             ),
             (
@@ -1335,7 +1692,12 @@ mod tests {
                     summary: "newer".to_string(),
                     author: "Tester".to_string(),
                     authored_at: "2026-04-13T01:00:00+00:00".to_string(),
-                    reasons: vec![TrackedPath::definition("docs/newer.yaml")],
+                    reasons: vec![TrackedPath::definition(
+                        "feature",
+                        "FEAT-LOG-001",
+                        "selected",
+                        "docs/newer.yaml",
+                    )],
                 },
             ),
         ]);

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -466,7 +466,10 @@ fn collect_related_tracked_paths(
     }
 
     if let Some(path_filter) = path_filter {
-        tracked.retain(|tracked| normalized_tracked_path(&tracked.path).starts_with(path_filter));
+        tracked.retain(|tracked| {
+            tracked.kind == "definition"
+                || normalized_tracked_path(&tracked.path).starts_with(path_filter)
+        });
     }
 
     Ok(tracked)

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -122,11 +122,8 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
         dedupe_tracked_paths(&mut target.tracked_paths);
     }
     let repository_root = resolve_git_repository_root(&workspace.root)?;
-    let scope = resolve_history_scope(
-        &workspace.root,
-        args.range.as_deref(),
-        args.merge_base_ref.as_deref(),
-    )?;
+    let merge_base_ref = args.merge_base_ref.as_deref();
+    let scope = resolve_history_scope(&workspace.root, args.range.as_deref(), merge_base_ref)?;
     let commits = load_git_history(
         &workspace.root,
         args.limit,
@@ -1211,6 +1208,20 @@ mod tests {
         let error = resolve_history_scope(Path::new("/repo"), None, Some("origin/main"))
             .expect_err("empty merge-base output should fail");
         assert!(error.to_string().contains("empty base SHA"));
+    }
+
+    #[test]
+    fn resolve_history_scope_reports_spawn_failures() {
+        let fake_bin = tempdir().expect("tempdir should exist");
+        let _path_guard = PathGuard::set(vec![fake_bin.path().to_path_buf()]);
+
+        let error = resolve_history_scope(Path::new("/repo"), None, Some("origin/main"))
+            .expect_err("missing git binary should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to run `git merge-base HEAD origin/main`")
+        );
     }
 
     #[test]

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -116,12 +116,9 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
         path_filter.as_deref(),
     )?;
     if args.include_related {
-        target.tracked_paths.extend(collect_related_tracked_paths(
-            &workspace,
-            &args.id,
-            args.kind,
-            path_filter.as_deref(),
-        )?);
+        let related =
+            collect_related_tracked_paths(&workspace, &args.id, args.kind, path_filter.as_deref())?;
+        target.tracked_paths.extend(related);
         dedupe_tracked_paths(&mut target.tracked_paths);
     }
     let repository_root = resolve_git_repository_root(&workspace.root)?;
@@ -1194,6 +1191,29 @@ mod tests {
     }
 
     #[test]
+    fn resolve_history_scope_reports_merge_base_failures() {
+        let fake_bin = tempdir().expect("tempdir should exist");
+        let _path_guard = PathGuard::set(vec![fake_bin.path().to_path_buf()]);
+        write_fake_git_for_scope_merge_base_failure(fake_bin.path());
+
+        let error = resolve_history_scope(Path::new("/repo"), None, Some("origin/main"))
+            .expect_err("merge-base failures should be reported");
+        assert!(error.to_string().contains("failed to compute merge-base"));
+        assert!(error.to_string().contains("synthetic merge-base failure"));
+    }
+
+    #[test]
+    fn resolve_history_scope_rejects_empty_merge_base_output() {
+        let fake_bin = tempdir().expect("tempdir should exist");
+        let _path_guard = PathGuard::set(vec![fake_bin.path().to_path_buf()]);
+        write_fake_git_for_scope_merge_base_empty_output(fake_bin.path());
+
+        let error = resolve_history_scope(Path::new("/repo"), None, Some("origin/main"))
+            .expect_err("empty merge-base output should fail");
+        assert!(error.to_string().contains("empty base SHA"));
+    }
+
+    #[test]
     fn collect_related_tracked_paths_excludes_selected_definition_from_related_set() {
         let workspace_root = tempdir().expect("tempdir should exist");
         write_related_workspace_fixture(workspace_root.path());
@@ -1821,6 +1841,39 @@ mod tests {
             "// FEAT-HIST-001\nfn feature_history() {}\n",
         )
         .expect("history feature file");
+    }
+
+    fn write_fake_git_for_scope_merge_base_failure(script_dir: &Path) {
+        let script_path = script_dir.join("git");
+        fs::write(
+            &script_path,
+            "#!/bin/sh\nset -eu\nif [ \"$3\" = \"merge-base\" ]; then\n  echo 'synthetic merge-base failure' >&2\n  exit 2\nfi\necho 'unexpected git invocation' >&2\nexit 1\n",
+        )
+        .expect("fake git script");
+        set_executable(&script_path);
+    }
+
+    fn write_fake_git_for_scope_merge_base_empty_output(script_dir: &Path) {
+        let script_path = script_dir.join("git");
+        fs::write(
+            &script_path,
+            "#!/bin/sh\nset -eu\nif [ \"$3\" = \"merge-base\" ]; then\n  exit 0\nfi\necho 'unexpected git invocation' >&2\nexit 1\n",
+        )
+        .expect("fake git script");
+        set_executable(&script_path);
+    }
+
+    fn set_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = fs::metadata(path)
+                .expect("metadata should exist")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).expect("permissions should update");
+        }
     }
 
     fn init_test_git_repository(path: &Path) {

--- a/src/command/relate.rs
+++ b/src/command/relate.rs
@@ -20,53 +20,53 @@ use crate::{
 use super::lookup::{EntitySummary, WorkspaceEntity, WorkspaceLookup};
 
 #[derive(Debug, Serialize)]
-struct JsonRelateOutput {
-    selection: SelectionSummary,
-    direct_matches: DirectMatches,
-    philosophies: Vec<RelatedNode>,
-    policies: Vec<RelatedNode>,
-    requirements: Vec<RelatedNode>,
-    features: Vec<RelatedNode>,
-    traces: Vec<RelatedTrace>,
-    gaps: Vec<Gap>,
+pub(crate) struct JsonRelateOutput {
+    pub(crate) selection: SelectionSummary,
+    pub(crate) direct_matches: DirectMatches,
+    pub(crate) philosophies: Vec<RelatedNode>,
+    pub(crate) policies: Vec<RelatedNode>,
+    pub(crate) requirements: Vec<RelatedNode>,
+    pub(crate) features: Vec<RelatedNode>,
+    pub(crate) traces: Vec<RelatedTrace>,
+    pub(crate) gaps: Vec<Gap>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct SelectionSummary {
-    kind: &'static str,
-    query: String,
+pub(crate) struct SelectionSummary {
+    pub(crate) kind: &'static str,
+    pub(crate) query: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
-struct DirectMatches {
-    definitions: Vec<RelatedNode>,
-    traces: Vec<RelatedTrace>,
+pub(crate) struct DirectMatches {
+    pub(crate) definitions: Vec<RelatedNode>,
+    pub(crate) traces: Vec<RelatedTrace>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct RelatedNode {
-    kind: &'static str,
-    id: String,
-    title: String,
-    document_path: String,
+pub(crate) struct RelatedNode {
+    pub(crate) kind: &'static str,
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) document_path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct RelatedTrace {
-    owner_kind: &'static str,
-    owner_id: String,
-    relation_kind: &'static str,
-    language: String,
-    file: String,
-    symbols: Vec<String>,
-    direct_match: bool,
+pub(crate) struct RelatedTrace {
+    pub(crate) owner_kind: &'static str,
+    pub(crate) owner_id: String,
+    pub(crate) relation_kind: &'static str,
+    pub(crate) language: String,
+    pub(crate) file: String,
+    pub(crate) symbols: Vec<String>,
+    pub(crate) direct_match: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct Gap {
-    kind: &'static str,
-    id: String,
-    message: String,
+pub(crate) struct Gap {
+    pub(crate) kind: &'static str,
+    pub(crate) id: String,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Clone)]
@@ -123,7 +123,10 @@ pub fn run_relate_command(args: &RelateArgs) -> Result<i32> {
     Ok(0)
 }
 
-fn build_relation_report(workspace: &Workspace, selector: &str) -> Result<JsonRelateOutput> {
+pub(crate) fn build_relation_report(
+    workspace: &Workspace,
+    selector: &str,
+) -> Result<JsonRelateOutput> {
     let lookup = WorkspaceLookup::new(workspace);
     let catalog = RelationCatalog::load(lookup)?;
     let selection = resolve_selection(workspace, lookup, &catalog, selector)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,9 @@ mod tests {
                     workspace: PathBuf::from("workspace"),
                     kind: HistoryKind::Definition,
                     path: Some(PathBuf::from("docs/syu/requirements")),
+                    include_related: true,
+                    merge_base_ref: Some("origin/main".to_string()),
+                    range: None,
                     limit: 5,
                     format: OutputFormat::Json,
                 })),
@@ -320,6 +323,9 @@ mod tests {
                 workspace,
                 kind,
                 path,
+                include_related,
+                merge_base_ref,
+                range,
                 limit,
                 format
             })
@@ -327,6 +333,9 @@ mod tests {
                     && workspace == Path::new("workspace")
                     && kind == HistoryKind::Definition
                     && path == Some(PathBuf::from("docs/syu/requirements"))
+                    && include_related
+                    && merge_base_ref.as_deref() == Some("origin/main")
+                    && range.is_none()
                     && limit == 5
                     && format == OutputFormat::Json
         ));

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -77,6 +77,9 @@ fn log_help_mentions_kind_path_and_json_output() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--kind"));
     assert!(stdout.contains("--path"));
+    assert!(stdout.contains("--include-related"));
+    assert!(stdout.contains("--merge-base-ref"));
+    assert!(stdout.contains("--range"));
     assert!(stdout.contains("--format"));
     assert!(stdout.contains("Philosophy, policy, requirement, or feature ID"));
     assert!(stdout.contains("syu log FEAT-CHECK-001 --kind implementation --path src/command"));

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -162,12 +162,21 @@ fn update_file(path: &Path, contents: &str) {
 }
 
 fn git_stdout(workspace: &Path, args: &[&str]) -> String {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(workspace)
-        .args(args)
-        .output()
-        .expect("git should run");
+    let mut command = Command::new("git");
+    command.arg("-C").arg(workspace).args(args);
+    for key in [
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_WORK_TREE",
+    ] {
+        command.env_remove(key);
+    }
+    let output = command.output().expect("git should run");
     assert!(
         output.status.success(),
         "git {:?} failed\nstdout:\n{}\nstderr:\n{}",

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -371,6 +371,55 @@ fn log_command_can_include_related_history_surface() {
 }
 
 #[test]
+fn log_command_keeps_related_definitions_when_path_scopes_code_history() {
+    let workspace = write_history_workspace();
+    update_file(
+        &workspace.path().join("docs/syu/features/cli/history.yaml"),
+        "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-001\n    title: Feature history lookup\n    summary: Feature history should show the traced implementation, linked requirement, and checked-in definition.\n    status: implemented\n    linked_requirements:\n      - REQ-HIST-001\n    implementations:\n      rust:\n        - file: src/history_feature.rs\n          symbols:\n            - feature_history\n",
+    );
+    git_commit(workspace.path(), "docs: refine related feature definition");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "REQ-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+            "--include-related",
+            "--path",
+            "src",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    let tracked_paths = json["tracked_paths"].as_array().expect("tracked paths");
+    assert!(tracked_paths.iter().any(|path| {
+        path["owner_id"] == "FEAT-HIST-001"
+            && path["kind"] == "definition"
+            && path["source"] == "related"
+            && path["path"] == "docs/syu/features/cli/history.yaml"
+    }));
+    let summaries = json["commits"]
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|commit| commit["summary"].as_str().expect("summary"))
+        .collect::<Vec<_>>();
+    assert!(summaries.contains(&"docs: refine related feature definition"));
+    assert!(summaries.contains(&"feat: update traced implementation"));
+}
+
+#[test]
 fn log_command_can_limit_history_to_an_explicit_range() {
     let workspace = write_history_workspace();
     let merge_base = git_stdout(workspace.path(), &["rev-parse", "HEAD~2"]);

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -161,6 +161,26 @@ fn update_file(path: &Path, contents: &str) {
     fs::write(path, contents).expect("file should update");
 }
 
+fn git_stdout(workspace: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .expect("git should run");
+    assert!(
+        output.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git output should be valid utf8")
+        .trim()
+        .to_string()
+}
+
 fn write_fake_git_for_log_failure(script_dir: &Path) {
     let script_path = script_dir.join("git");
     fs::write(
@@ -296,6 +316,101 @@ fn log_command_supports_json_kind_and_path_filters() {
         json["commits"][1]["summary"],
         "chore: initial history fixture"
     );
+}
+
+#[test]
+fn log_command_can_include_related_history_surface() {
+    let workspace = write_history_workspace();
+    update_file(
+        &workspace.path().join("docs/syu/features/cli/history.yaml"),
+        "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-001\n    title: Feature history lookup\n    summary: Feature history should show the traced implementation, linked requirement, and checked-in definition.\n    status: implemented\n    linked_requirements:\n      - REQ-HIST-001\n    implementations:\n      rust:\n        - file: src/history_feature.rs\n          symbols:\n            - feature_history\n",
+    );
+    git_commit(workspace.path(), "docs: refine related feature definition");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "REQ-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+            "--include-related",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(json["include_related"], true);
+    let tracked_paths = json["tracked_paths"].as_array().expect("tracked paths");
+    assert!(tracked_paths.iter().any(|path| {
+        path["owner_id"] == "FEAT-HIST-001"
+            && path["kind"] == "definition"
+            && path["source"] == "related"
+    }));
+    assert!(tracked_paths.iter().any(|path| {
+        path["owner_id"] == "FEAT-HIST-001"
+            && path["kind"] == "implementation"
+            && path["source"] == "related"
+    }));
+    let summaries = json["commits"]
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|commit| commit["summary"].as_str().expect("summary"))
+        .collect::<Vec<_>>();
+    assert!(summaries.contains(&"docs: refine related feature definition"));
+    assert!(summaries.contains(&"feat: update traced implementation"));
+}
+
+#[test]
+fn log_command_can_limit_history_to_an_explicit_range() {
+    let workspace = write_history_workspace();
+    let merge_base = git_stdout(workspace.path(), &["rev-parse", "HEAD~2"]);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "log",
+            "REQ-HIST-001",
+            workspace.path().to_str().expect("utf8 path"),
+            "--include-related",
+            "--range",
+            &format!("{merge_base}..HEAD"),
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    assert_eq!(
+        json["scope"]["label"],
+        format!("range `{merge_base}..HEAD`")
+    );
+    let summaries = json["commits"]
+        .as_array()
+        .expect("commit array")
+        .iter()
+        .map(|commit| commit["summary"].as_str().expect("summary"))
+        .collect::<Vec<_>>();
+    assert!(summaries.contains(&"test: adjust traced requirement coverage"));
+    assert!(summaries.contains(&"feat: update traced implementation"));
+    assert!(!summaries.contains(&"chore: initial history fixture"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add reviewer-oriented syu log options for related trace expansion and git-range scoping
- annotate matched history with the owning selected or related surface in text and JSON output
- document the new reviewer flow and extend log command coverage

Closes #488
