### PR TITLE
feat: add C# trace validation support (FEAT-CHECK-001, REQ-CORE-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ Key behaviors:
 - `validate.allow_planned` controls whether `planned` requirements and features are allowed at all
 - `validate.require_non_orphaned_items` turns isolated layered definitions into validation errors
 - `validate.require_reciprocal_links` keeps adjacent-layer backlinks mandatory by default while still allowing phased migration when disabled
-- `validate.require_symbol_trace_coverage` opt-in checks that public Rust, Python, Go, Java, and TypeScript/JavaScript symbols belong to features and tests belong to requirements, while still skipping configured repository-relative generated paths
+- `validate.require_symbol_trace_coverage` opt-in checks that public Rust, Python, Go, Java, C#, and TypeScript/JavaScript symbols belong to features and tests belong to requirements, while still skipping configured repository-relative generated paths
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence
 - `app.bind` and `app.port` define the default local browser-app address and port unless `--bind` / `--port` override them
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence
@@ -672,9 +672,10 @@ The repository ships working example projects:
 
 `docs-first`, `rust-only`, `python-only`, `go-only`, `java-only`, and
 `polyglot` match `syu init --template ...` starters directly.
-`csharp-fallback` remains the reference-only example for repositories whose
-main implementation language is still unsupported, and `team-scale` remains a
-reference-only example for studying a larger split-by-area repository shape.
+`csharp-fallback` remains the reference-only example for teams that want a
+lighter staged C# adoption path before tracing every C# symbol directly, and
+`team-scale` remains a reference-only example for studying a larger
+split-by-area repository shape.
 
 Each one is validated in the automated test suite. If you are deciding between a
 checked-in example and a scaffold template, start with

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -83,13 +83,13 @@ description: "Generated reference for docs/syu/config/validate.yaml"
 - **key**: validate.require_symbol_trace_coverage
   - **type**: boolean
   - **default**: False
-  - **summary**: Enforces ownership for public Rust, Python, Go, Java, and TypeScript/JavaScript symbols and tests.
+  - **summary**: Enforces ownership for public Rust, Python, Go, Java, C#, and TypeScript/JavaScript symbols and tests.
   - **description**:
     - |
-      When enabled, `syu` requires every public Rust, Python, Go, Java, and
-      TypeScript/JavaScript symbol to belong to some feature and every test in
-      those inventoried languages to belong to some requirement, in addition to
-      verifying declared traces. The
+      When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
+      and TypeScript/JavaScript symbol to belong to some feature and every
+      test in those inventoried languages to belong to some requirement, in
+      addition to verifying declared traces. The
       validate command can enable or disable this for one run with
       `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.
@@ -202,12 +202,12 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust, Python, Go, Java, and TypeScript/JavaScript symbols and tests.
+    summary: Enforces ownership for public Rust, Python, Go, Java, C#, and TypeScript/JavaScript symbols and tests.
     description: |
-      When enabled, `syu` requires every public Rust, Python, Go, Java, and
-      TypeScript/JavaScript symbol to belong to some feature and every test in
-      those inventoried languages to belong to some requirement, in addition to
-      verifying declared traces. The
+      When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
+      and TypeScript/JavaScript symbol to belong to some feature and every
+      test in those inventoried languages to belong to some requirement, in
+      addition to verifying declared traces. The
       validate command can enable or disable this for one run with
       `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.

--- a/docs/generated/site-spec/features/repository/contributor.md
+++ b/docs/generated/site-spec/features/repository/contributor.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/repository/contributor.y
 
 - **id**: FEAT-CONTRIB-001
   - **title**: Contributor devcontainer and example workspaces
-  - **summary**: Provide a ready-to-use contributor container and validated example projects, including unsupported-language adoption examples.
+  - **summary**: Provide a ready-to-use contributor container and validated example projects, including staged C# adoption examples.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-011
@@ -119,7 +119,7 @@ version: 1
 features:
   - id: FEAT-CONTRIB-001
     title: Contributor devcontainer and example workspaces
-    summary: Provide a ready-to-use contributor container and validated example projects, including unsupported-language adoption examples.
+    summary: Provide a ready-to-use contributor container and validated example projects, including staged C# adoption examples.
     status: implemented
     linked_requirements:
       - REQ-CORE-011

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -374,12 +374,12 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
   - **genre**: coverage
   - **severity**: error
   - **title**: Coverage inventory paths must be walkable
-  - **summary**: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+  - **summary**: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
   - **description**:
     - |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, and TypeScript/JavaScript source and test files. Generated-path
+      Java, C#, and TypeScript/JavaScript source and test files. Generated-path
       ignores keep common build output such as `build/`, `coverage/`, `dist/`,
       and `target/` out of the inventory without hiding authored nested paths
       like `src/build/`. If directory discovery fails, the inventory itself is
@@ -802,11 +802,11 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, and TypeScript/JavaScript source and test files. Generated-path
+      Java, C#, and TypeScript/JavaScript source and test files. Generated-path
       ignores keep common build output such as `build/`, `coverage/`, `dist/`,
       and `target/` out of the inventory without hiding authored nested paths
       like `src/build/`. If directory discovery fails, the inventory itself is

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -93,7 +93,7 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
     - |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, Go, Java, and TypeScript/JavaScript. A declared
+      today: Rust, Python, Go, Java, C#, and TypeScript/JavaScript. A declared
       trace is valid only when the file exists, the symbol exists, the trace
       path uses canonical repository-relative form, and any `doc_contains`
       snippets are present in the symbol documentation when the declared
@@ -106,11 +106,12 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       duplicate trace mappings inside a single language list, support wildcard
       file ownership, and provide an optional mode that requires every public
       symbol (non-underscore-prefixed for Python, exported identifiers for Go,
-      public Java types and members, `pub` for Rust, exported for
-      TypeScript/JavaScript) and every test symbol (`test_*` functions for
-      Python, `Test*`, `Benchmark*`, `Fuzz*`, and `Example*` functions in Go
-      `_test.go` files, JUnit `@Test` methods or legacy `test*` methods for
-      Java, `#[test]` for Rust, `test*`-prefixed functions for
+      public Java types and members, public C# types and members, `pub` for
+      Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `Test*`, `Benchmark*`, `Fuzz*`, and
+      `Example*` functions in Go `_test.go` files, JUnit `@Test` methods or
+      legacy `test*` methods for Java, xUnit/NUnit/MSTest-attributed methods
+      for C#, `#[test]` for Rust, `test*`-prefixed functions for
       TypeScript/JavaScript) in repository source and test roots to belong to
       some feature or requirement respectively. That inventory MUST ignore
       configured repository-relative generated paths, defaulting to common
@@ -315,7 +316,7 @@ requirements:
     description: |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, Go, Java, and TypeScript/JavaScript. A declared
+      today: Rust, Python, Go, Java, C#, and TypeScript/JavaScript. A declared
       trace is valid only when the file exists, the symbol exists, the trace
       path uses canonical repository-relative form, and any `doc_contains`
       snippets are present in the symbol documentation when the declared
@@ -328,11 +329,12 @@ requirements:
       duplicate trace mappings inside a single language list, support wildcard
       file ownership, and provide an optional mode that requires every public
       symbol (non-underscore-prefixed for Python, exported identifiers for Go,
-      public Java types and members, `pub` for Rust, exported for
-      TypeScript/JavaScript) and every test symbol (`test_*` functions for
-      Python, `Test*`, `Benchmark*`, `Fuzz*`, and `Example*` functions in Go
-      `_test.go` files, JUnit `@Test` methods or legacy `test*` methods for
-      Java, `#[test]` for Rust, `test*`-prefixed functions for
+      public Java types and members, public C# types and members, `pub` for
+      Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `Test*`, `Benchmark*`, `Fuzz*`, and
+      `Example*` functions in Go `_test.go` files, JUnit `@Test` methods or
+      legacy `test*` methods for Java, xUnit/NUnit/MSTest-attributed methods
+      for C#, `#[test]` for Rust, `test*`-prefixed functions for
       TypeScript/JavaScript) in repository source and test roots to belong to
       some feature or requirement respectively. That inventory MUST ignore
       configured repository-relative generated paths, defaulting to common

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -140,9 +140,9 @@ of editing `syu.yaml`.
 
 ### `validate.require_symbol_trace_coverage`
 
-When `true`, `syu` scans Rust, Python, Go, Java, and TypeScript/JavaScript source and
-test files to confirm that every public symbol belongs to some feature and
-every test belongs to some requirement.
+When `true`, `syu` scans Rust, Python, Go, Java, C#, and TypeScript/JavaScript
+source and test files to confirm that every public symbol belongs to some
+feature and every test belongs to some requirement.
 
 - `false`: only declared traces are verified
 - `true`: undeclared public APIs and tests become validation errors
@@ -153,11 +153,10 @@ coverage still skips configured repository-relative generated paths such as
 `build/`, `coverage/`, `dist/`, and `target/` so authored files nested under
 `src/` or `tests/` keep counting.
 For an experimental strict run, use `syu validate . --require-symbol-trace-coverage`.
-If part of the repository still depends on a language without a built-in
-adapter, keep strict coverage off there and borrow the starter shape from the
+If you want a gradual C# rollout, borrow the lighter starter shape from the
 [`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback).
-That example keeps the higher-layer spec and adjacent supported traces explicit
-without pretending unsupported `csharp:` mappings validate today. Use
+That example keeps the higher-layer spec and surrounding automation explicit
+without requiring every checked-in C# file to be traced immediately. Use
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 or `syu init . --template go-only` as a reminder that Go now supports
 symbol checks, coverage ownership, and `doc_contains`.

--- a/docs/guide/examples-and-templates.md
+++ b/docs/guide/examples-and-templates.md
@@ -25,7 +25,7 @@ whether you should scaffold a template or open one of the repository examples.
 
 | Path | Type | Best for | How to start |
 | --- | --- | --- | --- |
-| `csharp-fallback` | Example only | repositories whose main implementation language is still unsupported and need a truthful fallback reference | `examples/csharp-fallback` |
+| `csharp-fallback` | Example only | C#-heavy repositories that want a staged adoption path with spec-first traces before they trace every C# file directly | `examples/csharp-fallback` |
 | `docs-first` | Template + example | documentation-heavy repositories that want starter markdown acceptance anchors, one shell trace, and one wildcard-owned YAML file | `syu init . --template docs-first` or `examples/docs-first` |
 | `generic` | Template only | the shortest neutral scaffold when you do not want language-specific starter copy yet | `syu init .` |
 | `go-only` | Template + example | Go-first repositories that want starter IDs, file names, a minimal `go.mod`, and small Go source/test files from the first scaffold | `syu init . --template go-only` or `examples/go-only` |
@@ -68,9 +68,9 @@ scaffold wholesale.
 2. **I already know the repo is docs-first / Rust-first / Python-first / Go-first / Java-first / polyglot**: start
    with the matching template, then compare against the matching example when
    you want a fuller repository story.
-3. **My main implementation language is still unsupported**: open
-   `examples/csharp-fallback` first to study the fallback pattern before you
-   invent placeholder `csharp:` traces that will not validate.
+3. **I want a staged C# adoption path instead of tracing every C# file on day one**:
+   open `examples/csharp-fallback` first to study the lighter pattern before
+   you turn strict C# ownership on everywhere.
 4. **I am Go-first and want to inspect native Go tracing before I scaffold
    anything**: open `examples/go-only` first, then copy the shape you need into
    your own repository.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -192,7 +192,7 @@ For a genuinely mixed-language repository, keep the first adoption step small:
 - keep unsupported implementation-language areas connected through the spec
   layers until adapter support lands
 - turn stricter symbol coverage on later for the supported implementation
-  languages you are tracing (Rust, Python, Go, Java, or
+  languages you are tracing (Rust, Python, Go, Java, C#, or
   TypeScript/JavaScript) once those traces are stable
 
 That keeps the repository connected to the spec from day one without forcing a
@@ -204,17 +204,17 @@ until you are ready to declare real tests and implementation traces.
 
 ### Unsupported implementation languages can still adopt the spec layers first
 
-`syu` can validate code-level traces today in Rust, Python, Go, Java, and
+`syu` can validate code-level traces today in Rust, Python, Go, Java, C#, and
 TypeScript/JavaScript, plus lighter file/symbol ownership in `shell`, `yaml`,
-`json`, `markdown`, and `gitignore`. Repositories that are mostly C# or another
-unsupported implementation language can still adopt `syu` today, but they
+`json`, `markdown`, and `gitignore`. Repositories that still contain other
+unsupported implementation languages can still adopt `syu` today, but they
 should treat code-level mappings for those files as future work.
 
-Go and Java already have built-in symbol validation and participate in strict
+Go, Java, and C# already participate in strict
 `validate.require_symbol_trace_coverage` inventory. Go now supports
-`doc_contains` checks as well, while Java still stops at symbol validation. The
-[trace adapter capability matrix](./trace-adapter-support.md) summarizes that
-language-by-language support.
+`doc_contains` checks as well, while Java and C# still stop at symbol
+validation. The [trace adapter capability matrix](./trace-adapter-support.md)
+summarizes that language-by-language support.
 
 Today you can still:
 
@@ -248,10 +248,9 @@ implementations:
 ```
 
 What you should avoid for unsupported-language files today is adding
-language-specific `tests:` or `implementations:` entries such as `csharp:`.
-Those keys still fail validation before `doc_contains` support even becomes
-relevant. If you need code-level tracing immediately with `doc_contains`, stay
-with Rust, Python, Go, or TypeScript/JavaScript for now. For Go-first repositories,
+language-specific `tests:` or `implementations:` entries before the adapter
+exists at all. If you need code-level tracing with `doc_contains`, stay with
+Rust, Python, Go, or TypeScript/JavaScript for now. For Go-first repositories,
 use [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 or `syu init . --template go-only`: both use real Go files plus symbol-level
 trace mappings that validate today.
@@ -260,9 +259,9 @@ For Java-first repositories, use
 or `syu init . --template java-only`: both use real Java files plus
 symbol-level trace mappings that validate today, even though `doc_contains`
 is still out of scope for Java.
-For unsupported-language repositories, use the
+For C#-first repositories that want a staged rollout, use the
 [`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback)
-to study the fallback pattern.
+to study the lighter adoption pattern before tracing every C# file directly.
 
 Keep this adoption path in mind for mixed-language repositories too: start with
 declared traces, keep `validate.require_symbol_trace_coverage: false`, then turn
@@ -270,12 +269,9 @@ strict coverage on later for the languages `syu` can already scan deeply.
 
 When `SYU-trace-docsupport-001` fires, read it as “this mapping can stay, but
 without `doc_contains`, only if the language adapter already exists.” That
-works for `go`, `java`, `shell`, `yaml`, `json`, `markdown`, and `gitignore`;
-it does not bypass `SYU-trace-language-001` for C#.
-
-Language-support roadmap:
-
-- [C# trace validation and symbol ownership (#314)](https://github.com/ugoite/syu/issues/314)
+works for `csharp`, `go`, `java`, `shell`, `yaml`, `json`, `markdown`, and
+`gitignore`; it does not bypass `SYU-trace-language-001` for truly unsupported
+languages.
 
 Not sure whether you should scaffold a template or study a working repository
 first? Use the [examples and templates guide](./examples-and-templates.md) to

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -22,6 +22,7 @@ enable strict coverage in a mixed-language repository.
 | Python | `python`, `py`, `pytest`, `unittest` / `.py` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
 | Go | `go`, `golang`, `gotest` / `.go` | ✅ Rich doc-comment inspection plus pattern fallback | ✅ | ✅ |
 | Java | `java`, `junit` / `.java` | ✅ Pattern-based symbol matching | ❌ | ✅ |
+| C# | `csharp`, `cs`, `dotnet`, `xunit`, `nunit`, `mstest` / `.cs` | ✅ Pattern-based symbol matching | ❌ | ✅ |
 | TypeScript / JavaScript | `typescript`, `ts`, `tsx`, `javascript`, `js`, `jsx`, `vitest`, `bun`, `bun-test` / `.ts`, `.tsx`, `.js`, `.jsx` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
 | Shell | `shell`, `sh`, `bash`, `zsh` / `.sh`, `.bash`, `.zsh` | ✅ Pattern-based symbol matching | ❌ | ❌ |
 | YAML | `yaml`, `yml` / `.yaml`, `.yml` | ✅ Pattern-based symbol matching | ❌ | ❌ |
@@ -43,6 +44,10 @@ builds ownership inventories for these languages only:
 - **Java** — public classes/interfaces/enums/records plus public or implicit
   interface members in `src/`, plus JUnit `@Test` methods and legacy `test...`
   methods in `tests/`
+- **C#** — public classes/interfaces/enums/records/structs plus public or
+  implicit interface members in `src/`, plus xUnit/NUnit/MSTest-style test
+  methods marked with attributes such as `[Fact]`, `[Theory]`, `[Test]`, and
+  `[TestMethod]` in `tests/`
 - **TypeScript / JavaScript** — exported symbols in `src/`, plus `test...` and
   `Test...` symbols in `tests/`
 
@@ -52,7 +57,7 @@ they do **not** participate in the repository-wide strict ownership scan.
 ## How to choose the right promises
 
 - Need `doc_contains`? Rust, Python, Go, and TypeScript / JavaScript traces all support it today.
-- Need strict ownership coverage? Rust, Python, Go, Java, and
+- Need strict ownership coverage? Rust, Python, Go, Java, C#, and
   TypeScript / JavaScript all participate today.
 - Using Shell, YAML, JSON, Markdown, or Gitignore traces? Keep the mapping to
   `file` + `symbols` (or `symbols: ["*"]` when one file intentionally belongs
@@ -68,7 +73,7 @@ because `symbols: ["*"]` does not point to one inspectable symbol.
 
 ## What about unsupported languages?
 
-Unsupported adapters such as `csharp` still raise `SYU-trace-language-001`.
+Unsupported adapters such as `kotlin` still raise `SYU-trace-language-001`.
 Keep those repositories connected through the spec layers first, and only add
 language-specific code traces once adapter support lands.
 If you need a Go-first starting point today, study the
@@ -81,8 +86,8 @@ If you need a Java-first starting point today, study the
 or scaffold `syu init . --template java-only`. Both keep real Java files in the
 repository while validating explicit symbol mappings, but Java traces should
 still stay with `file` plus `symbols` because `doc_contains` is not supported yet.
-If you need a concrete fallback shape today, study the
+If you want a concrete staged C# adoption shape today, study the
 [`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback).
 It keeps real C# files in the repository while validating supported shell and
-markdown evidence around them instead of inventing unsupported `csharp:` trace
-keys.
+markdown evidence around them before you decide how aggressively to trace the
+rest of the C# codebase.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -238,8 +238,8 @@ current name.
 ### `SYU-trace-language-001` — unsupported trace adapter
 
 **What it means:** The `lang:` key does not match any built-in adapter. Today
-`syu` ships Rust, Python, TypeScript / JavaScript, Shell, YAML, JSON, Markdown,
-and Gitignore adapters.
+`syu` ships Rust, Python, Go, Java, C#, TypeScript / JavaScript, Shell, YAML,
+JSON, Markdown, and Gitignore adapters.
 
 **Fix:** Change the trace to one of those built-in language aliases, or check
 the [trace adapter capability matrix](./trace-adapter-support.md) before you
@@ -293,15 +293,15 @@ implementations:
 ```
 
 Use that lighter mapping until the language gains richer inspection support.
-If the mapping uses an unsupported implementation language such as `csharp`,
+If the mapping uses an unsupported implementation language such as `kotlin`,
 removing `doc_contains` is not enough: those entries still raise
 `SYU-trace-language-001`. Keep the higher-layer spec link in place and wait for
 adapter support before adding the code-level trace.
 The
 [`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback)
-shows one concrete unsupported-language starting point that keeps real C#
-source files in the repository while validated traces stay in supported shell
-and markdown files. The
+shows one concrete staged C# starting point that keeps real C# source files in
+the repository while validated traces stay in supported shell and markdown
+files until you are ready to trace more C# directly. The
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 and `syu init . --template go-only` remain the concrete Go-first path with real
 source files plus symbol-level trace mappings.

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -58,12 +58,12 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust, Python, Go, Java, and TypeScript/JavaScript symbols and tests.
+    summary: Enforces ownership for public Rust, Python, Go, Java, C#, and TypeScript/JavaScript symbols and tests.
     description: |
-      When enabled, `syu` requires every public Rust, Python, Go, Java, and
-      TypeScript/JavaScript symbol to belong to some feature and every test in
-      those inventoried languages to belong to some requirement, in addition to
-      verifying declared traces. The
+      When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
+      and TypeScript/JavaScript symbol to belong to some feature and every
+      test in those inventoried languages to belong to some requirement, in
+      addition to verifying declared traces. The
       validate command can enable or disable this for one run with
       `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.

--- a/docs/syu/features/repository/contributor.yaml
+++ b/docs/syu/features/repository/contributor.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-CONTRIB-001
     title: Contributor devcontainer and example workspaces
-    summary: Provide a ready-to-use contributor container and validated example projects, including unsupported-language adoption examples.
+    summary: Provide a ready-to-use contributor container and validated example projects, including staged C# adoption examples.
     status: implemented
     linked_requirements:
       - REQ-CORE-011

--- a/docs/syu/features/validation/validation.yaml
+++ b/docs/syu/features/validation/validation.yaml
@@ -363,11 +363,11 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, and TypeScript/JavaScript source and test files. Generated-path
+      Java, C#, and TypeScript/JavaScript source and test files. Generated-path
       ignores keep common build output such as `build/`, `coverage/`, `dist/`,
       and `target/` out of the inventory without hiding authored nested paths
       like `src/build/`. If directory discovery fails, the inventory itself is

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -75,7 +75,7 @@ requirements:
     description: |
       The `validate` command MUST verify requirement-to-test and
       feature-to-implementation traceability in the languages used by `syu`
-      today: Rust, Python, Go, Java, and TypeScript/JavaScript. A declared
+      today: Rust, Python, Go, Java, C#, and TypeScript/JavaScript. A declared
       trace is valid only when the file exists, the symbol exists, the trace
       path uses canonical repository-relative form, and any `doc_contains`
       snippets are present in the symbol documentation when the declared
@@ -88,11 +88,12 @@ requirements:
       duplicate trace mappings inside a single language list, support wildcard
       file ownership, and provide an optional mode that requires every public
       symbol (non-underscore-prefixed for Python, exported identifiers for Go,
-      public Java types and members, `pub` for Rust, exported for
-      TypeScript/JavaScript) and every test symbol (`test_*` functions for
-      Python, `Test*`, `Benchmark*`, `Fuzz*`, and `Example*` functions in Go
-      `_test.go` files, JUnit `@Test` methods or legacy `test*` methods for
-      Java, `#[test]` for Rust, `test*`-prefixed functions for
+      public Java types and members, public C# types and members, `pub` for
+      Rust, exported for TypeScript/JavaScript) and every test symbol
+      (`test_*` functions for Python, `Test*`, `Benchmark*`, `Fuzz*`, and
+      `Example*` functions in Go `_test.go` files, JUnit `@Test` methods or
+      legacy `test*` methods for Java, xUnit/NUnit/MSTest-attributed methods
+      for C#, `#[test]` for Rust, `test*`-prefixed functions for
       TypeScript/JavaScript) in repository source and test roots to belong to
       some feature or requirement respectively. That inventory MUST ignore
       configured repository-relative generated paths, defaulting to common

--- a/examples/csharp-fallback/README.md
+++ b/examples/csharp-fallback/README.md
@@ -1,12 +1,13 @@
 # csharp-fallback example
 
-This example demonstrates the current fallback pattern for a repository whose
-main application language still does not have a built-in `syu` trace adapter.
+This example demonstrates a lighter staged adoption pattern for a repository
+whose main application language is C#, even when the team is not ready to trace
+every C# file directly yet.
 
-It keeps a real C# source file and test file in the repository, but it does
-not add unsupported `csharp:` trace mappings yet. Instead, the example keeps
-the higher-layer spec links explicit and validates the surrounding automation in
-supported lightweight adapters.
+It keeps a real C# source file and test file in the repository, but it does not
+trace those C# files directly yet. Instead, the example keeps the higher-layer
+spec links explicit and validates the surrounding automation in supported
+lightweight adapters.
 
 ## Files
 
@@ -17,9 +18,9 @@ supported lightweight adapters.
 | `docs/syu/requirements/core/csharp.yaml` | `REQ-CSHARP-001` with a markdown-backed acceptance anchor |
 | `docs/syu/features/languages/csharp.yaml` | `FEAT-CSHARP-001` with a shell-backed implementation trace |
 | `scripts/check-workspace.sh` | shell implementation containing `verify_spec_links` |
-| `src/OrderSummary.cs` | real C# source kept visible but intentionally untraced for now |
-| `tests/OrderSummaryTests.cs` | real C# test kept visible but intentionally untraced for now |
-| `README.md` | explains why the C# files are not traced directly yet |
+| `src/OrderSummary.cs` | real C# source kept visible while the example focuses on surrounding workflow traces first |
+| `tests/OrderSummaryTests.cs` | real C# test kept visible while the example focuses on surrounding workflow traces first |
+| `README.md` | explains why the example delays direct C# tracing |
 
 ## Try it
 
@@ -42,22 +43,22 @@ traceability: requirements=1/1 traces validated; features=1/1 traces validated
 
 ## CsharpFallbackAcceptanceChecklist
 
-- `REQ-CSHARP-001` expects unsupported-language repositories to keep the spec
-  layers explicit from the first commit.
+- `REQ-CSHARP-001` expects staged-adoption repositories to keep the spec layers
+  explicit from the first commit.
 - `FEAT-CSHARP-001` traces the supporting shell workflow with the named
   `verify_spec_links` symbol.
-- The checked-in C# files stay visible to contributors, but this example does
-  **not** add `tests.csharp` or `implementations.csharp` entries yet because
-  those mappings still fail with `SYU-trace-language-001`.
+- The checked-in C# files stay visible to contributors, but this example
+  intentionally delays `tests.csharp` and `implementations.csharp` entries so
+  the lighter adoption path stays obvious.
 
 ## Key things to notice
 
-- **Real unsupported-language files still belong in the repository** — `syu`
-  can help the team connect intent and workflow before the language adapter
-  exists.
+- **Real C# files still belong in the repository even before full tracing** —
+  `syu` can help the team connect intent and workflow before they trace every
+  code symbol directly.
 - **Supported lightweight traces are the bridge** — shell and markdown keep the
-  repository mechanically connected to the spec while code-level C# traces wait
-  for native support.
+  repository mechanically connected to the spec while code-level C# traces roll
+  out more gradually.
 - **Go is no longer the workaround** — use `examples/go-only` when you want the
-  built-in Go adapter, and use this example when your main implementation
-  language is still unsupported.
+  built-in Go adapter, and use this example when you want a lighter C#-first
+  rollout.

--- a/examples/csharp-fallback/docs/syu/features/languages/csharp.yaml
+++ b/examples/csharp-fallback/docs/syu/features/languages/csharp.yaml
@@ -3,8 +3,8 @@ version: 1
 
 features:
   - id: FEAT-CSHARP-001
-    title: Trace the fallback workflow through an explicit shell symbol
-    summary: Demonstrate one concrete implementation trace that keeps the unsupported-language repository connected to the spec.
+    title: Trace the staged workflow through an explicit shell symbol
+    summary: Demonstrate one concrete implementation trace that keeps the staged C# repository connected to the spec.
     status: implemented
     linked_requirements:
       - REQ-CSHARP-001

--- a/examples/csharp-fallback/docs/syu/philosophy/foundation.yaml
+++ b/examples/csharp-fallback/docs/syu/philosophy/foundation.yaml
@@ -4,8 +4,8 @@ language: en
 
 philosophies:
   - id: PHIL-CSHARP-001
-    title: Unsupported-language repositories should still connect intent to reviewable evidence
-    product_design_principle: Keep the unsupported-language example honest about current adapter limits while still showing a low-friction adoption path.
-    coding_guideline: Trace the surrounding docs and automation with supported adapters until native language support lands.
+    title: Staged C# repositories should still connect intent to reviewable evidence
+    product_design_principle: Keep the staged-adoption example honest about what is already traced while still showing a low-friction C# path.
+    coding_guideline: Trace the surrounding docs and automation with supported adapters before tracing every C# file directly.
     linked_policies:
       - POL-CSHARP-001

--- a/examples/csharp-fallback/docs/syu/policies/policies.yaml
+++ b/examples/csharp-fallback/docs/syu/policies/policies.yaml
@@ -4,9 +4,9 @@ language: en
 
 policies:
   - id: POL-CSHARP-001
-    title: Unsupported-language adoption should keep real code visible without pretending it is traced already
-    summary: Demonstrate the fallback pattern for a C#-backed repository by validating supported shell and markdown evidence first.
-    description: Require the example to ship real C# source and test files while validated trace evidence stays in supported file types until a native adapter exists.
+    title: Staged C# adoption should keep real code visible without pretending it is traced already
+    summary: Demonstrate a lighter C# adoption pattern by validating supported shell and markdown evidence first.
+    description: Require the example to ship real C# source and test files while validated trace evidence stays in supported file types until the repository is ready to trace more C# directly.
     linked_philosophies:
       - PHIL-CSHARP-001
     linked_requirements:

--- a/examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml
+++ b/examples/csharp-fallback/docs/syu/requirements/core/csharp.yaml
@@ -3,8 +3,8 @@ prefix: REQ-CSHARP
 
 requirements:
   - id: REQ-CSHARP-001
-    title: Unsupported-language repositories should be able to adopt syu without fake code-level traces
-    description: The fallback example should keep real C# files in the repository while validating supported evidence around them.
+    title: C# repositories should be able to adopt syu without tracing every code file immediately
+    description: The staged-adoption example should keep real C# files in the repository while validating supported evidence around them.
     priority: high
     status: implemented
     linked_policies:

--- a/examples/csharp-fallback/scripts/check-workspace.sh
+++ b/examples/csharp-fallback/scripts/check-workspace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 verify_spec_links() {
-  printf '%s\n' "verifying spec links before the unsupported-language code grows"
+  printf '%s\n' "verifying spec links before the staged C# traces grow"
 }
 
 verify_spec_links

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -1303,7 +1303,7 @@ mod tests {
                 .iter()
                 .any(|source| source.section == SectionKind::Features)
         );
-        assert_eq!(payload.validation.definition_counts.features, 5);
+        assert_eq!(payload.validation.definition_counts.features, 6);
     }
 
     #[test]

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -3674,9 +3674,9 @@ mod tests {
         let mut entry = requirement("REQ-1");
         entry.status = "proposed".to_string();
         entry.tests.insert(
-            "csharp".to_string(),
+            "kotlin".to_string(),
             vec![TraceReference {
-                file: PathBuf::from("Trace.cs"),
+                file: PathBuf::from("Trace.kt"),
                 symbols: vec!["trace".to_string()],
                 doc_contains: Vec::new(),
             }],
@@ -3864,7 +3864,7 @@ mod tests {
     #[test]
     fn verify_trace_reference_reports_unsupported_languages() {
         let reference = TraceReference {
-            file: PathBuf::from("Trace.cs"),
+            file: PathBuf::from("Trace.kt"),
             symbols: vec!["main".to_string()],
             doc_contains: Vec::new(),
         };
@@ -3874,7 +3874,7 @@ mod tests {
             &SyuConfig::default(),
             "REQ-1",
             TraceRole::RequirementTest,
-            "csharp",
+            "kotlin",
             &reference,
             &mut issues,
         ));

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -36,32 +36,43 @@ struct CoverageMap {
     wildcard_files: BTreeSet<PathBuf>,
 }
 
+type DiscoveryFn = fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>;
+
+#[derive(Clone, Copy)]
+struct CoverageDiscoverers {
+    rust: DiscoveryFn,
+    python: DiscoveryFn,
+    go: DiscoveryFn,
+    java: DiscoveryFn,
+    csharp: DiscoveryFn,
+    typescript: DiscoveryFn,
+}
+
 pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Issue>) {
     validate_symbol_trace_coverage_with(
         workspace,
         issues,
-        discover_rust_targets,
-        discover_python_targets,
-        discover_go_targets,
-        discover_java_targets,
-        discover_typescript_targets,
+        CoverageDiscoverers {
+            rust: discover_rust_targets,
+            python: discover_python_targets,
+            go: discover_go_targets,
+            java: discover_java_targets,
+            csharp: discover_csharp_targets,
+            typescript: discover_typescript_targets,
+        },
     );
 }
 
 fn validate_symbol_trace_coverage_with(
     workspace: &Workspace,
     issues: &mut Vec<Issue>,
-    rust_discovery: impl Fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>,
-    python_discovery: impl Fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>,
-    go_discovery: impl Fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>,
-    java_discovery: impl Fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>,
-    ts_discovery: impl Fn(&SyuConfig, &Path) -> Result<Vec<CoverageTarget>, Box<Issue>>,
+    discoverers: CoverageDiscoverers,
 ) {
     if !workspace.config.validate.require_symbol_trace_coverage {
         return;
     }
 
-    let mut targets = match rust_discovery(&workspace.config, &workspace.root) {
+    let mut targets = match (discoverers.rust)(&workspace.config, &workspace.root) {
         Ok(targets) => targets,
         Err(issue) => {
             issues.push(*issue);
@@ -69,7 +80,7 @@ fn validate_symbol_trace_coverage_with(
         }
     };
 
-    match python_discovery(&workspace.config, &workspace.root) {
+    match (discoverers.python)(&workspace.config, &workspace.root) {
         Ok(python_targets) => targets.extend(python_targets),
         Err(issue) => {
             issues.push(*issue);
@@ -77,7 +88,7 @@ fn validate_symbol_trace_coverage_with(
         }
     }
 
-    match go_discovery(&workspace.config, &workspace.root) {
+    match (discoverers.go)(&workspace.config, &workspace.root) {
         Ok(go_targets) => targets.extend(go_targets),
         Err(issue) => {
             issues.push(*issue);
@@ -85,7 +96,7 @@ fn validate_symbol_trace_coverage_with(
         }
     }
 
-    match java_discovery(&workspace.config, &workspace.root) {
+    match (discoverers.java)(&workspace.config, &workspace.root) {
         Ok(java_targets) => targets.extend(java_targets),
         Err(issue) => {
             issues.push(*issue);
@@ -93,7 +104,15 @@ fn validate_symbol_trace_coverage_with(
         }
     }
 
-    match ts_discovery(&workspace.config, &workspace.root) {
+    match (discoverers.csharp)(&workspace.config, &workspace.root) {
+        Ok(csharp_targets) => targets.extend(csharp_targets),
+        Err(issue) => {
+            issues.push(*issue);
+            return;
+        }
+    }
+
+    match (discoverers.typescript)(&workspace.config, &workspace.root) {
         Ok(ts_targets) => targets.extend(ts_targets),
         Err(issue) => {
             issues.push(*issue);
@@ -790,6 +809,15 @@ fn is_go_test_file(path: &Path) -> bool {
         .is_some_and(|name| name.ends_with("_test.go"))
 }
 
+fn is_csharp_test_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with("Tests.cs") || name.ends_with("Test.cs"))
+        || path
+            .components()
+            .any(|component| component.as_os_str().eq_ignore_ascii_case("tests"))
+}
+
 fn discover_java_targets(
     config: &SyuConfig,
     root: &Path,
@@ -827,6 +855,78 @@ fn discover_java_targets(
         }
 
         for symbol in collect_java_public_symbols(&contents) {
+            targets.push(CoverageTarget {
+                file: relative.clone(),
+                symbol,
+                kind: CoverageTargetKind::PublicSymbol,
+            });
+        }
+    }
+
+    targets.sort_by(|left, right| {
+        (
+            left.file.as_os_str(),
+            left.symbol.as_str(),
+            match left.kind {
+                CoverageTargetKind::PublicSymbol => 0,
+                CoverageTargetKind::TestSymbol => 1,
+            },
+        )
+            .cmp(&(
+                right.file.as_os_str(),
+                right.symbol.as_str(),
+                match right.kind {
+                    CoverageTargetKind::PublicSymbol => 0,
+                    CoverageTargetKind::TestSymbol => 1,
+                },
+            ))
+    });
+    targets.dedup();
+
+    Ok(targets)
+}
+
+fn discover_csharp_targets(
+    config: &SyuConfig,
+    root: &Path,
+) -> Result<Vec<CoverageTarget>, Box<Issue>> {
+    let ignored_paths = normalized_symbol_trace_coverage_ignored_paths(config);
+    let mut files = csharp_files_under(root, &root.join("src"), &ignored_paths)?;
+    files.extend(csharp_files_under(
+        root,
+        &root.join("tests"),
+        &ignored_paths,
+    )?);
+    files.sort();
+
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut targets = Vec::new();
+    for path in files {
+        let contents = match fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(_) => continue,
+        };
+
+        let relative = path
+            .strip_prefix(root)
+            .expect("scanned file should remain under the workspace root")
+            .to_path_buf();
+
+        if is_csharp_test_file(&path) {
+            for symbol in collect_csharp_test_symbols(&contents) {
+                targets.push(CoverageTarget {
+                    file: relative.clone(),
+                    symbol,
+                    kind: CoverageTargetKind::TestSymbol,
+                });
+            }
+            continue;
+        }
+
+        for symbol in collect_csharp_public_symbols(&contents) {
             targets.push(CoverageTarget {
                 file: relative.clone(),
                 symbol,
@@ -924,6 +1024,123 @@ fn collect_java_test_symbols(contents: &str) -> Vec<String> {
     symbols.into_iter().collect()
 }
 
+fn collect_csharp_public_symbols(contents: &str) -> Vec<String> {
+    let type_regex = Regex::new(
+        r"(?m)^\s*public\s+(?:sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|interface|enum|record|struct)\s+(?P<name>[A-Z][A-Za-z0-9_]*)\b",
+    )
+    .expect("C# type regex should compile");
+    let method_regex = Regex::new(
+        r"(?m)^\s*public\s+(?:static\s+)?(?:sealed\s+|override\s+|virtual\s+|abstract\s+|async\s+|partial\s+|new\s+)*(?:<[^>{}]+>\s*)?(?:[\w\[\]<>?,.]+\s+)+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    )
+    .expect("C# method regex should compile");
+    let constructor_regex = Regex::new(r"(?m)^\s*public\s+(?P<name>[A-Z][A-Za-z0-9_]*)\s*\(")
+        .expect("C# constructor regex should compile");
+    let property_regex = Regex::new(
+        r"(?m)^\s*public\s+(?:static\s+)?(?:[\w\[\]<>?,.]+\s+)+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:\{|=>)",
+    )
+    .expect("C# property regex should compile");
+    let field_regex = Regex::new(
+        r"(?m)^\s*public\s+(?:static\s+)?(?:readonly\s+|const\s+)?(?:[\w\[\]<>?,.]+\s+)+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|;)",
+    )
+    .expect("C# field regex should compile");
+
+    let mut symbols = BTreeSet::new();
+    for captures in type_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for captures in method_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for captures in constructor_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for captures in property_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for captures in field_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for symbol in collect_csharp_public_interface_members(contents) {
+        symbols.insert(symbol);
+    }
+    symbols.into_iter().collect()
+}
+
+fn collect_csharp_test_symbols(contents: &str) -> Vec<String> {
+    let attribute_regex = Regex::new(
+        r"(?ms)\[(?:[\w.]+\.)?(?:Fact|Theory|Test|TestCase|TestCaseSource|TestMethod|DataTestMethod)(?:Attribute)?(?:\s*\([^)]*\))?\s*\](?:(?:\s*//[^\n]*)?\s*(?:\r?\n\s*)*(?:\[[^\]]+\]\s*)*)*(?:public|internal|protected|private)\s+(?:async\s+)?(?:Task|ValueTask|void)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    )
+    .expect("C# test attribute regex should compile");
+    let legacy_regex = Regex::new(
+        r"(?m)^\s*public\s+(?:async\s+)?(?:Task|ValueTask|void)\s+(?P<name>Test[A-Za-z0-9_]*)\s*\(",
+    )
+    .expect("C# legacy test regex should compile");
+
+    let mut symbols = BTreeSet::new();
+    for captures in attribute_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    for captures in legacy_regex.captures_iter(contents) {
+        if let Some(name) = captures.name("name") {
+            symbols.insert(name.as_str().to_string());
+        }
+    }
+    symbols.into_iter().collect()
+}
+
+fn collect_csharp_public_interface_members(contents: &str) -> Vec<String> {
+    let interface_start_regex =
+        Regex::new(r"(?m)^\s*public\s+(?:partial\s+)?interface\s+[A-Z][A-Za-z0-9_]*\b[^{]*\{")
+            .expect("C# interface regex should compile");
+    let method_regex =
+        Regex::new(r"^\s*(?:async\s+)?(?:[\w\[\]<>?,.]+\s+)+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(")
+            .expect("C# interface method regex should compile");
+    let property_regex =
+        Regex::new(r"^\s*(?:[\w\[\]<>?,.]+\s+)+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:\{|=>)")
+            .expect("C# interface property regex should compile");
+
+    let mut symbols = BTreeSet::new();
+    for mat in interface_start_regex.find_iter(contents) {
+        let body_start = mat.end() - 1;
+        let Some(body_end) = find_matching_brace(contents, body_start) else {
+            continue;
+        };
+        let body = &contents[body_start + 1..body_end];
+        let top_level = collect_java_top_level_lines(body);
+        for line in top_level.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("private ") || trimmed.is_empty() {
+                continue;
+            }
+            if let Some(captures) = method_regex.captures(trimmed) {
+                if let Some(name) = captures.name("name") {
+                    symbols.insert(name.as_str().to_string());
+                }
+                continue;
+            }
+            if let Some(captures) = property_regex.captures(trimmed)
+                && let Some(name) = captures.name("name")
+            {
+                symbols.insert(name.as_str().to_string());
+            }
+        }
+    }
+
+    symbols.into_iter().collect()
+}
+
 fn collect_java_public_interface_members(contents: &str) -> Vec<String> {
     let interface_start_regex = Regex::new(
         r"(?m)^\s*public\s+(?:sealed\s+|non-sealed\s+)?interface\s+[A-Z][A-Za-z0-9_]*\b[^{]*\{",
@@ -1015,6 +1232,32 @@ fn java_files_under(
 
     let mut files = Vec::new();
     collect_files_recursive_by_extension(workspace_root, root, "java", ignored_paths, &mut files)
+        .map_err(|error| {
+            Box::new(Issue::error(
+                "SYU-coverage-walk-001",
+                "trace coverage inventory",
+                Some(root.display().to_string()),
+                format!(
+                    "Failed to walk `{}` while building trace coverage inventory: {error}",
+                    root.display()
+                ),
+                Some("Fix the directory layout or disable `validate.require_symbol_trace_coverage` until the workspace can be scanned.".to_string()),
+            ))
+        })?;
+    Ok(files)
+}
+
+fn csharp_files_under(
+    workspace_root: &Path,
+    root: &Path,
+    ignored_paths: &BTreeSet<PathBuf>,
+) -> Result<Vec<PathBuf>, Box<Issue>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_files_recursive_by_extension(workspace_root, root, "cs", ignored_paths, &mut files)
         .map_err(|error| {
             Box::new(Issue::error(
                 "SYU-coverage-walk-001",
@@ -1179,11 +1422,13 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        CoverageTargetKind, collect_feature_coverage, collect_files_recursive_by_extension,
-        collect_go_public_symbols, collect_go_test_symbols, collect_java_public_symbols,
-        collect_java_test_symbols, collect_requirement_coverage, discover_go_targets,
-        discover_java_targets, discover_python_targets, discover_rust_targets,
-        discover_typescript_targets, go_files_under, java_files_under, normalize_relative_path,
+        CoverageDiscoverers, CoverageTargetKind, collect_csharp_public_symbols,
+        collect_csharp_test_symbols, collect_feature_coverage,
+        collect_files_recursive_by_extension, collect_go_public_symbols, collect_go_test_symbols,
+        collect_java_public_symbols, collect_java_test_symbols, collect_requirement_coverage,
+        discover_csharp_targets, discover_go_targets, discover_java_targets,
+        discover_python_targets, discover_rust_targets, discover_typescript_targets,
+        go_files_under, java_files_under, normalize_relative_path,
         normalized_symbol_trace_coverage_ignored_paths, path_matches_ignored_generated_directory,
         python_files_under, rust_files_under, typescript_files_under,
         validate_symbol_trace_coverage, validate_symbol_trace_coverage_with,
@@ -1542,6 +1787,98 @@ mod tests {
         );
 
         assert_eq!(symbols, vec!["BrokenTrace"]);
+    }
+
+    #[test]
+    fn discover_csharp_targets_collects_public_symbols_and_tests() {
+        let tempdir = tempdir().expect("tempdir");
+        fs::create_dir_all(tempdir.path().join("src")).expect("src");
+        fs::create_dir_all(tempdir.path().join("tests")).expect("tests");
+        fs::write(
+            tempdir.path().join("src/FeatureTrace.cs"),
+            "public interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n    void FeatureTraceCSharp();\n}\npublic record FeatureTraceRecord(string Value);\npublic class FeatureTraceService {\n    public const string TraceLabel = \"ok\";\n    public Task FeatureTraceAsync() => Task.CompletedTask;\n    private void HiddenHelper() {}\n}\n",
+        )
+        .expect("csharp source");
+        fs::write(
+            tempdir.path().join("tests/TraceabilityTests.cs"),
+            "using Xunit;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpTest() {}\n\n    [Theory]\n    public async Task ReqTraceCSharpTheory() => await Task.CompletedTask;\n\n    public void HelperCase() {}\n}\n",
+        )
+        .expect("csharp tests");
+
+        let targets =
+            discover_csharp_targets(&SyuConfig::default(), tempdir.path()).expect("targets");
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("src/FeatureTrace.cs")
+                && target.symbol == "FeatureTrace"
+                && target.kind == CoverageTargetKind::PublicSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("src/FeatureTrace.cs")
+                && target.symbol == "FeatureTraceRecord"
+                && target.kind == CoverageTargetKind::PublicSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("src/FeatureTrace.cs")
+                && target.symbol == "FeatureTraceService"
+                && target.kind == CoverageTargetKind::PublicSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("src/FeatureTrace.cs")
+                && target.symbol == "FeatureTraceCSharp"
+                && target.kind == CoverageTargetKind::PublicSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("src/FeatureTrace.cs")
+                && target.symbol == "TraceLabel"
+                && target.kind == CoverageTargetKind::PublicSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("tests/TraceabilityTests.cs")
+                && target.symbol == "ReqTraceCSharpTest"
+                && target.kind == CoverageTargetKind::TestSymbol
+        }));
+        assert!(targets.iter().any(|target| {
+            target.file == Path::new("tests/TraceabilityTests.cs")
+                && target.symbol == "ReqTraceCSharpTheory"
+                && target.kind == CoverageTargetKind::TestSymbol
+        }));
+        assert!(!targets.iter().any(|target| target.symbol == "HelperCase"));
+        assert!(!targets.iter().any(|target| target.symbol == "HiddenHelper"));
+    }
+
+    #[test]
+    fn collect_csharp_public_symbols_covers_properties_fields_and_methods() {
+        let symbols = collect_csharp_public_symbols(
+            "public interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n    void FeatureTraceCSharp();\n}\npublic class FeatureTraceService {\n    public const string TraceLabel = \"ok\";\n    public Task FeatureTraceAsync() => Task.CompletedTask;\n}\n",
+        );
+
+        assert_eq!(
+            symbols,
+            vec![
+                "EXPORTED_NAME",
+                "FeatureTrace",
+                "FeatureTraceAsync",
+                "FeatureTraceCSharp",
+                "FeatureTraceService",
+                "TraceLabel"
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_csharp_test_symbols_covers_xunit_nunit_and_mstest() {
+        let symbols = collect_csharp_test_symbols(
+            "using Xunit;\nusing NUnit.Framework;\nusing Microsoft.VisualStudio.TestTools.UnitTesting;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpFact() {}\n\n    [Test]\n    public void ReqTraceCSharpNUnit() {}\n\n    [TestMethod]\n    public async Task ReqTraceCSharpMsTest() => await Task.CompletedTask;\n}\n",
+        );
+
+        assert_eq!(
+            symbols,
+            vec![
+                "ReqTraceCSharpFact",
+                "ReqTraceCSharpMsTest",
+                "ReqTraceCSharpNUnit"
+            ]
+        );
     }
 
     #[test]
@@ -2147,19 +2484,22 @@ mod tests {
         validate_symbol_trace_coverage_with(
             &workspace,
             &mut issues,
-            no_targets,
-            |_config, _root| {
-                Err(Box::new(crate::model::Issue::error(
-                    "SYU-coverage-walk-001",
-                    "trace coverage inventory",
-                    None,
-                    "injected python discovery error".to_string(),
-                    None,
-                )))
+            CoverageDiscoverers {
+                rust: no_targets,
+                python: |_config, _root| {
+                    Err(Box::new(crate::model::Issue::error(
+                        "SYU-coverage-walk-001",
+                        "trace coverage inventory",
+                        None,
+                        "injected python discovery error".to_string(),
+                        None,
+                    )))
+                },
+                go: no_targets,
+                java: no_java_targets,
+                csharp: no_targets,
+                typescript: discover_typescript_targets,
             },
-            no_targets,
-            no_java_targets,
-            discover_typescript_targets,
         );
 
         assert_eq!(issues.len(), 1);
@@ -2185,19 +2525,22 @@ mod tests {
         validate_symbol_trace_coverage_with(
             &workspace,
             &mut issues,
-            |_config, _root| Ok(Vec::new()),
-            |_config, _root| Ok(Vec::new()),
-            |_config, _root| {
-                Err(Box::new(crate::model::Issue::error(
-                    "SYU-coverage-walk-001",
-                    "trace coverage inventory",
-                    None,
-                    "injected go discovery error".to_string(),
-                    None,
-                )))
+            CoverageDiscoverers {
+                rust: |_config, _root| Ok(Vec::new()),
+                python: |_config, _root| Ok(Vec::new()),
+                go: |_config, _root| {
+                    Err(Box::new(crate::model::Issue::error(
+                        "SYU-coverage-walk-001",
+                        "trace coverage inventory",
+                        None,
+                        "injected go discovery error".to_string(),
+                        None,
+                    )))
+                },
+                java: discover_java_targets,
+                csharp: no_targets,
+                typescript: discover_typescript_targets,
             },
-            discover_java_targets,
-            discover_typescript_targets,
         );
 
         assert_eq!(issues.len(), 1);
@@ -2223,19 +2566,22 @@ mod tests {
         validate_symbol_trace_coverage_with(
             &workspace,
             &mut issues,
-            |_config, _root| Ok(Vec::new()),
-            |_config, _root| Ok(Vec::new()),
-            |_config, _root| Ok(Vec::new()),
-            |_config, _root| {
-                Err(Box::new(crate::model::Issue::error(
-                    "SYU-coverage-walk-001",
-                    "trace coverage inventory",
-                    None,
-                    "injected java discovery error".to_string(),
-                    None,
-                )))
+            CoverageDiscoverers {
+                rust: |_config, _root| Ok(Vec::new()),
+                python: |_config, _root| Ok(Vec::new()),
+                go: |_config, _root| Ok(Vec::new()),
+                java: |_config, _root| {
+                    Err(Box::new(crate::model::Issue::error(
+                        "SYU-coverage-walk-001",
+                        "trace coverage inventory",
+                        None,
+                        "injected java discovery error".to_string(),
+                        None,
+                    )))
+                },
+                csharp: no_targets,
+                typescript: discover_typescript_targets,
             },
-            discover_typescript_targets,
         );
 
         assert_eq!(issues.len(), 1);
@@ -2261,18 +2607,21 @@ mod tests {
         validate_symbol_trace_coverage_with(
             &workspace,
             &mut issues,
-            no_targets,
-            no_targets,
-            no_targets,
-            no_java_targets,
-            |_config, _root| {
-                Err(Box::new(crate::model::Issue::error(
-                    "SYU-coverage-walk-001",
-                    "trace coverage inventory",
-                    None,
-                    "injected typescript discovery error".to_string(),
-                    None,
-                )))
+            CoverageDiscoverers {
+                rust: no_targets,
+                python: no_targets,
+                go: no_targets,
+                java: no_java_targets,
+                csharp: no_targets,
+                typescript: |_config, _root| {
+                    Err(Box::new(crate::model::Issue::error(
+                        "SYU-coverage-walk-001",
+                        "trace coverage inventory",
+                        None,
+                        "injected typescript discovery error".to_string(),
+                        None,
+                    )))
+                },
             },
         );
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -1419,6 +1419,9 @@ mod tests {
         path::{Path, PathBuf},
     };
 
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
     use tempfile::tempdir;
 
     use super::{
@@ -1426,7 +1429,7 @@ mod tests {
         collect_csharp_test_symbols, collect_feature_coverage,
         collect_files_recursive_by_extension, collect_go_public_symbols, collect_go_test_symbols,
         collect_java_public_symbols, collect_java_test_symbols, collect_requirement_coverage,
-        discover_csharp_targets, discover_go_targets, discover_java_targets,
+        csharp_files_under, discover_csharp_targets, discover_go_targets, discover_java_targets,
         discover_python_targets, discover_rust_targets, discover_typescript_targets,
         go_files_under, java_files_under, normalize_relative_path,
         normalized_symbol_trace_coverage_ignored_paths, path_matches_ignored_generated_directory,
@@ -1849,7 +1852,7 @@ mod tests {
     #[test]
     fn collect_csharp_public_symbols_covers_properties_fields_and_methods() {
         let symbols = collect_csharp_public_symbols(
-            "public interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n    void FeatureTraceCSharp();\n}\npublic class FeatureTraceService {\n    public const string TraceLabel = \"ok\";\n    public Task FeatureTraceAsync() => Task.CompletedTask;\n}\n",
+            "public interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n    void FeatureTraceCSharp();\n}\npublic class FeatureTraceService {\n    public FeatureTraceService() {}\n    public const string TraceLabel = \"ok\";\n    public Task FeatureTraceAsync() => Task.CompletedTask;\n}\n",
         );
 
         assert_eq!(
@@ -1868,7 +1871,7 @@ mod tests {
     #[test]
     fn collect_csharp_test_symbols_covers_xunit_nunit_and_mstest() {
         let symbols = collect_csharp_test_symbols(
-            "using Xunit;\nusing NUnit.Framework;\nusing Microsoft.VisualStudio.TestTools.UnitTesting;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpFact() {}\n\n    [Test]\n    public void ReqTraceCSharpNUnit() {}\n\n    [TestMethod]\n    public async Task ReqTraceCSharpMsTest() => await Task.CompletedTask;\n}\n",
+            "using Xunit;\nusing NUnit.Framework;\nusing Microsoft.VisualStudio.TestTools.UnitTesting;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpFact() {}\n\n    [Test]\n    public void ReqTraceCSharpNUnit() {}\n\n    [TestMethod]\n    public async Task ReqTraceCSharpMsTest() => await Task.CompletedTask;\n\n    public void TestLegacyTrace() {}\n}\n",
         );
 
         assert_eq!(
@@ -1876,9 +1879,43 @@ mod tests {
             vec![
                 "ReqTraceCSharpFact",
                 "ReqTraceCSharpMsTest",
-                "ReqTraceCSharpNUnit"
+                "ReqTraceCSharpNUnit",
+                "TestLegacyTrace"
             ]
         );
+    }
+
+    #[test]
+    fn collect_csharp_public_symbols_ignores_unclosed_interfaces() {
+        let symbols = collect_csharp_public_symbols(
+            "public interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n",
+        );
+
+        assert_eq!(symbols, vec!["FeatureTrace"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_csharp_targets_skips_unreadable_symlinks() {
+        let tempdir = tempdir().expect("tempdir");
+        fs::create_dir_all(tempdir.path().join("src")).expect("src");
+        fs::create_dir_all(tempdir.path().join("tests")).expect("tests");
+        symlink(
+            tempdir.path().join("missing/FeatureTrace.cs"),
+            tempdir.path().join("src/BrokenTrace.cs"),
+        )
+        .expect("symlink");
+        fs::write(
+            tempdir.path().join("tests/TraceabilityTests.cs"),
+            "using Xunit;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpTest() {}\n}\n",
+        )
+        .expect("csharp tests");
+
+        let targets =
+            discover_csharp_targets(&SyuConfig::default(), tempdir.path()).expect("targets");
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].symbol, "ReqTraceCSharpTest");
     }
 
     #[test]
@@ -1898,6 +1935,27 @@ mod tests {
         let file_root = tempdir.path().join("not-a-dir.rs");
         fs::write(&file_root, "pub fn nope() {}\n").expect("file");
         let issue = rust_files_under(tempdir.path(), &file_root, &ignored_paths)
+            .expect_err("file roots should fail");
+        assert_eq!(issue.code, "SYU-coverage-walk-001");
+    }
+
+    #[test]
+    fn csharp_files_under_handles_missing_and_invalid_roots() {
+        let tempdir = tempdir().expect("tempdir");
+        let ignored_paths = BTreeSet::new();
+        assert!(
+            csharp_files_under(
+                tempdir.path(),
+                &tempdir.path().join("missing"),
+                &ignored_paths
+            )
+            .expect("missing directories should be ignored")
+            .is_empty()
+        );
+
+        let file_root = tempdir.path().join("not-a-dir.cs");
+        fs::write(&file_root, "public class BrokenTrace {}\n").expect("file");
+        let issue = csharp_files_under(tempdir.path(), &file_root, &ignored_paths)
             .expect_err("file roots should fail");
         assert_eq!(issue.code, "SYU-coverage-walk-001");
     }
@@ -2580,6 +2638,47 @@ mod tests {
                     )))
                 },
                 csharp: no_targets,
+                typescript: discover_typescript_targets,
+            },
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].code, "SYU-coverage-walk-001");
+    }
+
+    #[test]
+    fn validate_with_csharp_discovery_error_records_issue_and_returns() {
+        let tempdir = tempdir().expect("tempdir");
+        let mut config = SyuConfig::default();
+        config.validate.require_symbol_trace_coverage = true;
+        let workspace = Workspace {
+            root: tempdir.path().to_path_buf(),
+            spec_root: tempdir.path().join("docs/syu"),
+            config,
+            philosophies: Vec::new(),
+            policies: Vec::new(),
+            requirements: Vec::new(),
+            features: Vec::new(),
+        };
+
+        let mut issues = Vec::new();
+        validate_symbol_trace_coverage_with(
+            &workspace,
+            &mut issues,
+            CoverageDiscoverers {
+                rust: no_targets,
+                python: no_targets,
+                go: no_targets,
+                java: no_java_targets,
+                csharp: |_config, _root| {
+                    Err(Box::new(crate::model::Issue::error(
+                        "SYU-coverage-walk-001",
+                        "trace coverage inventory",
+                        None,
+                        "injected csharp discovery error".to_string(),
+                        None,
+                    )))
+                },
                 typescript: discover_typescript_targets,
             },
         );

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -892,11 +892,8 @@ fn discover_csharp_targets(
 ) -> Result<Vec<CoverageTarget>, Box<Issue>> {
     let ignored_paths = normalized_symbol_trace_coverage_ignored_paths(config);
     let mut files = csharp_files_under(root, &root.join("src"), &ignored_paths)?;
-    files.extend(csharp_files_under(
-        root,
-        &root.join("tests"),
-        &ignored_paths,
-    )?);
+    let test_files = csharp_files_under(root, &root.join("tests"), &ignored_paths)?;
+    files.extend(test_files);
     files.sort();
 
     if files.is_empty() {

--- a/src/language.rs
+++ b/src/language.rs
@@ -49,6 +49,9 @@ struct GoAdapter;
 struct JavaAdapter;
 
 #[derive(Debug)]
+struct CSharpAdapter;
+
+#[derive(Debug)]
 struct ShellAdapter;
 
 #[derive(Debug)]
@@ -68,6 +71,7 @@ static PYTHON_ADAPTER: PythonAdapter = PythonAdapter;
 static TYPESCRIPT_ADAPTER: TypeScriptAdapter = TypeScriptAdapter;
 static GO_ADAPTER: GoAdapter = GoAdapter;
 static JAVA_ADAPTER: JavaAdapter = JavaAdapter;
+static CSHARP_ADAPTER: CSharpAdapter = CSharpAdapter;
 static SHELL_ADAPTER: ShellAdapter = ShellAdapter;
 static YAML_ADAPTER: YamlAdapter = YamlAdapter;
 static JSON_ADAPTER: JsonAdapter = JsonAdapter;
@@ -204,6 +208,37 @@ impl LanguageAdapter for JavaAdapter {
     }
 }
 
+impl LanguageAdapter for CSharpAdapter {
+    fn canonical_name(&self) -> &'static str {
+        "csharp"
+    }
+
+    fn aliases(&self) -> &'static [&'static str] {
+        &["csharp", "cs", "dotnet", "xunit", "nunit", "mstest"]
+    }
+
+    fn extensions(&self) -> &'static [&'static str] {
+        &["cs"]
+    }
+
+    fn patterns(&self, symbol: &str) -> Vec<String> {
+        let escaped = regex::escape(symbol);
+        vec![
+            format!(
+                r"(?m)\b(?:public|protected|internal|private)?\s*(?:sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|interface|enum|record|struct)\s+{escaped}\b"
+            ),
+            format!(
+                r"(?m)\bpublic\s+(?:static\s+)?(?:sealed\s+|override\s+|virtual\s+|abstract\s+|async\s+|partial\s+|new\s+)*(?:<[^>{{}}]+>\s*)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*\("
+            ),
+            format!(r"(?m)\bpublic\s+(?:static\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:\{{|=>)"),
+            format!(
+                r"(?m)\bpublic\s+(?:static\s+)?(?:readonly\s+|const\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:=|;)"
+            ),
+            format!(r"(?m)\b{escaped}\b"),
+        ]
+    }
+}
+
 impl LanguageAdapter for ShellAdapter {
     fn canonical_name(&self) -> &'static str {
         "shell"
@@ -319,6 +354,7 @@ pub fn adapter_for_language(language: &str) -> Option<&'static dyn LanguageAdapt
         &TYPESCRIPT_ADAPTER as &dyn LanguageAdapter,
         &GO_ADAPTER as &dyn LanguageAdapter,
         &JAVA_ADAPTER as &dyn LanguageAdapter,
+        &CSHARP_ADAPTER as &dyn LanguageAdapter,
         &SHELL_ADAPTER as &dyn LanguageAdapter,
         &YAML_ADAPTER as &dyn LanguageAdapter,
         &JSON_ADAPTER as &dyn LanguageAdapter,
@@ -380,6 +416,10 @@ mod tests {
             adapter_for_language("ignore").map(LanguageAdapter::canonical_name),
             Some("gitignore")
         );
+        assert_eq!(
+            adapter_for_language("mstest").map(LanguageAdapter::canonical_name),
+            Some("csharp")
+        );
         assert!(adapter_for_language("unknown").is_none());
     }
 
@@ -392,6 +432,7 @@ mod tests {
         let json = adapter_for_language("json").expect("json adapter should exist");
         let markdown = adapter_for_language("markdown").expect("markdown adapter should exist");
         let gitignore = adapter_for_language("gitignore").expect("gitignore adapter should exist");
+        let csharp = adapter_for_language("csharp").expect("csharp adapter should exist");
 
         assert!(rust.supports_path(Path::new("src/lib.rs")));
         assert!(go.supports_path(Path::new("go/app.go")));
@@ -402,6 +443,7 @@ mod tests {
         assert!(markdown.supports_path(Path::new("README.md")));
         assert!(gitignore.supports_path(Path::new(".gitignore")));
         assert!(gitignore.supports_path(Path::new("app/.gitignore")));
+        assert!(csharp.supports_path(Path::new("src/FeatureTrace.cs")));
         assert_eq!(gitignore.extensions(), &["gitignore"]);
         assert!(!yaml.supports_path(Path::new("README.md")));
         assert!(!gitignore.supports_path(Path::new("README.md")));
@@ -419,6 +461,7 @@ mod tests {
         let json = adapter_for_language("json").expect("json adapter should exist");
         let markdown = adapter_for_language("markdown").expect("markdown adapter should exist");
         let gitignore = adapter_for_language("gitignore").expect("gitignore adapter should exist");
+        let csharp = adapter_for_language("csharp").expect("csharp adapter should exist");
 
         assert!(rust.symbol_exists("pub fn hello_world() {}", "hello_world"));
         assert!(python.symbol_exists("def test_trace():\n    return True\n", "test_trace"));
@@ -444,6 +487,18 @@ mod tests {
         assert!(gitignore.symbol_exists("# FEAT-CONTRIB-002\n/.worktrees/\n", "FEAT-CONTRIB-002"));
         assert!(gitignore.symbol_exists("# FEAT-CONTRIB-002\n/.worktrees/\n", "/.worktrees/"));
         assert!(gitignore.symbol_exists("worktree_helper\n", "worktree_helper"));
+        assert!(csharp.symbol_exists(
+            "public record FeatureTrace(string Value);\npublic async Task featureTraceCSharpAsync() => Task.CompletedTask;\n",
+            "FeatureTrace"
+        ));
+        assert!(csharp.symbol_exists(
+            "public class FeatureTraceService {\n    public string TraceLabel { get; } = \"ok\";\n}\n",
+            "TraceLabel"
+        ));
+        assert!(csharp.symbol_exists(
+            "public class FeatureTraceService {\n    public async Task featureTraceCSharpAsync() => Task.CompletedTask;\n}\n",
+            "featureTraceCSharpAsync"
+        ));
     }
 
     #[test]

--- a/src/language.rs
+++ b/src/language.rs
@@ -223,16 +223,19 @@ impl LanguageAdapter for CSharpAdapter {
 
     fn patterns(&self, symbol: &str) -> Vec<String> {
         let escaped = regex::escape(symbol);
+        let visibility = r"(?:public|protected|internal|private)(?:\s+(?:protected|internal))?";
         vec![
             format!(
-                r"(?m)\b(?:public|protected|internal|private)?\s*(?:sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|interface|enum|record|struct)\s+{escaped}\b"
+                r"(?m)\b(?:{visibility}\s+)?(?:sealed\s+|abstract\s+|static\s+|partial\s+)*(?:class|interface|enum|record|struct)\s+{escaped}\b"
             ),
             format!(
-                r"(?m)\bpublic\s+(?:static\s+)?(?:sealed\s+|override\s+|virtual\s+|abstract\s+|async\s+|partial\s+|new\s+)*(?:<[^>{{}}]+>\s*)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*\("
+                r"(?m)\b{visibility}\s+(?:static\s+)?(?:sealed\s+|override\s+|virtual\s+|abstract\s+|async\s+|partial\s+|new\s+)*(?:<[^>{{}}]+>\s*)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*\("
             ),
-            format!(r"(?m)\bpublic\s+(?:static\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:\{{|=>)"),
             format!(
-                r"(?m)\bpublic\s+(?:static\s+)?(?:readonly\s+|const\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:=|;)"
+                r"(?m)\b{visibility}\s+(?:static\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:\{{|=>)"
+            ),
+            format!(
+                r"(?m)\b{visibility}\s+(?:static\s+)?(?:readonly\s+|const\s+)?(?:[\w<>\[\],?.]+\s+)+{escaped}\s*(?:=|;)"
             ),
             format!(r"(?m)\b{escaped}\b"),
         ]
@@ -498,6 +501,18 @@ mod tests {
         assert!(csharp.symbol_exists(
             "public class FeatureTraceService {\n    public async Task featureTraceCSharpAsync() => Task.CompletedTask;\n}\n",
             "featureTraceCSharpAsync"
+        ));
+        assert!(csharp.symbol_exists(
+            "internal class FeatureTraceService {\n    internal async Task featureTraceCSharpInternalAsync() => Task.CompletedTask;\n}\n",
+            "featureTraceCSharpInternalAsync"
+        ));
+        assert!(csharp.symbol_exists(
+            "private protected class FeatureTraceService {\n    private protected string TraceSecret { get; } = \"ok\";\n}\n",
+            "TraceSecret"
+        ));
+        assert!(csharp.symbol_exists(
+            "public class FeatureTraceService {\n    private const string HiddenTraceLabel = \"ok\";\n}\n",
+            "HiddenTraceLabel"
         ));
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -325,8 +325,8 @@ mod tests {
         let workspace = load_workspace(&fixture_root("passing")).expect("fixture should load");
         assert_eq!(workspace.philosophies.len(), 1);
         assert_eq!(workspace.policies.len(), 2);
-        assert_eq!(workspace.requirements.len(), 5);
-        assert_eq!(workspace.features.len(), 5);
+        assert_eq!(workspace.requirements.len(), 6);
+        assert_eq!(workspace.features.len(), 6);
     }
 
     #[test]

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -169,7 +169,7 @@ fn check_command_accepts_passing_workspace() {
     assert!(stdout.contains("(workspace, graph, delivery, trace)"));
     assert!(stdout.contains("validate.require_symbol_trace_coverage=false"));
     assert!(stdout.contains(
-        "traceability: requirements=5/5 traces validated; features=5/5 traces validated"
+        "traceability: requirements=6/6 traces validated; features=6/6 traces validated"
     ));
     assert!(
         stdout.contains("What to do next:"),
@@ -520,8 +520,8 @@ fn check_command_verifies_requirement_test_traceability_in_all_supported_languag
 
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
-    assert_eq!(json["trace_summary"]["requirement_traces"]["declared"], 5);
-    assert_eq!(json["trace_summary"]["requirement_traces"]["validated"], 5);
+    assert_eq!(json["trace_summary"]["requirement_traces"]["declared"], 6);
+    assert_eq!(json["trace_summary"]["requirement_traces"]["validated"], 6);
 }
 
 #[test]
@@ -545,8 +545,8 @@ fn check_command_verifies_feature_implementation_traceability_in_all_supported_l
 
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
-    assert_eq!(json["trace_summary"]["feature_traces"]["declared"], 5);
-    assert_eq!(json["trace_summary"]["feature_traces"]["validated"], 5);
+    assert_eq!(json["trace_summary"]["feature_traces"]["declared"], 6);
+    assert_eq!(json["trace_summary"]["feature_traces"]["validated"], 6);
 }
 
 #[test]

--- a/tests/fixtures/workspaces/passing/csharp/FeatureTrace.cs
+++ b/tests/fixtures/workspaces/passing/csharp/FeatureTrace.cs
@@ -1,0 +1,4 @@
+public interface FeatureTrace
+{
+    void FeatureTraceCSharp();
+}

--- a/tests/fixtures/workspaces/passing/csharp/TraceabilityTests.cs
+++ b/tests/fixtures/workspaces/passing/csharp/TraceabilityTests.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+public class TraceabilityTests
+{
+    [Fact]
+    public void ReqTraceCSharpTest()
+    {
+    }
+}

--- a/tests/fixtures/workspaces/passing/docs/syu/features/traceability/core.yaml
+++ b/tests/fixtures/workspaces/passing/docs/syu/features/traceability/core.yaml
@@ -62,3 +62,16 @@ features:
           symbols:
             - FeatureTrace
             - featureTraceJava
+
+  - id: FEAT-TRACE-006
+    title: C# implementation trace
+    summary: Feature links to C# source.
+    status: implemented
+    linked_requirements:
+      - REQ-TRACE-006
+    implementations:
+      csharp:
+        - file: csharp/FeatureTrace.cs
+          symbols:
+            - FeatureTrace
+            - FeatureTraceCSharp

--- a/tests/fixtures/workspaces/passing/docs/syu/policies/policies.yaml
+++ b/tests/fixtures/workspaces/passing/docs/syu/policies/policies.yaml
@@ -16,6 +16,7 @@ policies:
       - REQ-TRACE-003
       - REQ-TRACE-004
       - REQ-TRACE-005
+      - REQ-TRACE-006
 
   - id: POL-TRACE-002
     title: Features need executable evidence
@@ -30,3 +31,4 @@ policies:
       - REQ-TRACE-003
       - REQ-TRACE-004
       - REQ-TRACE-005
+      - REQ-TRACE-006

--- a/tests/fixtures/workspaces/passing/docs/syu/requirements/traceability/core.yaml
+++ b/tests/fixtures/workspaces/passing/docs/syu/requirements/traceability/core.yaml
@@ -81,3 +81,19 @@ requirements:
         - file: java/TraceabilityTest.java
           symbols:
             - reqTraceJavaTest
+
+  - id: REQ-TRACE-006
+    title: C# requirement trace
+    description: C# requirements should point to C# test files.
+    priority: high
+    status: implemented
+    linked_policies:
+      - POL-TRACE-001
+      - POL-TRACE-002
+    linked_features:
+      - FEAT-TRACE-006
+    tests:
+      csharp:
+        - file: csharp/TraceabilityTests.cs
+          symbols:
+            - ReqTraceCSharpTest

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -56,7 +56,7 @@ fn list_command_supports_json_output() {
             .as_array()
             .expect("items should be an array")
             .len(),
-        5
+        6
     );
     assert_eq!(json["items"][0]["id"], "FEAT-TRACE-001");
 }

--- a/tests/report_command.rs
+++ b/tests/report_command.rs
@@ -60,7 +60,7 @@ fn report_command_generates_markdown_output() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("# syu validation report"));
-    assert!(stdout.contains("Requirement-to-test traceability: 5/5"));
+    assert!(stdout.contains("Requirement-to-test traceability: 6/6"));
 }
 
 #[test]

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -627,7 +627,7 @@ fn repository_declares_documentation_guides() {
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("trace-adapter-support.md"));
     assert!(configuration.contains("validate.allow_planned"));
-    assert!(configuration.contains("Rust, Python, Go, Java, and TypeScript/JavaScript"));
+    assert!(configuration.contains("Rust, Python, Go, Java, C#, and TypeScript/JavaScript"));
     assert!(configuration.contains("--spec-root"));
     assert!(configuration.contains(&format!("version: {current_version}")));
     assert!(configuration.contains("docs/syu/config/overview.yaml"));
@@ -637,14 +637,14 @@ fn repository_declares_documentation_guides() {
     assert!(config_spec.contains("spec.root"));
     assert!(config_validate.contains("validate.default_fix"));
     assert!(config_validate.contains("validate.require_symbol_trace_coverage"));
-    assert!(config_validate.contains("Rust, Python, Go, Java, and TypeScript/JavaScript"));
+    assert!(config_validate.contains("Rust, Python, Go, Java, C#, and TypeScript/JavaScript"));
     assert!(config_runtimes.contains("runtimes.python.command"));
     assert!(generated_config_overview.contains("docs/syu/config/overview.yaml"));
     assert!(generated_config_overview.contains("current CLI version"));
     assert!(generated_config_spec.contains("docs/syu/config/spec.yaml"));
     assert!(generated_config_validate.contains("validate.default_fix"));
     assert!(
-        generated_config_validate.contains("Rust, Python, Go, Java, and TypeScript/JavaScript")
+        generated_config_validate.contains("Rust, Python, Go, Java, C#, and TypeScript/JavaScript")
     );
     assert!(generated_config_validate.contains("array&lt;path&gt;"));
     assert!(generated_config_runtimes.contains("docs/syu/config/runtimes.yaml"));
@@ -654,8 +654,9 @@ fn repository_declares_documentation_guides() {
     assert!(generated_validation.contains("docs/syu/features/validation/validation.yaml"));
     assert!(generated_validation.contains("SYU-graph-reference-001"));
     assert!(
-        generated_validation
-            .contains("Rust, Python, Go, Java, and TypeScript/JavaScript source and test files")
+        generated_validation.contains(
+            "Rust, Python, Go, Java, C#, and TypeScript/JavaScript source and test files"
+        )
     );
     assert!(generated_docs_freshness.contains("FEAT-QUALITY-001"));
     assert!(generated_docs_freshness.contains("check_generated_docs_freshness"));
@@ -821,7 +822,7 @@ fn repository_ships_example_workspaces() {
     assert!(python_example_requirement.contains("REQ-PY-001"));
     assert!(csharp_fallback_requirement.contains("REQ-CSHARP-001"));
     assert!(csharp_fallback_readme.contains("CsharpFallbackAcceptanceChecklist"));
-    assert!(csharp_fallback_readme.contains("SYU-trace-language-001"));
+    assert!(csharp_fallback_readme.contains("staged adoption pattern"));
     assert!(docs_first_requirement.contains("REQ-DOCS-001"));
     assert!(docs_first_requirement.contains("DocsFirstAcceptanceChecklist"));
     assert!(docs_first_readme.contains("syu init --template docs-first"));

--- a/tests/trace_coverage_validation.rs
+++ b/tests/trace_coverage_validation.rs
@@ -655,3 +655,125 @@ fn validate_accepts_wildcard_java_coverage() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+fn write_csharp_workspace(root: &Path, cover_everything: bool) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_symbol_trace_coverage: true\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep the graph explicit\n    product_design_principle: Every layer should be connected.\n    coding_guideline: Prefer explicit ownership.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Every symbol must be owned\n    summary: Public C# symbols and tests may require ownership.\n    description: This fixture turns the strict coverage rule on.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    let requirement_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - ReqTraceCSharpTest\n"
+    };
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Tests must stay justified\n    description: Each test should link to a requirement.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      csharp:\n        - file: tests/TraceabilityTests.cs\n{requirement_symbols}",
+        ),
+    )
+    .expect("requirement");
+
+    let feature_symbols = if cover_everything {
+        "          symbols:\n            - '*'\n"
+    } else {
+        "          symbols:\n            - FeatureTraceCSharp\n"
+    };
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        format!(
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: Public APIs must stay owned\n    summary: Each public C# symbol should link to a feature.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      csharp:\n        - file: src/FeatureTrace.cs\n{feature_symbols}",
+        ),
+    )
+    .expect("feature");
+
+    fs::write(
+        root.join("src/FeatureTrace.cs"),
+        "// FEAT-001\npublic interface FeatureTrace {\n    string EXPORTED_NAME { get; }\n    void FeatureTraceCSharp();\n    void CoveredMethod();\n}\n",
+    )
+    .expect("source");
+    fs::write(
+        root.join("tests/TraceabilityTests.cs"),
+        "// REQ-001\nusing Xunit;\n\npublic class TraceabilityTests {\n    [Fact]\n    public void ReqTraceCSharpTest() {}\n\n    [Theory]\n    public async Task UntrackedTheory() => await Task.CompletedTask;\n}\n",
+    )
+    .expect("tests");
+}
+
+#[test]
+fn validate_reports_untracked_csharp_symbols_and_tests() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_csharp_workspace(tempdir.path(), false);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(!output.status.success(), "csharp coverage gaps should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SYU-coverage-public-001"),
+        "expected public coverage error, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("SYU-coverage-test-001"),
+        "expected test coverage error, got:\n{stdout}"
+    );
+    assert!(stdout.contains("CoveredMethod"), "stdout:\n{stdout}");
+    assert!(stdout.contains("EXPORTED_NAME"), "stdout:\n{stdout}");
+    assert!(stdout.contains("UntrackedTheory"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn validate_accepts_wildcard_csharp_coverage() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_csharp_workspace(tempdir.path(), true);
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- add a built-in C# trace adapter plus strict coverage discovery for public symbols and test methods
- extend the passing fixture, integration tests, docs, and generated site-spec pages for the new C# support
- reframe the csharp-fallback example as a staged-adoption reference instead of an unsupported-language workaround

## Testing
- bash scripts/ci/quality-gates.sh
- cargo run -- validate .
- npm --prefix website ci
- npm --prefix website run build

Closes #314