### PR TITLE
Guard Python bytecode ignores

### DIFF
--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1059,6 +1059,8 @@ fn repository_declares_contribution_workflow_assets() {
 
     assert!(gitignore.contains("FEAT-CONTRIB-002"));
     assert!(gitignore.contains("/.worktrees/"));
+    assert!(gitignore.contains("__pycache__/"));
+    assert!(gitignore.contains("*.py[cod]"));
 }
 
 #[test]


### PR DESCRIPTION
Adds a repo-quality assertion so scripts/ci Python bytecode caches stay ignored under .gitignore.\n\nValidation: cargo test repository_declares_contribution_workflow_assets -- --nocapture, bash scripts/ci/quality-gates.sh, git push pre-push checks.