### PR TITLE
fix: clarify browser-app prerequisites for fresh worktrees (REQ-CORE-017, FEAT-APP-001)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,11 @@ match your change:
    npm --prefix app ci
    ```
 
-   Normal Cargo-driven builds no longer run that install step for you. If the
-   embedded browser app dependencies are missing or stale, `build.rs` stops and
-   points back to the commands above so Rust-only or docs-only work does not
-   silently mutate your `app/node_modules` tree.
+Normal Cargo-driven builds no longer run that install step for you. If you are
+in a fresh clone or fresh worktree and the embedded browser app dependencies are
+missing or stale, `build.rs` stops and points back to the commands above so
+Rust-only or docs-only work does not silently mutate your `app/node_modules`
+tree.
 
    Then run the same freshness flow CI uses:
 

--- a/README.md
+++ b/README.md
@@ -740,10 +740,9 @@ scripts/ci/pinned-npm.sh install app
 npm --prefix app ci
 ```
 
-Cargo no longer runs `npm ci` for you during normal builds. If `app/node_modules`
-is missing or stale, `build.rs` stops and points back to the commands above so
-offline, hermetic, and security-sensitive environments do not hide a networked
-package-manager install inside an ordinary Rust build.
+Cargo no longer runs `npm ci` for you during normal builds. If you are in a
+fresh clone or fresh worktree and `app/node_modules` is missing or stale,
+`build.rs` stops and points back to the commands above so offline, hermetic, and security-sensitive environments do not hide a networked package-manager install inside an ordinary Rust build.
 
 When contributors change browser app sources or build inputs, they should run
 `scripts/ci/check-browser-app-freshness.sh`. That flow regenerates the local

--- a/build.rs
+++ b/build.rs
@@ -214,9 +214,22 @@ fn ensure_app_dependencies(app_dir: &Path, required_npm: &str) -> Result<(), Str
         return Ok(());
     }
 
-    Err(format!(
-        "browser app dependencies are not ready; run `scripts/ci/pinned-npm.sh install app && npm --prefix app ci` from the repository root with npm {required_npm} before running Cargo commands that embed the browser app"
-    ))
+    Err(missing_app_dependencies_message(required_npm))
+}
+
+fn missing_app_dependencies_message(required_npm: &str) -> String {
+    format!(
+        concat!(
+            "browser app dependencies are not ready.\n\n",
+            "This usually means you are in a fresh clone or fresh worktree that does not have `app/node_modules` yet.\n",
+            "Cargo intentionally does not run a networked npm install for you during embedded browser-app builds.\n\n",
+            "From the repository root, run:\n",
+            "  scripts/ci/pinned-npm.sh install app\n",
+            "  npm --prefix app ci\n\n",
+            "Then rerun the Cargo command. The pinned npm workflow expects npm {}."
+        ),
+        required_npm
+    )
 }
 
 fn remove_dir_if_exists(path: &Path, description: &str) -> Result<(), String> {
@@ -377,5 +390,16 @@ mod tests {
             default_wasm_target_dir_from_common_dir(Path::new("/repo/.worktrees/impl"), None, None),
             Path::new("/repo/.worktrees/impl/target/app-wasm")
         );
+    }
+
+    #[test]
+    fn missing_app_dependencies_message_guides_fresh_worktrees() {
+        let message = super::missing_app_dependencies_message("11.8.0");
+
+        assert!(message.contains("fresh clone or fresh worktree"));
+        assert!(message.contains("Cargo intentionally does not run a networked npm install"));
+        assert!(message.contains("scripts/ci/pinned-npm.sh install app"));
+        assert!(message.contains("npm --prefix app ci"));
+        assert!(message.contains("npm 11.8.0"));
     }
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1077,6 +1077,8 @@ fn repository_ships_browser_app() {
     assert!(build_script.contains("syu-app-dist"));
     assert!(build_script.contains("scripts/ci/pinned-npm.sh install app"));
     assert!(build_script.contains("browser app dependencies are not ready"));
+    assert!(build_script.contains("fresh clone or fresh worktree"));
+    assert!(build_script.contains("Cargo intentionally does not run a networked npm install"));
     assert!(build_script.contains("build:wasm"));
     assert!(build_script.contains("--outDir"));
     assert!(build_script.contains("shared_core_dir"));
@@ -1113,6 +1115,7 @@ fn repository_ships_browser_app() {
     assert!(readme.contains("generates the embedded"));
     assert!(readme.contains("scripts/ci/pinned-npm.sh install app"));
     assert!(readme.contains("Cargo no longer runs `npm ci` for you during normal builds."));
+    assert!(readme.contains("fresh clone or fresh worktree"));
     assert!(readme.contains("offline, hermetic, and security-sensitive environments"));
     assert!(readme.contains("check-browser-app-freshness.sh"));
     assert!(readme.contains("regenerates the local"));


### PR DESCRIPTION
## Summary
- turn the build.rs missing-dependency panic into a guided fresh-clone/worktree prerequisite message
- keep README and CONTRIBUTING aligned with that same contributor path
- cover the new wording in repository quality checks

Closes #535