### PR TITLE
fix: require explicit opt-in for remote app binds (REQ-CORE-017, FEAT-APP-001)

### DIFF
--- a/docs/generated/site-spec/config/app.md
+++ b/docs/generated/site-spec/config/app.md
@@ -40,7 +40,9 @@ description: "Generated reference for docs/syu/config/app.yaml"
     - |
       `syu app` uses this address when `--bind` is not passed. Repositories can
       keep a checked-in default when contributors usually inspect the app through
-      a shared local workflow or demo setup.
+      a shared local workflow or demo setup. Non-loopback addresses such as
+      `0.0.0.0` still require the explicit `--allow-remote` CLI opt-in before
+      the server starts.
 - **key**: app.port
   - **type**: integer
   - **default**: 3000
@@ -74,7 +76,9 @@ items:
     description: |
       `syu app` uses this address when `--bind` is not passed. Repositories can
       keep a checked-in default when contributors usually inspect the app through
-      a shared local workflow or demo setup.
+      a shared local workflow or demo setup. Non-loopback addresses such as
+      `0.0.0.0` still require the explicit `--allow-remote` CLI opt-in before
+      the server starts.
   - key: app.port
     type: integer
     default: 3000

--- a/docs/generated/site-spec/features/browser/app.md
+++ b/docs/generated/site-spec/features/browser/app.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/browser/app.yaml"
 
 - **id**: FEAT-APP-001
   - **title**: Local browser workspace app powered by Rust and WebAssembly
-  - **summary**: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
+  - **summary**: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, explicit remote-bind safety opt-in, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-017
@@ -70,7 +70,7 @@ version: 1
 features:
   - id: FEAT-APP-001
     title: Local browser workspace app powered by Rust and WebAssembly
-    summary: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
+    summary: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, explicit remote-bind safety opt-in, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
     status: implemented
     linked_requirements:
       - REQ-CORE-017

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -131,8 +131,10 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them. When the workspace argument (or default current directory) points
-      inside a workspace, `syu app` MUST walk parent directories until it finds
+      them. When `app.bind` or `--bind` selects a non-loopback address, `syu
+      app` MUST require an explicit `--allow-remote` opt-in before it starts.
+      When the workspace argument (or default current directory) points inside a
+      workspace, `syu app` MUST walk parent directories until it finds
       `syu.yaml`. The startup output MUST also tell users which workspace root
       was selected, which local URL to open in a browser, and how to stop the
       server cleanly.
@@ -155,6 +157,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: tests/app_command.rs
         - **symbols**:
           - *
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - app_help_mentions_remote_bind_opt_in
       - **file**: src/command/app.rs
         - **symbols**:
           - *
@@ -539,8 +544,10 @@ requirements:
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them. When the workspace argument (or default current directory) points
-      inside a workspace, `syu app` MUST walk parent directories until it finds
+      them. When `app.bind` or `--bind` selects a non-loopback address, `syu
+      app` MUST require an explicit `--allow-remote` opt-in before it starts.
+      When the workspace argument (or default current directory) points inside a
+      workspace, `syu app` MUST walk parent directories until it finds
       `syu.yaml`. The startup output MUST also tell users which workspace root
       was selected, which local URL to open in a browser, and how to stop the
       server cleanly.
@@ -563,6 +570,9 @@ requirements:
         - file: tests/app_command.rs
           symbols:
             - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - app_help_mentions_remote_bind_opt_in
         - file: src/command/app.rs
           symbols:
             - '*'

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 98/98
+- Requirement-to-test traceability: 99/99
 - Feature-to-implementation traceability: 112/112
 
 ## Issues

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -246,7 +246,10 @@ app:
   port: 3000
 ```
 
-CLI flags always override the config values. See the [configuration guide](./configuration.md#appbind) for the full reference.
+CLI flags always override the config values. If you switch `bind` to a
+non-loopback address such as `0.0.0.0`, you must also pass `--allow-remote`
+when starting `syu app`. See the [configuration guide](./configuration.md#appbind)
+for the full reference.
 
 ---
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -202,6 +202,8 @@ Controls the default address that `syu app` binds to.
 
 Use `127.0.0.1` for a localhost-only browser app or `0.0.0.0` when a demo or
 container workflow needs the server to be reachable from outside the process.
+When the configured address is non-loopback, `syu app` still requires the
+explicit `--allow-remote` flag before it starts serving workspace data.
 
 ### `app.port`
 

--- a/docs/syu/config/app.yaml
+++ b/docs/syu/config/app.yaml
@@ -19,7 +19,9 @@ items:
     description: |
       `syu app` uses this address when `--bind` is not passed. Repositories can
       keep a checked-in default when contributors usually inspect the app through
-      a shared local workflow or demo setup.
+      a shared local workflow or demo setup. Non-loopback addresses such as
+      `0.0.0.0` still require the explicit `--allow-remote` CLI opt-in before
+      the server starts.
   - key: app.port
     type: integer
     default: 3000

--- a/docs/syu/features/browser/app.yaml
+++ b/docs/syu/features/browser/app.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-APP-001
     title: Local browser workspace app powered by Rust and WebAssembly
-    summary: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
+    summary: Start `syu app` from the workspace root or any child directory to inspect the current workspace in a browser with clear startup guidance, explicit remote-bind safety opt-in, the resolved workspace root, a minimal header, layered navigation, section-aware drilldown, discoverable keyboard search shortcuts, linked definitions, and the current validation state.
     status: implemented
     linked_requirements:
       - REQ-CORE-017

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -112,8 +112,10 @@ requirements:
       browser-safe Rust logic through WebAssembly instead of reimplementing the
       layered model only in JavaScript. When `syu.yaml` defines app defaults,
       `syu app` MUST use `app.bind` and `app.port` unless CLI flags override
-      them. When the workspace argument (or default current directory) points
-      inside a workspace, `syu app` MUST walk parent directories until it finds
+      them. When `app.bind` or `--bind` selects a non-loopback address, `syu
+      app` MUST require an explicit `--allow-remote` opt-in before it starts.
+      When the workspace argument (or default current directory) points inside a
+      workspace, `syu app` MUST walk parent directories until it finds
       `syu.yaml`. The startup output MUST also tell users which workspace root
       was selected, which local URL to open in a browser, and how to stop the
       server cleanly.
@@ -136,6 +138,9 @@ requirements:
         - file: tests/app_command.rs
           symbols:
             - '*'
+        - file: tests/help_command.rs
+          symbols:
+            - app_help_mentions_remote_bind_opt_in
         - file: src/command/app.rs
           symbols:
             - '*'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -393,6 +393,10 @@ pub struct AppArgs {
     #[arg(help = "Port to bind the local app server to (default: app.port or 3000)")]
     #[arg(short, long)]
     pub port: Option<u16>,
+
+    #[arg(help = "Allow syu app to bind to a non-loopback address such as 0.0.0.0")]
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub allow_remote: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -177,6 +177,19 @@ fn bind_failure_message(
         "failed to bind `{bind}:{port}`. {likely_cause} Try `syu app {workspace} --port <free-port>` to retry with a different port, or set `app.port` in syu.yaml to change the default. {error}"
     )
 }
+
+fn require_remote_bind_opt_in(bind: IpAddr, allow_remote: bool) -> Result<()> {
+    if bind.is_loopback() || allow_remote {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "refusing to bind `syu app` to non-loopback address `{bind}` without `--allow-remote`. \
+This protects workspace data and source documents from accidental network exposure. \
+Use `--bind 127.0.0.1` to keep the browser UI local, or pass `--allow-remote` when remote access is intentional."
+    ))
+}
+
 pub fn run_app_command(args: &AppArgs) -> Result<i32> {
     let workspace_root = canonical_workspace_root(&args.workspace)?;
     let loaded = load_config(&workspace_root)?;
@@ -185,6 +198,7 @@ pub fn run_app_command(args: &AppArgs) -> Result<i32> {
         .bind
         .parse::<IpAddr>()
         .with_context(|| format!("invalid bind address `{}`", settings.bind))?;
+    require_remote_bind_opt_in(bind, args.allow_remote)?;
     build_app_payload_from_config(&workspace_root, &loaded.config)?;
     println!("workspace: {}", workspace_root.display());
     let state = AppState::new(workspace_root.clone(), loaded.config);
@@ -984,9 +998,9 @@ mod tests {
         content_type_for_path, is_asset_like, load_current_snapshot, non_loopback_warning_lines,
         normalized_asset_path, normalized_trace_snapshot_path, readiness_probe_request_sent,
         readiness_probe_succeeds, redacted_relative_label, redacted_root_label,
-        refresh_current_once, relative_display, resolve_app_server_settings, spec_snapshot,
-        startup_lines, trailing_path_components_label, validation_snapshot,
-        wait_for_ready_with_retry,
+        refresh_current_once, relative_display, require_remote_bind_opt_in,
+        resolve_app_server_settings, spec_snapshot, startup_lines, trailing_path_components_label,
+        validation_snapshot, wait_for_ready_with_retry,
     };
 
     fn fixture_root(name: &str) -> PathBuf {
@@ -1136,6 +1150,7 @@ mod tests {
                 workspace: PathBuf::from("."),
                 bind: None,
                 port: None,
+                allow_remote: false,
             },
             &config,
         );
@@ -1163,6 +1178,7 @@ mod tests {
                 workspace: tempdir.path().to_path_buf(),
                 bind: None,
                 port: None,
+                allow_remote: false,
             },
             &config,
         );
@@ -1190,6 +1206,7 @@ mod tests {
                 workspace: tempdir.path().to_path_buf(),
                 bind: Some("127.0.0.1".to_string()),
                 port: Some(5123),
+                allow_remote: false,
             },
             &config,
         );
@@ -1254,6 +1271,28 @@ mod tests {
                     .to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn require_remote_bind_opt_in_allows_loopback_without_flag() {
+        require_remote_bind_opt_in("127.0.0.1".parse().expect("valid ip"), false)
+            .expect("loopback should stay allowed");
+    }
+
+    #[test]
+    fn require_remote_bind_opt_in_rejects_non_loopback_without_flag() {
+        let error = require_remote_bind_opt_in("0.0.0.0".parse().expect("valid ip"), false)
+            .expect_err("non-loopback should require explicit opt-in");
+        let message = error.to_string();
+        assert!(message.contains("--allow-remote"));
+        assert!(message.contains("127.0.0.1"));
+        assert!(message.contains("accidental network exposure"));
+    }
+
+    #[test]
+    fn require_remote_bind_opt_in_allows_non_loopback_with_flag() {
+        require_remote_bind_opt_in("0.0.0.0".parse().expect("valid ip"), true)
+            .expect("explicit opt-in should allow non-loopback binds");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ mod tests {
                     workspace: PathBuf::from("workspace"),
                     bind: Some("127.0.0.1".to_string()),
                     port: Some(4173),
+                    allow_remote: false,
                 })),
             },
             true,

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -233,10 +233,33 @@ fn app_command_help_mentions_browser_and_stop_instructions() {
     assert!(stdout.contains("Use GET /health for readiness checks once the app is serving."));
     assert!(stdout.contains("After startup, open the printed URL in your browser."));
     assert!(stdout.contains("Press Ctrl-C to stop the local app server."));
+    assert!(stdout.contains("--allow-remote"));
 }
 
 #[test]
-fn app_command_warns_on_non_loopback_binds() {
+fn app_command_rejects_non_loopback_binds_without_explicit_opt_in() {
+    let port = reserve_port();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("app")
+        .arg(fixture_path("passing"))
+        .arg("--bind")
+        .arg("0.0.0.0")
+        .arg("--port")
+        .arg(port.to_string())
+        .output()
+        .expect("command should run");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--allow-remote"));
+    assert!(stderr.contains("accidental network exposure"));
+    assert!(!stdout.contains("syu app listening on"));
+}
+
+#[test]
+fn app_command_warns_on_non_loopback_binds_after_explicit_opt_in() {
     let port = reserve_port();
     let child = Command::cargo_bin("syu")
         .expect("binary should build")
@@ -244,6 +267,7 @@ fn app_command_warns_on_non_loopback_binds() {
         .arg(fixture_path("passing"))
         .arg("--bind")
         .arg("0.0.0.0")
+        .arg("--allow-remote")
         .arg("--port")
         .arg(port.to_string())
         .stdin(Stdio::null())
@@ -265,9 +289,6 @@ fn app_command_warns_on_non_loopback_binds() {
     let listening_index = stdout
         .find(&listening)
         .expect("stdout should include the listening url");
-    assert!(stdout.contains(&format!("syu app listening on http://0.0.0.0:{port}")));
-    assert!(stdout.contains(&format!("syu app ready: http://0.0.0.0:{port}")));
-    assert!(stdout.contains(&format!("Open http://0.0.0.0:{port} in your browser.")));
     assert!(warning_index < listening_index);
     assert!(stdout.contains("workspace data and source documents may be reachable"));
     assert!(stdout.contains("use --bind 127.0.0.1 to keep the browser UI local"));

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -33,6 +33,21 @@ fn root_help_includes_start_here_guidance() {
 }
 
 #[test]
+fn app_help_mentions_remote_bind_opt_in() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["app", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "app help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--allow-remote"));
+    assert!(stdout.contains("non-loopback address"));
+}
+
+#[test]
 fn workspace_help_uses_current_directory_default_consistently() {
     for command in [
         "browse", "show", "search", "trace", "app", "validate", "check", "report", "add", "relate",

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -488,6 +488,7 @@ fn repository_declares_documentation_guides() {
     assert!(app_guide.contains("ArrowDown"));
     assert!(app_guide.contains("Escape"));
     assert!(app_guide.contains("the item's YAML `status:` field"));
+    assert!(app_guide.contains("--allow-remote"));
     assert!(app_guide.contains("../../website/static/img/app-guide-overview.png"));
     assert!(!app_guide.contains("](/img/"));
     assert!(!app_guide.contains("`planned`, `implemented`, or `deprecated`"));
@@ -625,6 +626,7 @@ fn repository_declares_documentation_guides() {
     assert!(merge_queue_playbook.contains("gh pr merge 123 --auto --squash"));
     assert!(merge_queue_playbook.contains("gh-readonly-queue/main/pr-123-<sha>"));
     assert!(configuration.contains("validate.default_fix"));
+    assert!(configuration.contains("--allow-remote"));
     assert!(configuration.contains("trace-adapter-support.md"));
     assert!(configuration.contains("validate.allow_planned"));
     assert!(configuration.contains("Rust, Python, Go, Java, and TypeScript/JavaScript"));


### PR DESCRIPTION
## Summary
- add a dedicated --allow-remote opt-in before syu app accepts non-loopback binds
- keep the existing stdout warning path after the explicit opt-in is present
- update checked-in app/config docs and self-spec coverage for the safer startup flow

Closes #540