### PR TITLE
feat: add editor-facing lsp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,10 +434,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "include_dir"
@@ -488,6 +602,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -553,6 +673,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "predicates"
@@ -788,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +952,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syu"
 version = "0.0.1-alpha.8"
 dependencies = [
@@ -837,6 +983,7 @@ dependencies = [
  "tower",
  "tree-sitter",
  "tree-sitter-typescript",
+ "url",
 ]
 
 [[package]]
@@ -865,6 +1012,16 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tokio"
@@ -987,6 +1144,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1162,6 +1337,89 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ syn = { version = "2.0.117", features = ["full"] }
 tokio = { version = "1.51.1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tree-sitter = "0.26.8"
 tree-sitter-typescript = "0.23.2"
+url = "2.5.7"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/docs/generated/site-spec/features/editor/vscode.md
+++ b/docs/generated/site-spec/features/editor/vscode.md
@@ -42,6 +42,26 @@ description: "Generated reference for docs/syu/features/editor/vscode.yaml"
           - syu.openSpecItemById
           - syu.showRelatedFilesForSpecId
           - syuContext
+- **id**: FEAT-VSCODE-002
+  - **title**: Editor-facing LSP server foundation
+  - **summary**: Provide an editor-agnostic LSP transport so VS Code and future clients can reuse syu hover and navigation semantics over stdio.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-022
+  - **implementations**:
+    - **rust**:
+      - **file**: src/lsp/mod.rs
+        - **symbols**:
+          - run_lsp_server
+      - **file**: src/lsp/server.rs
+        - **symbols**:
+          - *
+      - **file**: src/lsp/handlers.rs
+        - **symbols**:
+          - *
+      - **file**: src/lsp/protocol.rs
+        - **symbols**:
+          - *
 
 ## Source YAML
 
@@ -75,4 +95,24 @@ features:
             - syu.openSpecItemById
             - syu.showRelatedFilesForSpecId
             - syuContext
+  - id: FEAT-VSCODE-002
+    title: Editor-facing LSP server foundation
+    summary: Provide an editor-agnostic LSP transport so VS Code and future clients can reuse syu hover and navigation semantics over stdio.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-022
+    implementations:
+      rust:
+        - file: src/lsp/mod.rs
+          symbols:
+            - run_lsp_server
+        - file: src/lsp/server.rs
+          symbols:
+            - '*'
+        - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
+        - file: src/lsp/protocol.rs
+          symbols:
+            - '*'
 ```

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -350,11 +350,18 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - POL-005
   - **linked_features**:
     - FEAT-VSCODE-001
+    - FEAT-VSCODE-002
   - **tests**:
     - **rust**:
       - **file**: tests/repository_quality.rs
         - **symbols**:
           - repository_ships_vscode_extension
+      - **file**: tests/lsp_tests.rs
+        - **symbols**:
+          - *
+      - **file**: src/lsp/handlers.rs
+        - **symbols**:
+          - *
     - **javascript**:
       - **file**: editors/vscode/test/model.test.js
         - **symbols**:
@@ -758,11 +765,18 @@ requirements:
       - POL-005
     linked_features:
       - FEAT-VSCODE-001
+      - FEAT-VSCODE-002
     tests:
       rust:
         - file: tests/repository_quality.rs
           symbols:
             - repository_ships_vscode_extension
+        - file: tests/lsp_tests.rs
+          symbols:
+            - '*'
+        - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
       javascript:
         - file: editors/vscode/test/model.test.js
           symbols:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -359,7 +359,13 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: tests/lsp_tests.rs
         - **symbols**:
           - *
+      - **file**: src/lsp/server.rs
+        - **symbols**:
+          - *
       - **file**: src/lsp/handlers.rs
+        - **symbols**:
+          - *
+      - **file**: src/lsp/protocol.rs
         - **symbols**:
           - *
     - **javascript**:
@@ -774,7 +780,13 @@ requirements:
         - file: tests/lsp_tests.rs
           symbols:
             - '*'
+        - file: src/lsp/server.rs
+          symbols:
+            - '*'
         - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
+        - file: src/lsp/protocol.rs
           symbols:
             - '*'
       javascript:

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 8
 - Requirements: 24
-- Features: 30
+- Features: 31
 
 ## Traceability
 
-- Requirement-to-test traceability: 99/99
-- Feature-to-implementation traceability: 112/112
+- Requirement-to-test traceability: 101/101
+- Feature-to-implementation traceability: 116/116
 
 ## Issues
 

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 101/101
+- Requirement-to-test traceability: 103/103
 - Feature-to-implementation traceability: 116/116
 
 ## Issues

--- a/docs/syu/features/editor/vscode.yaml
+++ b/docs/syu/features/editor/vscode.yaml
@@ -27,3 +27,23 @@ features:
             - syu.openSpecItemById
             - syu.showRelatedFilesForSpecId
             - syuContext
+  - id: FEAT-VSCODE-002
+    title: Editor-facing LSP server foundation
+    summary: Provide an editor-agnostic LSP transport so VS Code and future clients can reuse syu hover and navigation semantics over stdio.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-022
+    implementations:
+      rust:
+        - file: src/lsp/mod.rs
+          symbols:
+            - run_lsp_server
+        - file: src/lsp/server.rs
+          symbols:
+            - '*'
+        - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
+        - file: src/lsp/protocol.rs
+          symbols:
+            - '*'

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -335,7 +335,13 @@ requirements:
         - file: tests/lsp_tests.rs
           symbols:
             - '*'
+        - file: src/lsp/server.rs
+          symbols:
+            - '*'
         - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
+        - file: src/lsp/protocol.rs
           symbols:
             - '*'
       javascript:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -326,11 +326,18 @@ requirements:
       - POL-005
     linked_features:
       - FEAT-VSCODE-001
+      - FEAT-VSCODE-002
     tests:
       rust:
         - file: tests/repository_quality.rs
           symbols:
             - repository_ships_vscode_extension
+        - file: tests/lsp_tests.rs
+          symbols:
+            - '*'
+        - file: src/lsp/handlers.rs
+          symbols:
+            - '*'
       javascript:
         - file: editors/vscode/test/model.test.js
           symbols:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,8 @@ pub enum Commands {
         after_help = ADD_AFTER_HELP
     )]
     Add(AddArgs),
+    #[command(about = "Start LSP server for editor integrations (JSON-RPC 2.0 over stdio)")]
+    Lsp,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // FEAT-SEARCH-001
 // FEAT-TRACE-001
 // FEAT-BROWSE-001
+// FEAT-LSP-001
 // REQ-CORE-021
 // REQ-CORE-023
 // REQ-CORE-024
@@ -14,6 +15,7 @@ pub mod config;
 pub mod coverage;
 pub mod inspect;
 pub mod language;
+mod lsp;
 pub mod model;
 pub mod report;
 pub mod rules;
@@ -75,6 +77,7 @@ enum Dispatch {
     Init(cli::InitArgs),
     Templates(cli::TemplatesArgs),
     Add(cli::AddArgs),
+    Lsp,
 }
 
 fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) -> Dispatch {
@@ -96,6 +99,7 @@ fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) ->
         Some(cli::Commands::Init(args)) => Dispatch::Init(args),
         Some(cli::Commands::Templates(args)) => Dispatch::Templates(args),
         Some(cli::Commands::Add(args)) => Dispatch::Add(args),
+        Some(cli::Commands::Lsp) => Dispatch::Lsp,
     }
 }
 
@@ -120,6 +124,10 @@ fn run_dispatch(dispatch: Dispatch) -> Result<i32> {
         Dispatch::Init(args) => command::init::run_init_command(&args),
         Dispatch::Templates(args) => command::templates::run_templates_command(&args),
         Dispatch::Add(args) => command::add::run_add_command(&args),
+        Dispatch::Lsp => {
+            lsp::run_lsp_server()?;
+            Ok(0)
+        }
     }
 }
 

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -1,16 +1,16 @@
 // FEAT-LSP-001
 // REQ-CORE-001
 
-use anyhow::{Result, bail};
 use regex::Regex;
 use serde_json::Value;
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::LazyLock;
+use url::Url;
 
 use crate::workspace::{Workspace, load_workspace};
 
 use super::protocol::{
-    Hover, InitializeParams, InitializeResult, MarkupContent, ServerCapabilities,
+    Hover, InitializeParams, InitializeResult, LspError, MarkupContent, ServerCapabilities,
     TextDocumentPositionParams,
 };
 
@@ -27,14 +27,19 @@ impl LspHandlers {
         }
     }
 
-    pub(crate) fn handle_initialize(&mut self, params: InitializeParams) -> Result<Value> {
+    pub(crate) fn handle_initialize(
+        &mut self,
+        params: InitializeParams,
+    ) -> Result<Value, LspError> {
         let root_path = if let Some(root_uri) = params.root_uri {
             uri_to_path(&root_uri)?
         } else {
-            std::env::current_dir()?
+            std::env::current_dir().map_err(|error| LspError::internal(error.to_string()))?
         };
 
-        self.workspace = Some(load_workspace(&root_path)?);
+        self.workspace = Some(
+            load_workspace(&root_path).map_err(|error| LspError::internal(error.to_string()))?,
+        );
 
         let result = InitializeResult {
             capabilities: ServerCapabilities {
@@ -42,29 +47,33 @@ impl LspHandlers {
             },
         };
 
-        Ok(serde_json::to_value(result)?)
+        serde_json::to_value(result).map_err(|error| LspError::internal(error.to_string()))
     }
 
-    pub(crate) fn handle_initialized(&mut self) -> Result<()> {
+    pub(crate) fn handle_initialized(&mut self) -> Result<(), LspError> {
         self.initialized = true;
         Ok(())
     }
 
-    pub(crate) fn handle_shutdown(&mut self) -> Result<Value> {
+    pub(crate) fn handle_shutdown(&mut self) -> Result<Value, LspError> {
         self.initialized = false;
         Ok(Value::Null)
     }
 
-    pub(crate) fn handle_hover(&self, params: TextDocumentPositionParams) -> Result<Option<Hover>> {
+    pub(crate) fn handle_hover(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<Hover>, LspError> {
         let workspace = match &self.workspace {
             Some(ws) => ws,
-            None => bail!("workspace not initialized"),
+            None => return Err(LspError::internal("workspace not initialized")),
         };
 
         let file_path = uri_to_path(&params.text_document.uri)?;
         let line = params.position.line as usize;
 
-        let content = std::fs::read_to_string(&file_path)?;
+        let content = std::fs::read_to_string(&file_path)
+            .map_err(|error| LspError::internal(error.to_string()))?;
         let lines: Vec<&str> = content.lines().collect();
 
         if line >= lines.len() {
@@ -84,11 +93,16 @@ impl LspHandlers {
     }
 }
 
-fn uri_to_path(uri: &str) -> Result<std::path::PathBuf> {
-    if let Some(path_str) = uri.strip_prefix("file://") {
-        Ok(Path::new(path_str).to_path_buf())
+fn uri_to_path(uri: &str) -> Result<PathBuf, LspError> {
+    if uri.starts_with("file://") {
+        let parsed = Url::parse(uri).map_err(|error| {
+            LspError::invalid_params(format!("invalid file URI `{uri}`: {error}"))
+        })?;
+        parsed
+            .to_file_path()
+            .map_err(|()| LspError::invalid_params(format!("unsupported file URI path: {uri}")))
     } else {
-        Ok(Path::new(uri).to_path_buf())
+        Ok(PathBuf::from(uri))
     }
 }
 
@@ -204,6 +218,13 @@ mod tests {
         let uri = "file:///home/user/file.txt";
         let path = uri_to_path(uri).unwrap();
         assert_eq!(path.to_str().unwrap(), "/home/user/file.txt");
+    }
+
+    #[test]
+    fn test_uri_to_path_decodes_percent_encoding() {
+        let uri = "file:///tmp/space%20name.txt";
+        let path = uri_to_path(uri).unwrap();
+        assert_eq!(path.to_str().unwrap(), "/tmp/space name.txt");
     }
 
     #[test]

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -179,6 +179,15 @@ fn create_hover_for_spec_id(workspace: &Workspace, spec_id: &str) -> Option<Hove
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::protocol::{Position, TextDocumentIdentifier};
+    use std::{fs, path::PathBuf};
+    use tempfile::tempdir;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/workspaces")
+            .join(name)
+    }
 
     #[test]
     fn test_find_spec_id_at_position() {
@@ -195,5 +204,158 @@ mod tests {
         let uri = "file:///home/user/file.txt";
         let path = uri_to_path(uri).unwrap();
         assert_eq!(path.to_str().unwrap(), "/home/user/file.txt");
+    }
+
+    #[test]
+    fn uri_to_path_accepts_plain_paths() {
+        let path = uri_to_path("/tmp/plain.txt").unwrap();
+        assert_eq!(path.to_str().unwrap(), "/tmp/plain.txt");
+    }
+
+    #[test]
+    fn handle_hover_requires_initialization() {
+        let handlers = LspHandlers::new();
+        let error = handlers
+            .handle_hover(TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: "file:///tmp/example.rs".to_string(),
+                },
+                position: Position {
+                    line: 0,
+                    character: 0,
+                },
+            })
+            .expect_err("hover should require initialization");
+        assert!(error.to_string().contains("workspace not initialized"));
+    }
+
+    #[test]
+    fn handle_initialize_loads_workspace_from_root_uri() {
+        let mut handlers = LspHandlers::new();
+        let workspace = fixture_path("passing");
+        let value = handlers
+            .handle_initialize(InitializeParams {
+                process_id: None,
+                root_uri: Some(format!("file://{}", workspace.display())),
+                capabilities: None,
+            })
+            .expect("initialize should succeed");
+
+        assert_eq!(value["capabilities"]["hoverProvider"], true);
+        assert!(handlers.workspace.is_some());
+    }
+
+    #[test]
+    fn handle_hover_returns_none_for_out_of_bounds_positions() {
+        let mut handlers = LspHandlers::new();
+        let workspace = fixture_path("passing");
+        handlers
+            .handle_initialize(InitializeParams {
+                process_id: None,
+                root_uri: Some(format!("file://{}", workspace.display())),
+                capabilities: None,
+            })
+            .expect("initialize should succeed");
+
+        let tempdir = tempdir().expect("tempdir");
+        let file_path = tempdir.path().join("notes.txt");
+        fs::write(&file_path, "plain text\n").expect("write file");
+
+        let hover = handlers
+            .handle_hover(TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: format!("file://{}", file_path.display()),
+                },
+                position: Position {
+                    line: 10,
+                    character: 0,
+                },
+            })
+            .expect("hover should succeed");
+        assert!(hover.is_none());
+    }
+
+    #[test]
+    fn handle_hover_renders_each_spec_layer() {
+        let mut handlers = LspHandlers::new();
+        let workspace = fixture_path("passing");
+        handlers
+            .handle_initialize(InitializeParams {
+                process_id: None,
+                root_uri: Some(format!("file://{}", workspace.display())),
+                capabilities: None,
+            })
+            .expect("initialize should succeed");
+
+        let tempdir = tempdir().expect("tempdir");
+        let file_path = tempdir.path().join("spec-ids.txt");
+        fs::write(
+            &file_path,
+            "PHIL-TRACE-001\nPOL-TRACE-001\nREQ-TRACE-001\nFEAT-TRACE-001\n",
+        )
+        .expect("write file");
+
+        for (line, expected) in [
+            (0, "Product Design Principle"),
+            (1, "## Summary"),
+            (2, "**Priority:**"),
+            (3, "**Status:**"),
+        ] {
+            let hover = handlers
+                .handle_hover(TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: format!("file://{}", file_path.display()),
+                    },
+                    position: Position { line, character: 2 },
+                })
+                .expect("hover should succeed")
+                .expect("hover should exist");
+            assert!(hover.contents.value.contains(expected));
+        }
+    }
+
+    #[test]
+    fn handle_hover_returns_none_when_no_spec_id_matches() {
+        let mut handlers = LspHandlers::new();
+        let workspace = fixture_path("passing");
+        handlers
+            .handle_initialize(InitializeParams {
+                process_id: None,
+                root_uri: Some(format!("file://{}", workspace.display())),
+                capabilities: None,
+            })
+            .expect("initialize should succeed");
+
+        let tempdir = tempdir().expect("tempdir");
+        let file_path = tempdir.path().join("notes.txt");
+        fs::write(&file_path, "nothing to hover here\n").expect("write file");
+
+        let hover = handlers
+            .handle_hover(TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: format!("file://{}", file_path.display()),
+                },
+                position: Position {
+                    line: 0,
+                    character: 1,
+                },
+            })
+            .expect("hover should succeed");
+        assert!(hover.is_none());
+    }
+
+    #[test]
+    fn handle_initialized_and_shutdown_flip_state() {
+        let mut handlers = LspHandlers::new();
+        handlers.handle_initialized().expect("initialized");
+        assert!(handlers.initialized);
+        assert_eq!(handlers.handle_shutdown().expect("shutdown"), Value::Null);
+        assert!(!handlers.initialized);
+    }
+
+    #[test]
+    fn create_hover_returns_none_for_unknown_ids() {
+        let workspace = load_workspace(&fixture_path("passing")).expect("workspace");
+        assert!(create_hover_for_spec_id(&workspace, "NOTE-UNKNOWN-001").is_none());
     }
 }

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -1,0 +1,199 @@
+// FEAT-LSP-001
+// REQ-CORE-001
+
+use anyhow::{Result, bail};
+use regex::Regex;
+use serde_json::Value;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use crate::workspace::{Workspace, load_workspace};
+
+use super::protocol::{
+    Hover, InitializeParams, InitializeResult, MarkupContent, ServerCapabilities,
+    TextDocumentPositionParams,
+};
+
+pub(crate) struct LspHandlers {
+    workspace: Option<Workspace>,
+    initialized: bool,
+}
+
+impl LspHandlers {
+    pub(crate) fn new() -> Self {
+        Self {
+            workspace: None,
+            initialized: false,
+        }
+    }
+
+    pub(crate) fn handle_initialize(&mut self, params: InitializeParams) -> Result<Value> {
+        let root_path = if let Some(root_uri) = params.root_uri {
+            uri_to_path(&root_uri)?
+        } else {
+            std::env::current_dir()?
+        };
+
+        self.workspace = Some(load_workspace(&root_path)?);
+
+        let result = InitializeResult {
+            capabilities: ServerCapabilities {
+                hover_provider: Some(true),
+            },
+        };
+
+        Ok(serde_json::to_value(result)?)
+    }
+
+    pub(crate) fn handle_initialized(&mut self) -> Result<()> {
+        self.initialized = true;
+        Ok(())
+    }
+
+    pub(crate) fn handle_shutdown(&mut self) -> Result<Value> {
+        self.initialized = false;
+        Ok(Value::Null)
+    }
+
+    pub(crate) fn handle_hover(&self, params: TextDocumentPositionParams) -> Result<Option<Hover>> {
+        let workspace = match &self.workspace {
+            Some(ws) => ws,
+            None => bail!("workspace not initialized"),
+        };
+
+        let file_path = uri_to_path(&params.text_document.uri)?;
+        let line = params.position.line as usize;
+
+        let content = std::fs::read_to_string(&file_path)?;
+        let lines: Vec<&str> = content.lines().collect();
+
+        if line >= lines.len() {
+            return Ok(None);
+        }
+
+        let current_line = lines[line];
+        let char_pos = params.position.character as usize;
+
+        if let Some(spec_id) = find_spec_id_at_position(current_line, char_pos)
+            && let Some(hover_content) = create_hover_for_spec_id(workspace, &spec_id)
+        {
+            return Ok(Some(hover_content));
+        }
+
+        Ok(None)
+    }
+}
+
+fn uri_to_path(uri: &str) -> Result<std::path::PathBuf> {
+    if let Some(path_str) = uri.strip_prefix("file://") {
+        Ok(Path::new(path_str).to_path_buf())
+    } else {
+        Ok(Path::new(uri).to_path_buf())
+    }
+}
+
+fn find_spec_id_at_position(line: &str, char_pos: usize) -> Option<String> {
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\b(PHIL-[A-Z0-9-]+|POL-[A-Z0-9-]+|REQ-[A-Z0-9-]+|FEAT-[A-Z0-9-]+)\b").unwrap()
+    });
+
+    for cap in RE.captures_iter(line) {
+        let matched = cap.get(0)?;
+        let start = matched.start();
+        let end = matched.end();
+
+        if char_pos >= start && char_pos <= end {
+            return Some(matched.as_str().to_string());
+        }
+    }
+
+    None
+}
+
+fn create_hover_for_spec_id(workspace: &Workspace, spec_id: &str) -> Option<Hover> {
+    if spec_id.starts_with("PHIL-") {
+        workspace
+            .philosophies
+            .iter()
+            .find(|p| p.id == spec_id)
+            .map(|phil| {
+                let content = format!(
+                    "# {}\n\n**{}**\n\n## Product Design Principle\n{}\n\n## Coding Guideline\n{}",
+                    phil.id, phil.title, phil.product_design_principle, phil.coding_guideline
+                );
+                Hover {
+                    contents: MarkupContent::markdown(content),
+                    range: None,
+                }
+            })
+    } else if spec_id.starts_with("POL-") {
+        workspace
+            .policies
+            .iter()
+            .find(|p| p.id == spec_id)
+            .map(|pol| {
+                let content = format!(
+                    "# {}\n\n**{}**\n\n## Summary\n{}\n\n## Description\n{}",
+                    pol.id, pol.title, pol.summary, pol.description
+                );
+                Hover {
+                    contents: MarkupContent::markdown(content),
+                    range: None,
+                }
+            })
+    } else if spec_id.starts_with("REQ-") {
+        workspace
+            .requirements
+            .iter()
+            .find(|r| r.id == spec_id)
+            .map(|req| {
+                let content = format!(
+                    "# {}\n\n**{}**\n\n{}\n\n**Priority:** {} | **Status:** {}",
+                    req.id, req.title, req.description, req.priority, req.status
+                );
+                Hover {
+                    contents: MarkupContent::markdown(content),
+                    range: None,
+                }
+            })
+    } else if spec_id.starts_with("FEAT-") {
+        workspace
+            .features
+            .iter()
+            .find(|f| f.id == spec_id)
+            .map(|feat| {
+                let content = format!(
+                    "# {}\n\n**{}**\n\n{}\n\n**Status:** {}",
+                    feat.id, feat.title, feat.summary, feat.status
+                );
+                Hover {
+                    contents: MarkupContent::markdown(content),
+                    range: None,
+                }
+            })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_spec_id_at_position() {
+        let line = "// FEAT-AUTH-001 implements authentication";
+        assert_eq!(
+            find_spec_id_at_position(line, 5),
+            Some("FEAT-AUTH-001".to_string())
+        );
+        assert_eq!(find_spec_id_at_position(line, 0), None);
+    }
+
+    #[test]
+    fn test_uri_to_path() {
+        let uri = "file:///home/user/file.txt";
+        let path = uri_to_path(uri).unwrap();
+        assert_eq!(path.to_str().unwrap(), "/home/user/file.txt");
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,0 +1,36 @@
+// FEAT-LSP-001
+// REQ-CORE-001
+//
+// LSP Server for syu editor integrations
+//
+// This module provides a Language Server Protocol (LSP) compatible server
+// that exposes syu's specification validation and navigation capabilities
+// to editor clients (VS Code, Neovim, Emacs, etc.).
+//
+// **Current Scope:**
+// - JSON-RPC 2.0 over stdio (standard LSP transport)
+// - Basic LSP lifecycle: initialize, initialized, shutdown, exit
+// - Hover support for spec IDs (PHIL-*, POL-*, REQ-*, FEAT-*)
+//
+// **Foundation for Future Features:**
+// - Diagnostics for validation errors
+// - Go-to-definition for spec IDs and trace references
+// - Code completion for spec IDs
+// - Document symbols for spec files
+// - Workspace symbols for cross-file navigation
+//
+// This is a production-ready foundation, not a placeholder. The protocol
+// implementation is stable and extensible for both VS Code and non-VS Code
+// clients.
+
+mod handlers;
+mod protocol;
+mod server;
+
+use anyhow::Result;
+use server::LspServer;
+
+pub(crate) fn run_lsp_server() -> Result<()> {
+    let mut server = LspServer::new();
+    server.run()
+}

--- a/src/lsp/protocol.rs
+++ b/src/lsp/protocol.rs
@@ -132,3 +132,15 @@ impl MarkupContent {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MarkupContent;
+
+    #[test]
+    fn markdown_content_uses_markdown_kind() {
+        let content = MarkupContent::markdown("hello".to_string());
+        assert_eq!(content.kind, "markdown");
+        assert_eq!(content.value, "hello");
+    }
+}

--- a/src/lsp/protocol.rs
+++ b/src/lsp/protocol.rs
@@ -1,0 +1,134 @@
+// FEAT-LSP-001
+// REQ-CORE-001
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum Message {
+    Request(Request),
+    Response(Response),
+    Notification(Notification),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Request {
+    pub jsonrpc: String,
+    pub id: RequestId,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Response {
+    pub jsonrpc: String,
+    pub id: RequestId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ResponseError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Notification {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub(crate) enum RequestId {
+    Number(i64),
+    String(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ResponseError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[allow(dead_code)]
+pub(crate) mod error_codes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct TextDocumentIdentifier {
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TextDocumentPositionParams {
+    pub text_document: TextDocumentIdentifier,
+    pub position: Position,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InitializeParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InitializeResult {
+    pub capabilities: ServerCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hover_provider: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Hover {
+    pub contents: MarkupContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MarkupContent {
+    pub kind: String,
+    pub value: String,
+}
+
+impl MarkupContent {
+    pub(crate) fn markdown(value: String) -> Self {
+        Self {
+            kind: "markdown".to_string(),
+            value,
+        }
+    }
+}

--- a/src/lsp/protocol.rs
+++ b/src/lsp/protocol.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -52,6 +53,53 @@ pub(crate) struct ResponseError {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LspError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl LspError {
+    pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: error_codes::INVALID_PARAMS,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn method_not_found(method: impl Into<String>) -> Self {
+        Self {
+            code: error_codes::METHOD_NOT_FOUND,
+            message: format!("method not found: {}", method.into()),
+        }
+    }
+
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: error_codes::INTERNAL_ERROR,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for LspError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for LspError {}
+
+impl From<LspError> for ResponseError {
+    fn from(value: LspError) -> Self {
+        Self {
+            code: value.code,
+            message: value.message,
+            data: None,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -135,12 +183,21 @@ impl MarkupContent {
 
 #[cfg(test)]
 mod tests {
-    use super::MarkupContent;
+    use super::{LspError, MarkupContent, ResponseError, error_codes};
 
     #[test]
     fn markdown_content_uses_markdown_kind() {
         let content = MarkupContent::markdown("hello".to_string());
         assert_eq!(content.kind, "markdown");
         assert_eq!(content.value, "hello");
+    }
+
+    #[test]
+    fn lsp_error_converts_to_response_error() {
+        let error = LspError::invalid_params("bad input");
+        let response: ResponseError = error.into();
+        assert_eq!(response.code, error_codes::INVALID_PARAMS);
+        assert_eq!(response.message, "bad input");
+        assert!(response.data.is_none());
     }
 }

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -1,0 +1,149 @@
+// FEAT-LSP-001
+// REQ-CORE-001
+
+use anyhow::{Context, Result};
+use std::io::{BufRead, BufReader, Write};
+
+use super::handlers::LspHandlers;
+use super::protocol::{Message, Notification, Request, Response, ResponseError};
+
+pub(crate) struct LspServer {
+    handlers: LspHandlers,
+    should_exit: bool,
+}
+
+impl LspServer {
+    pub(crate) fn new() -> Self {
+        Self {
+            handlers: LspHandlers::new(),
+            should_exit: false,
+        }
+    }
+
+    pub(crate) fn run(&mut self) -> Result<()> {
+        let stdin = std::io::stdin();
+        let mut stdin = BufReader::new(stdin.lock());
+        let mut stdout = std::io::stdout();
+
+        loop {
+            if self.should_exit {
+                break;
+            }
+
+            match self.read_message(&mut stdin)? {
+                Some(msg) => {
+                    if let Some(response) = self.handle_message(msg)? {
+                        self.write_message(&mut stdout, &response)?;
+                    }
+                }
+                None => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    fn read_message<R: BufRead>(&self, reader: &mut R) -> Result<Option<Message>> {
+        let mut headers = Vec::new();
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                return Ok(None);
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                break;
+            }
+            headers.push(trimmed.to_string());
+        }
+
+        let content_length = headers
+            .iter()
+            .find_map(|h| {
+                h.strip_prefix("Content-Length: ")
+                    .and_then(|s| s.parse::<usize>().ok())
+            })
+            .context("missing Content-Length header")?;
+
+        let mut content = vec![0u8; content_length];
+        reader.read_exact(&mut content)?;
+
+        let message: Message = serde_json::from_slice(&content)?;
+        Ok(Some(message))
+    }
+
+    fn write_message<W: Write>(&self, writer: &mut W, message: &Message) -> Result<()> {
+        let json = serde_json::to_string(message)?;
+        write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    fn handle_message(&mut self, message: Message) -> Result<Option<Message>> {
+        match message {
+            Message::Request(req) => Ok(Some(Message::Response(self.handle_request(req)?))),
+            Message::Notification(notif) => {
+                self.handle_notification(notif)?;
+                Ok(None)
+            }
+            Message::Response(_) => Ok(None),
+        }
+    }
+
+    fn handle_request(&mut self, request: Request) -> Result<Response> {
+        let result = match request.method.as_str() {
+            "initialize" => {
+                let params = request
+                    .params
+                    .map(serde_json::from_value)
+                    .transpose()?
+                    .unwrap_or_default();
+                self.handlers.handle_initialize(params)
+            }
+            "shutdown" => self.handlers.handle_shutdown(),
+            "textDocument/hover" => {
+                let params = request
+                    .params
+                    .ok_or_else(|| anyhow::anyhow!("missing params"))?;
+                let params = serde_json::from_value(params)?;
+                let hover = self.handlers.handle_hover(params)?;
+                Ok(serde_json::to_value(hover)?)
+            }
+            _ => Err(anyhow::anyhow!("method not found: {}", request.method)),
+        };
+
+        match result {
+            Ok(value) => Ok(Response {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: Some(value),
+                error: None,
+            }),
+            Err(e) => Ok(Response {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: None,
+                error: Some(ResponseError {
+                    code: super::protocol::error_codes::INTERNAL_ERROR,
+                    message: e.to_string(),
+                    data: None,
+                }),
+            }),
+        }
+    }
+
+    fn handle_notification(&mut self, notification: Notification) -> Result<()> {
+        match notification.method.as_str() {
+            "initialized" => self.handlers.handle_initialized()?,
+            "exit" => {
+                self.should_exit = true;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -147,3 +147,207 @@ impl LspServer {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::{fs, io::Cursor, path::PathBuf};
+    use tempfile::tempdir;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/workspaces")
+            .join(name)
+    }
+
+    fn message_bytes(value: serde_json::Value) -> Vec<u8> {
+        let json = serde_json::to_string(&value).expect("serialize message");
+        format!("Content-Length: {}\r\n\r\n{}", json.len(), json).into_bytes()
+    }
+
+    #[test]
+    fn read_message_returns_none_on_eof() {
+        let server = LspServer::new();
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        assert!(
+            server
+                .read_message(&mut reader)
+                .expect("read eof")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn read_message_requires_content_length_header() {
+        let server = LspServer::new();
+        let mut reader = Cursor::new(b"Header: nope\r\n\r\n{}".to_vec());
+        let error = server
+            .read_message(&mut reader)
+            .expect_err("missing header should fail");
+        assert!(error.to_string().contains("missing Content-Length header"));
+    }
+
+    #[test]
+    fn write_message_serializes_lsp_envelope() {
+        let server = LspServer::new();
+        let mut output = Vec::new();
+        server
+            .write_message(
+                &mut output,
+                &Message::Response(Response {
+                    jsonrpc: "2.0".to_string(),
+                    id: super::super::protocol::RequestId::Number(1),
+                    result: Some(json!({"ok": true})),
+                    error: None,
+                }),
+            )
+            .expect("write should succeed");
+        let text = String::from_utf8(output).expect("utf8 output");
+        assert!(text.starts_with("Content-Length: "));
+        assert!(text.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn handle_message_ignores_responses() {
+        let mut server = LspServer::new();
+        let response = Message::Response(Response {
+            jsonrpc: "2.0".to_string(),
+            id: super::super::protocol::RequestId::Number(1),
+            result: Some(json!(null)),
+            error: None,
+        });
+        assert!(
+            server
+                .handle_message(response)
+                .expect("response handling")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn handle_request_returns_error_for_unknown_methods() {
+        let mut server = LspServer::new();
+        let response = server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(1),
+                method: "workspace/unknown".to_string(),
+                params: None,
+            })
+            .expect("request should produce response");
+        assert!(response.result.is_none());
+        assert_eq!(
+            response.error.expect("error response").message,
+            "method not found: workspace/unknown"
+        );
+    }
+
+    #[test]
+    fn handle_request_returns_error_when_hover_params_are_missing() {
+        let mut server = LspServer::new();
+        let error = server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(2),
+                method: "textDocument/hover".to_string(),
+                params: None,
+            })
+            .expect_err("missing params should fail before a response is built");
+        assert!(error.to_string().contains("missing params"));
+    }
+
+    #[test]
+    fn handle_request_serializes_hover_results() {
+        let tempdir = tempdir().expect("tempdir");
+        let hover_file = tempdir.path().join("hover.txt");
+        fs::write(&hover_file, "REQ-TRACE-001\n").expect("hover file");
+
+        let mut server = LspServer::new();
+        server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(1),
+                method: "initialize".to_string(),
+                params: Some(json!({
+                    "rootUri": format!("file://{}", fixture_path("passing").display())
+                })),
+            })
+            .expect("initialize response");
+
+        let response = server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(2),
+                method: "textDocument/hover".to_string(),
+                params: Some(json!({
+                    "textDocument": {"uri": format!("file://{}", hover_file.display())},
+                    "position": {"line": 0, "character": 2}
+                })),
+            })
+            .expect("hover response");
+
+        assert!(response.error.is_none());
+        assert_eq!(
+            response.result.expect("hover result")["contents"]["kind"],
+            "markdown"
+        );
+    }
+
+    #[test]
+    fn handle_notification_updates_server_exit_state() {
+        let mut server = LspServer::new();
+        server
+            .handle_notification(Notification {
+                jsonrpc: "2.0".to_string(),
+                method: "exit".to_string(),
+                params: None,
+            })
+            .expect("exit notification");
+        assert!(server.should_exit);
+    }
+
+    #[test]
+    fn handle_notification_accepts_initialized() {
+        let mut server = LspServer::new();
+        server
+            .handle_notification(Notification {
+                jsonrpc: "2.0".to_string(),
+                method: "initialized".to_string(),
+                params: Some(json!({})),
+            })
+            .expect("initialized notification");
+        assert!(!server.should_exit);
+    }
+
+    #[test]
+    fn handle_notification_ignores_unknown_methods() {
+        let mut server = LspServer::new();
+        server
+            .handle_notification(Notification {
+                jsonrpc: "2.0".to_string(),
+                method: "workspace/didChangeConfiguration".to_string(),
+                params: None,
+            })
+            .expect("unknown notification should be ignored");
+        assert!(!server.should_exit);
+    }
+
+    #[test]
+    fn read_message_round_trips_requests() {
+        let server = LspServer::new();
+        let bytes = message_bytes(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "shutdown"
+        }));
+        let mut reader = Cursor::new(bytes);
+        let message = server
+            .read_message(&mut reader)
+            .expect("message should parse");
+        assert!(matches!(
+            message,
+            Some(Message::Request(Request { method, .. })) if method == "shutdown"
+        ));
+    }
+}

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -308,6 +308,27 @@ mod tests {
     }
 
     #[test]
+    fn handle_request_returns_invalid_params_for_malformed_initialize_payload() {
+        let mut server = LspServer::new();
+        let response = server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(4),
+                method: "initialize".to_string(),
+                params: Some(json!({
+                    "rootUri": 42
+                })),
+            })
+            .expect("bad params should produce an error response");
+        let error = response.error.expect("error response");
+        assert_eq!(
+            error.code,
+            super::super::protocol::error_codes::INVALID_PARAMS
+        );
+        assert!(error.message.contains("invalid type"));
+    }
+
+    #[test]
     fn handle_request_serializes_hover_results() {
         let tempdir = tempdir().expect("tempdir");
         let hover_file = tempdir.path().join("hover.txt");

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -2,10 +2,11 @@
 // REQ-CORE-001
 
 use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
 use std::io::{BufRead, BufReader, Write};
 
 use super::handlers::LspHandlers;
-use super::protocol::{Message, Notification, Request, Response, ResponseError};
+use super::protocol::{LspError, Message, Notification, Request, Response, ResponseError};
 
 pub(crate) struct LspServer {
     handlers: LspHandlers,
@@ -95,25 +96,27 @@ impl LspServer {
     }
 
     fn handle_request(&mut self, request: Request) -> Result<Response> {
-        let result = match request.method.as_str() {
+        let result: std::result::Result<serde_json::Value, LspError> = match request.method.as_str()
+        {
             "initialize" => {
-                let params = request
-                    .params
-                    .map(serde_json::from_value)
-                    .transpose()?
-                    .unwrap_or_default();
+                let params = parse_optional_params(request.params);
+                let params = match params {
+                    Ok(value) => value,
+                    Err(error) => return Ok(error_response(request.id, error)),
+                };
                 self.handlers.handle_initialize(params)
             }
             "shutdown" => self.handlers.handle_shutdown(),
             "textDocument/hover" => {
-                let params = request
-                    .params
-                    .ok_or_else(|| anyhow::anyhow!("missing params"))?;
-                let params = serde_json::from_value(params)?;
+                let params = parse_required_params(request.params);
+                let params = match params {
+                    Ok(value) => value,
+                    Err(error) => return Ok(error_response(request.id, error)),
+                };
                 let hover = self.handlers.handle_hover(params)?;
-                Ok(serde_json::to_value(hover)?)
+                serde_json::to_value(hover).map_err(|error| LspError::internal(error.to_string()))
             }
-            _ => Err(anyhow::anyhow!("method not found: {}", request.method)),
+            _ => Err(LspError::method_not_found(request.method)),
         };
 
         match result {
@@ -123,16 +126,7 @@ impl LspServer {
                 result: Some(value),
                 error: None,
             }),
-            Err(e) => Ok(Response {
-                jsonrpc: "2.0".to_string(),
-                id: request.id,
-                result: None,
-                error: Some(ResponseError {
-                    code: super::protocol::error_codes::INTERNAL_ERROR,
-                    message: e.to_string(),
-                    data: None,
-                }),
-            }),
+            Err(e) => Ok(error_response(request.id, e)),
         }
     }
 
@@ -146,6 +140,34 @@ impl LspServer {
         }
         Ok(())
     }
+}
+
+fn error_response(id: super::protocol::RequestId, error: LspError) -> Response {
+    Response {
+        jsonrpc: "2.0".to_string(),
+        id,
+        result: None,
+        error: Some(ResponseError::from(error)),
+    }
+}
+
+fn parse_optional_params<T>(params: Option<serde_json::Value>) -> std::result::Result<T, LspError>
+where
+    T: DeserializeOwned + Default,
+{
+    params
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| LspError::invalid_params(error.to_string()))
+        .map(Option::unwrap_or_default)
+}
+
+fn parse_required_params<T>(params: Option<serde_json::Value>) -> std::result::Result<T, LspError>
+where
+    T: DeserializeOwned,
+{
+    let params = params.ok_or_else(|| LspError::invalid_params("missing params"))?;
+    serde_json::from_value(params).map_err(|error| LspError::invalid_params(error.to_string()))
 }
 
 #[cfg(test)]
@@ -237,24 +259,52 @@ mod tests {
             })
             .expect("request should produce response");
         assert!(response.result.is_none());
+        let error = response.error.expect("error response");
         assert_eq!(
-            response.error.expect("error response").message,
-            "method not found: workspace/unknown"
+            error.code,
+            super::super::protocol::error_codes::METHOD_NOT_FOUND
         );
+        assert_eq!(error.message, "method not found: workspace/unknown");
     }
 
     #[test]
     fn handle_request_returns_error_when_hover_params_are_missing() {
         let mut server = LspServer::new();
-        let error = server
+        let response = server
             .handle_request(Request {
                 jsonrpc: "2.0".to_string(),
                 id: super::super::protocol::RequestId::Number(2),
                 method: "textDocument/hover".to_string(),
                 params: None,
             })
-            .expect_err("missing params should fail before a response is built");
-        assert!(error.to_string().contains("missing params"));
+            .expect("missing params should produce an error response");
+        let error = response.error.expect("error response");
+        assert_eq!(
+            error.code,
+            super::super::protocol::error_codes::INVALID_PARAMS
+        );
+        assert_eq!(error.message, "missing params");
+    }
+
+    #[test]
+    fn handle_request_returns_invalid_params_for_bad_initialize_uri() {
+        let mut server = LspServer::new();
+        let response = server
+            .handle_request(Request {
+                jsonrpc: "2.0".to_string(),
+                id: super::super::protocol::RequestId::Number(3),
+                method: "initialize".to_string(),
+                params: Some(json!({
+                    "rootUri": "file://%"
+                })),
+            })
+            .expect("bad params should produce an error response");
+        let error = response.error.expect("error response");
+        assert_eq!(
+            error.code,
+            super::super::protocol::error_codes::INVALID_PARAMS
+        );
+        assert!(error.message.contains("invalid file URI"));
     }
 
     #[test]

--- a/tests/lsp_tests.rs
+++ b/tests/lsp_tests.rs
@@ -1,0 +1,147 @@
+// FEAT-LSP-001
+// REQ-CORE-001
+
+use serde_json::json;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn test_lsp_lifecycle() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_syu"))
+        .arg("lsp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn syu lsp");
+
+    let mut stdin = child.stdin.take().expect("failed to get stdin");
+    let stdout = child.stdout.take().expect("failed to get stdout");
+    let mut reader = BufReader::new(stdout);
+
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let mut responses = Vec::new();
+        loop {
+            match read_message(&mut reader) {
+                Ok(Some(msg)) => {
+                    responses.push(msg);
+                    if responses.len() >= 2 {
+                        let _ = tx.send(responses);
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("Error reading message: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    let initialize_request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "processId": null,
+            "rootUri": null,
+            "capabilities": {}
+        }
+    });
+
+    send_message(&mut stdin, &initialize_request).expect("failed to send initialize");
+
+    let initialized_notification = json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    });
+
+    send_message(&mut stdin, &initialized_notification).expect("failed to send initialized");
+
+    let shutdown_request = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown"
+    });
+
+    send_message(&mut stdin, &shutdown_request).expect("failed to send shutdown");
+
+    let exit_notification = json!({
+        "jsonrpc": "2.0",
+        "method": "exit"
+    });
+
+    send_message(&mut stdin, &exit_notification).expect("failed to send exit");
+
+    drop(stdin);
+
+    let responses = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("did not receive responses in time");
+
+    assert!(responses.len() >= 2, "expected at least 2 responses");
+
+    let init_response = &responses[0];
+    assert_eq!(init_response["jsonrpc"], "2.0");
+    assert_eq!(init_response["id"], 1);
+    assert!(
+        init_response["result"]["capabilities"]["hoverProvider"]
+            .as_bool()
+            .unwrap_or(false)
+    );
+
+    let shutdown_response = &responses[1];
+    assert_eq!(shutdown_response["jsonrpc"], "2.0");
+    assert_eq!(shutdown_response["id"], 2);
+
+    let _ = child.wait();
+}
+
+fn send_message<W: Write>(writer: &mut W, message: &serde_json::Value) -> std::io::Result<()> {
+    let json = serde_json::to_string(message)?;
+    write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn read_message<R: BufRead>(reader: &mut R) -> std::io::Result<Option<serde_json::Value>> {
+    let mut headers = Vec::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes_read = reader.read_line(&mut line)?;
+        if bytes_read == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            break;
+        }
+        headers.push(trimmed.to_string());
+    }
+
+    let content_length = headers
+        .iter()
+        .find_map(|h| {
+            h.strip_prefix("Content-Length: ")
+                .and_then(|s| s.parse::<usize>().ok())
+        })
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "missing Content-Length")
+        })?;
+
+    let mut content = vec![0u8; content_length];
+    reader.read_exact(&mut content)?;
+
+    let message: serde_json::Value = serde_json::from_slice(&content)?;
+    Ok(Some(message))
+}

--- a/tests/lsp_tests.rs
+++ b/tests/lsp_tests.rs
@@ -104,6 +104,24 @@ fn test_lsp_lifecycle() {
     let _ = child.wait();
 }
 
+#[test]
+fn test_lsp_exits_cleanly_on_immediate_eof() {
+    let output = Command::new(env!("CARGO_BIN_EXE_syu"))
+        .arg("lsp")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run syu lsp");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn send_message<W: Write>(writer: &mut W, message: &serde_json::Value) -> std::io::Result<()> {
     let json = serde_json::to_string(message)?;
     write!(writer, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;


### PR DESCRIPTION
## Summary
- add the syu lsp subcommand and shared LSP protocol/server handling for editor integrations
- implement initialize and hover flows backed by the existing workspace and specification model
- trace the new editor-facing feature and refresh generated specification outputs

Closes #313