### PR TITLE
fix(FEAT-QUALITY-001): cache pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
           cache: pip
           cache-dependency-path: .pre-commit-config.yaml
 
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
       - name: Install pre-commit
         run: python -m pip install --upgrade pip pre-commit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Set up Python with pip cache
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -62,7 +63,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             pre-commit-${{ runner.os }}-
 

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -85,6 +85,9 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - tool: cargo-audit
           - Set up Python with pip cache
           - cache-dependency-path: app/package-lock.json
+          - Cache pre-commit hooks
+          - actions/cache@v4
+          - ~/.cache/pre-commit
           - scripts/ci/pinned-npm.sh install app
           - scripts/ci/pinned-npm.sh install website
           - Build browser app bundle
@@ -197,6 +200,9 @@ features:
             - "tool: cargo-audit"
             - Set up Python with pip cache
             - "cache-dependency-path: app/package-lock.json"
+            - Cache pre-commit hooks
+            - actions/cache@v4
+            - "~/.cache/pre-commit"
             - scripts/ci/pinned-npm.sh install app
             - scripts/ci/pinned-npm.sh install website
             - Build browser app bundle

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -70,6 +70,9 @@ features:
             - "tool: cargo-audit"
             - Set up Python with pip cache
             - "cache-dependency-path: app/package-lock.json"
+            - Cache pre-commit hooks
+            - actions/cache@v4
+            - "~/.cache/pre-commit"
             - scripts/ci/pinned-npm.sh install app
             - scripts/ci/pinned-npm.sh install website
             - Build browser app bundle

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1097,6 +1097,9 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(ci_workflow.contains("Set up Python with pip cache"));
     assert!(ci_workflow.contains("cache: pip"));
     assert!(ci_workflow.contains("cache-dependency-path: .pre-commit-config.yaml"));
+    assert!(ci_workflow.contains("Cache pre-commit hooks"));
+    assert!(ci_workflow.contains("actions/cache@v4"));
+    assert!(ci_workflow.contains("~/.cache/pre-commit"));
     assert!(ci_workflow.contains("cache-dependency-path: app/package-lock.json"));
     assert!(browser_app_freshness.contains("npm ci"));
     assert!(ci_workflow.contains("docs-site:"));


### PR DESCRIPTION
## Summary\n- cache the pre-commit hook environment in CI so repeated runs reuse downloaded hooks\n- document the cache step in the repository quality spec and generated docs\n- extend the repository quality test to cover the new cache step\n\nCloses #600