### PR TITLE
Cache quality CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,23 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Rust
+      - name: Set up Rust for quality gates
         uses: ./.github/actions/setup-rust
         with:
           components: rustfmt,clippy
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "25"
-          cache: npm
-          cache-dependency-path: app/package-lock.json
-
-      - name: Install browser app dependencies
-        shell: bash
-        run: |
-          scripts/ci/pinned-npm.sh install app
-          npm --prefix app ci
 
       - name: Run quality gates
         run: scripts/ci/quality-gates.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
         with:
           components: rustfmt,clippy
 
+      - name: Install browser app dependencies
+        shell: bash
+        run: |
+          scripts/ci/pinned-npm.sh install app
+          npm --prefix app ci
+
       - name: Run quality gates
         run: scripts/ci/quality-gates.sh
 

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1102,6 +1102,8 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(ci_workflow.contains("~/.cache/pre-commit"));
     assert!(ci_workflow.contains("cache-dependency-path: app/package-lock.json"));
     assert!(ci_workflow.contains("Set up Rust for quality gates"));
+    assert!(ci_workflow.contains("Install browser app dependencies"));
+    assert!(ci_workflow.contains("npm --prefix app ci"));
     assert!(browser_app_freshness.contains("npm ci"));
     assert!(ci_workflow.contains("docs-site:"));
     assert!(ci_workflow.contains("./.github/actions/build-docs-site"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -1101,6 +1101,7 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
     assert!(ci_workflow.contains("actions/cache@v4"));
     assert!(ci_workflow.contains("~/.cache/pre-commit"));
     assert!(ci_workflow.contains("cache-dependency-path: app/package-lock.json"));
+    assert!(ci_workflow.contains("Set up Rust for quality gates"));
     assert!(browser_app_freshness.contains("npm ci"));
     assert!(ci_workflow.contains("docs-site:"));
     assert!(ci_workflow.contains("./.github/actions/build-docs-site"));


### PR DESCRIPTION
Uses the shared Rust setup in the quality job so the Rust-heavy CI path reuses the same caches as the other workflow jobs.\n\nValidation: cargo test repository_declares_dependency_hygiene_and_ci_caching -- --nocapture, bash scripts/ci/quality-gates.sh, git push pre-push checks.