### PR TITLE
fix(ci): ignore Python bytecode caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .tooling
 .DS_Store
 __pycache__/
-*.pyc
+*.py[cod]
 # FEAT-CONTRIB-002: keep contributor-local helper worktrees out of routine status output
 /.worktrees/
 website/.docusaurus

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 .tooling
 .DS_Store
+__pycache__/
+*.pyc
 # FEAT-CONTRIB-002: keep contributor-local helper worktrees out of routine status output
 /.worktrees/
 website/.docusaurus


### PR DESCRIPTION
## Summary\n- ignore Python bytecode caches so scripts under scripts/ci do not leave untracked artifacts behind\n\nCloses #605