### PR TITLE
docs(FEAT-DOCS-001): promote audit and report as reviewer tools

### DIFF
--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -50,6 +50,8 @@ syu relate FEAT-CHECK-001
 syu trace src/command/check.rs --symbol run_check_command
 syu log FEAT-CHECK-001 --kind implementation --path src/command
 syu validate . --id FEAT-CHECK-001
+syu audit .
+syu report .
 ```
 
 ### Share the current state

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -20,6 +20,7 @@ If a pull request already exists, pair this page with the
 | Check the workspace | `syu validate .` | run the full graph, trace, and coverage validation pass |
 | Focus one validation view | `syu validate . --id FEAT-CHECK-001` | keep the visible output anchored on one requirement or feature after the normal validation run |
 | Focus trace failures first | `syu validate . --genre trace` | inspect trace-specific problems before reading the full validation output |
+| Audit a review target | `syu audit .` | scan for likely overlap, drift, and other review notes before you decide whether `validate` should fail |
 | Generate the Markdown report | `syu report .` | save the current validation result as a shareable report |
 | Inspect one spec item | `syu show FEAT-CHECK-001` | read the title, links, traces, and status for one philosophy, policy, requirement, or feature |
 | Expand the nearby graph | `syu relate FEAT-CHECK-001` | see linked policies, requirements, features, files, and symbols around one selector |

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -13,7 +13,7 @@ history.
 3. **What changed recently in those traced paths?**
 
 The commands below answer those questions with `show`/`relate`, `trace`,
-`explain`, and `log`.
+`audit`, `report`, `explain`, and `log`.
 
 If you review from the terminal often, generate shell completions once so spec
 IDs and subcommands stay close at hand:
@@ -79,14 +79,25 @@ When you want the same selector flexibility but a more opinionated summary, run
 relate`, then turns the result into a focused assessment with the connected
 chain, traces in scope, and obvious gaps that still need review.
 
-For bigger spec edits or cleanup PRs, add a quick heuristic audit pass:
+For bigger spec edits or cleanup PRs, add a quick heuristic audit pass before
+you decide whether the PR really belongs in `validate`:
 
 ```bash
 syu audit .
 ```
 
-That summary is useful when you want review notes about likely overlap,
-policy drift, or policy text that no longer turns into concrete requirements.
+`syu audit` is the fast reviewer lens: it highlights likely overlap, policy
+drift, and spec text that no longer turns into concrete requirements. When the
+audit points at something you need to share with the author, turn it into a
+report:
+
+```bash
+syu report .
+```
+
+`syu report` gives you a shareable snapshot of the current validation state.
+Use it to hand off findings, then return to `syu validate .` once the fixes are
+in place.
 
 ## 3. Jump from code back to the owning spec
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -644,6 +644,7 @@ fn repository_declares_documentation_guides() {
     assert!(command_card.contains("syu templates"));
     assert!(command_card.contains("syu validate . --id FEAT-CHECK-001"));
     assert!(command_card.contains("syu audit ."));
+    assert!(command_card.contains("syu report ."));
     assert!(command_card.contains("scan for likely overlap"));
     assert!(command_card.contains("syu app ."));
     assert!(command_card.contains("[reviewer workflow](./reviewer-workflow.md)"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -643,6 +643,8 @@ fn repository_declares_documentation_guides() {
     assert!(command_card.contains("| Task | Command | Choose it when |"));
     assert!(command_card.contains("syu templates"));
     assert!(command_card.contains("syu validate . --id FEAT-CHECK-001"));
+    assert!(command_card.contains("syu audit ."));
+    assert!(command_card.contains("scan for likely overlap"));
     assert!(command_card.contains("syu app ."));
     assert!(command_card.contains("[reviewer workflow](./reviewer-workflow.md)"));
     assert!(vscode_guide.contains("CLI-backed first"));
@@ -676,6 +678,8 @@ fn repository_declares_documentation_guides() {
     let reviewer_workflow = read_file("docs/guide/reviewer-workflow.md");
     assert!(reviewer_workflow.contains("[command card](./command-card.md)"));
     assert!(reviewer_workflow.contains("currently traced"));
+    assert!(reviewer_workflow.contains("audit"));
+    assert!(reviewer_workflow.contains("syu report"));
     assert!(reviewer_workflow.contains("the whole PR diff is covered"));
     assert!(reviewer_workflow.contains("too-small log result with the PR diff"));
     assert!(reviewer_workflow.contains("filtered down to that item"));


### PR DESCRIPTION
Adds a reviewer-focused entry point that explains when to use audit versus validate, and how to move from audit to report to re-validation.\n\nCloses #603