### PR TITLE
feat: add JSON output for non-interactive browse snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Render list-shaped output without entering the interactive browser:
 Use `syu list` when you want list-shaped output that can be narrowed to one
 layer or emitted as JSON for automation. Use `syu browse --non-interactive`
 when you want the browse snapshot instead: workspace metadata, per-layer
-counts, and the current validation errors in plain text.
+counts, grouped items, and the current validation errors in text or JSON.
 
 ```bash
 syu list philosophy

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -428,7 +428,7 @@ syu app .
 Use `syu list` when you want list-shaped output that can be narrowed to one
 layer or emitted as JSON for automation. Use `syu browse --non-interactive`
 when you want the browse snapshot instead: workspace metadata, per-layer
-counts, and the current validation errors in plain text.
+counts, grouped items, and the current validation errors in text or JSON.
 
 If you only remember the task and not the command name yet, use this chooser:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,7 +73,7 @@ const WORKSPACE_HELP: &str = "Workspace root or any child directory; syu walks u
 
 const LIST_AFTER_HELP: &str = "\
 Choose `syu list` when you want list-shaped output that can be narrowed to one layer or emitted as JSON for automation.
-Choose `syu browse --non-interactive` when you want the browse snapshot instead: workspace metadata, per-layer counts, and the current validation errors in plain text.
+Choose `syu browse --non-interactive` when you want the browse snapshot instead: workspace metadata, per-layer counts, grouped items, and the current validation errors in text or JSON.
 
 Examples:
   syu list
@@ -89,12 +89,13 @@ Note:
   Pass the workspace root, the configured spec.root directory, or any child directory.
   syu walks upward until it finds syu.yaml, then resolves the configured spec.root from that workspace.";
 const BROWSE_AFTER_HELP: &str = "\
-Choose `syu browse --non-interactive` when you want the browse snapshot in plain text: workspace metadata, per-layer counts, grouped items, and the current validation errors.
-Choose `syu list` when you want list-shaped output that can be narrowed to one layer or emitted as JSON for automation.
+Choose `syu browse --non-interactive` when you want the browse snapshot in text or JSON: workspace metadata, per-layer counts, grouped items, and the current validation errors.
+Choose `syu list` when you want list-shaped output that can be narrowed to one layer.
 
 Examples:
   syu browse .
   syu browse . --non-interactive
+  syu browse . --non-interactive --format json
 ";
 
 const SEARCH_AFTER_HELP: &str = "\
@@ -209,6 +210,10 @@ pub struct BrowseArgs {
     /// Useful in CI pipelines and scripts.
     #[arg(long, action = ArgAction::SetTrue)]
     pub non_interactive: bool,
+
+    #[arg(help = "Output format for non-interactive browse snapshots")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }
 
 impl Default for BrowseArgs {
@@ -216,6 +221,7 @@ impl Default for BrowseArgs {
         Self {
             workspace: PathBuf::from("."),
             non_interactive: false,
+            format: OutputFormat::Text,
         }
     }
 }

--- a/src/command/browse.rs
+++ b/src/command/browse.rs
@@ -5,9 +5,10 @@
 use std::io::{self, Write};
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::{
-    cli::{BrowseArgs, LookupKind as EntityKind},
+    cli::{BrowseArgs, LookupKind as EntityKind, OutputFormat},
     command::check::collect_check_result,
     model::{CheckResult, Feature, Issue, Philosophy, Policy, Requirement},
     rules::rule_by_code,
@@ -43,13 +44,37 @@ struct EntityRef {
     id: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct JsonBrowseEntry {
+    id: String,
+    title: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct JsonBrowseGroups {
+    philosophies: Vec<JsonBrowseEntry>,
+    policies: Vec<JsonBrowseEntry>,
+    requirements: Vec<JsonBrowseEntry>,
+    features: Vec<JsonBrowseEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct JsonBrowseOutput {
+    workspace_root: String,
+    spec_root: Option<String>,
+    definition_counts: crate::model::DefinitionCounts,
+    trace_summary: crate::model::TraceSummary,
+    groups: JsonBrowseGroups,
+    issues: Vec<Issue>,
+}
+
 pub fn run_browse_command(args: &BrowseArgs) -> Result<i32> {
     let result = collect_check_result(&args.workspace);
     let workspace = load_workspace(&args.workspace).ok();
     let state = BrowseState { workspace, result };
 
     if args.non_interactive {
-        state.print_non_interactive();
+        state.print_non_interactive(args.format);
         return Ok(0);
     }
 
@@ -376,7 +401,16 @@ impl BrowseState {
         println!();
     }
 
-    fn print_non_interactive(&self) {
+    fn print_non_interactive(&self, format: OutputFormat) {
+        if matches!(format, OutputFormat::Json) {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&self.non_interactive_json())
+                    .expect("serializing browse snapshot to JSON should succeed")
+            );
+            return;
+        }
+
         self.print_summary("syu spec tree");
 
         for (heading, kind) in [
@@ -401,6 +435,25 @@ impl BrowseState {
                 }
             }
             println!();
+        }
+    }
+
+    fn non_interactive_json(&self) -> JsonBrowseOutput {
+        JsonBrowseOutput {
+            workspace_root: self.result.workspace_root.display().to_string(),
+            spec_root: self
+                .workspace
+                .as_ref()
+                .map(|workspace| workspace.spec_root.display().to_string()),
+            definition_counts: self.result.definition_counts.clone(),
+            trace_summary: self.result.trace_summary.clone(),
+            groups: JsonBrowseGroups {
+                philosophies: self.json_entries(EntityKind::Philosophy),
+                policies: self.json_entries(EntityKind::Policy),
+                requirements: self.json_entries(EntityKind::Requirement),
+                features: self.json_entries(EntityKind::Feature),
+            },
+            issues: self.result.issues.clone(),
         }
     }
 
@@ -441,6 +494,13 @@ impl BrowseState {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    fn json_entries(&self, kind: EntityKind) -> Vec<JsonBrowseEntry> {
+        self.entity_entries(kind)
+            .into_iter()
+            .map(|(id, title)| JsonBrowseEntry { id, title })
+            .collect()
     }
 
     fn philosophy(&self, id: &str) -> Option<&Philosophy> {

--- a/tests/browse_command.rs
+++ b/tests/browse_command.rs
@@ -1,6 +1,7 @@
 // REQ-CORE-015
 
 use assert_cmd::{Command, cargo::CommandCargoExt};
+use serde_json::Value;
 use std::{fs, path::PathBuf, process::Command as StdCommand};
 use tempfile::tempdir;
 
@@ -65,8 +66,8 @@ fn browse_command_help_explains_when_to_use_non_interactive_mode() {
         "help should explain the browse snapshot shape:\n{stdout}",
     );
     assert!(
-        stdout.contains("emitted as JSON for automation"),
-        "help should point to syu list for automation-oriented output:\n{stdout}",
+        stdout.contains("syu browse . --non-interactive --format json"),
+        "help should show the JSON browse example:\n{stdout}",
     );
 }
 
@@ -321,5 +322,46 @@ fn browse_command_non_interactive_shows_errors_when_workspace_is_failing() {
     assert!(
         stdout.contains("suggestion: Declare requirement `REQ-MISSING-999`"),
         "should include actionable suggestions: {stdout}"
+    );
+}
+
+#[test]
+// REQ-CORE-015
+fn browse_command_non_interactive_supports_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args([
+            "browse",
+            fixture_path("passing").to_str().expect("utf8 path"),
+            "--non-interactive",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("browse command should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid json");
+    assert_eq!(json["definition_counts"]["philosophies"], 1);
+    assert_eq!(json["groups"]["philosophies"][0]["id"], "PHIL-TRACE-001");
+    assert_eq!(json["groups"]["requirements"][0]["id"], "REQ-TRACE-001");
+    assert_eq!(
+        json["issues"]
+            .as_array()
+            .expect("issues should be an array")
+            .len(),
+        0
+    );
+    assert_eq!(
+        json["spec_root"],
+        fixture_path("passing")
+            .join("docs/syu")
+            .display()
+            .to_string()
     );
 }

--- a/tests/list_command.rs
+++ b/tests/list_command.rs
@@ -257,7 +257,7 @@ fn list_command_help_documents_both_argument_orders() {
         "help should explain the automation-oriented list output:\n{stdout}",
     );
     assert!(
-        stdout.contains("workspace metadata, per-layer counts, and the current validation errors"),
+        stdout.contains("workspace metadata, per-layer counts, grouped items, and the current validation errors in text or JSON"),
         "help should distinguish list output from the browse snapshot:\n{stdout}",
     );
 }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -447,7 +447,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("review what changed for one spec item in Git history"));
     assert!(readme.contains("list-shaped output"));
     assert!(readme.contains("workspace metadata, per-layer"));
-    assert!(readme.contains("current validation errors in plain text"));
+    assert!(readme.contains("current validation errors in text or JSON"));
     assert!(readme.contains("syu show"));
     assert!(readme.contains("syu show REQ-001"));
     assert!(!readme.contains("syu show REQ-CORE-015"));
@@ -541,7 +541,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu validate ."));
     assert!(getting_started.contains("emitted as JSON for automation"));
     assert!(getting_started.contains("workspace metadata, per-layer"));
-    assert!(getting_started.contains("current validation errors in plain text"));
+    assert!(getting_started.contains("current validation errors in text or JSON"));
     assert!(getting_started.contains("review change history for one requirement or feature"));
     assert!(getting_started.contains("syu list feature"));
     assert!(getting_started.contains("syu show REQ-001"));


### PR DESCRIPTION
## Summary
- add JSON output for syu browse --non-interactive with workspace metadata, grouped items, and validation issues
- document the browse snapshot as text-or-JSON in the CLI help, README, and getting-started guide
- extend browse/list/repository-quality coverage for the new non-interactive JSON contract

Closes #539
