### PR TITLE
docs(onboarding): make the first 10 minutes smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Pick the newcomer path that matches what you need next:
 
 - **Getting started**: choose this if you are new to `syu`, want a guided first
   run, and do **not** already know the four-layer model. Expect the most
-  hand-holding and roughly 10-15 minutes for the first workspace setup.
+  hand-holding and roughly 10-15 minutes for the first workspace setup, with a
+  guided `doctor → init → validate → browse` path.
 - **Quick start**: stay in this README when you want a compact, self-contained
   reference card, are happy with a short layer refresher, and want the fastest
   install-to-`syu validate .` path in about 5 minutes.

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -15,6 +15,7 @@ If a pull request already exists, pair this page with the
 | --- | --- | --- |
 | Install or verify the CLI | `syu --version` | confirm the installed binary is on your `PATH` before you start editing a workspace |
 | Compare starter layouts | `syu templates` | choose between docs-first, language-first, or polyglot scaffolds before `init` |
+| Check local readiness | `syu doctor .` | confirm the Rust, Node, and browser-app dependencies are ready before you scaffold or validate |
 | Scaffold a workspace | `syu init .` | create the default four-layer tree in the current directory |
 | Scaffold with another starter | `syu init . --template rust-only` | begin from a language-shaped or docs-first layout instead of the generic starter |
 | Check the workspace | `syu validate .` | run the full graph, trace, and coverage validation pass |
@@ -37,6 +38,7 @@ If a pull request already exists, pair this page with the
 ### First workspace pass
 
 ```bash
+syu doctor .
 syu init .
 syu validate .
 syu browse .

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -69,6 +69,8 @@ instead? Use [Before you begin](#before-you-begin). Want the narrated version
 of the same flow? Continue with
 [Is syu right for this repository?](#is-syu-right-for-this-repository).
 
+That first pass is intentionally short: `doctor → init → validate → browse`.
+
 ## Is syu right for this repository?
 
 Use the canonical fit check in the

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -18,7 +18,7 @@ Need a different level of guidance?
   when you want the shortest install-to-validate path and are happy with a
   compact command card.
 - Open the [command card](./command-card.md) when you already understand the
-  model and want one docs-site page that keeps the core install / init /
+  model and want one docs-site page that keeps the core install / doctor / init /
   validate / report / browse / app / review commands close at hand.
 - Follow [existing repository adoption](./existing-repository.md) when the
   repository already has code and history and you want to add `syu` without
@@ -57,12 +57,14 @@ longer installer discussion in [Before you begin](#before-you-begin).
 RELEASE=v0.0.1-alpha.8
 # x-release-please-end
 curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_VERSION=alpha bash
+syu doctor .
 syu init .
 syu validate .
+syu browse .
 ```
 
 If `syu` is already installed, skip the installer line and start with
-`syu init .`. Need the verified-download, Windows, or source-build variants
+`syu doctor .`. Need the verified-download, Windows, or source-build variants
 instead? Use [Before you begin](#before-you-begin). Want the narrated version
 of the same flow? Continue with
 [Is syu right for this repository?](#is-syu-right-for-this-repository).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,10 +27,11 @@ use crate::command::init::{starter_template_example_commands, starter_template_n
 const ROOT_AFTER_HELP: &str = "\
 New here?
   1. syu templates   compare starter layouts before you scaffold
-  2. syu init .      scaffold a workspace in the current directory
-  3. syu validate .  check the layered spec and traceability
-  4. syu browse .    explore the spec in your terminal
-  5. syu app .       start the local browser UI server";
+  2. syu doctor .    check local contributor-tooling readiness
+  3. syu init .      scaffold a workspace in the current directory
+  4. syu validate .  check the layered spec and traceability
+  5. syu browse .    explore the spec in your terminal
+  6. syu app .       start the local browser UI server";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -25,6 +25,7 @@ fn root_help_includes_start_here_guidance() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("New here?"));
     assert!(stdout.contains("syu templates"));
+    assert!(stdout.contains("syu doctor ."));
     assert!(stdout.contains("syu init ."));
     assert!(stdout.contains("syu validate ."));
     assert!(stdout.contains("syu browse ."));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -464,6 +464,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("**Visual explorer**"));
     assert!(readme.contains("**Reviewer workflow**"));
     assert!(readme.contains("**Contributor runtime setup**"));
+    assert!(readme.contains("guided `doctor → init → validate → browse` path"));
     assert!(readme.contains("new to `syu`"));
     assert!(readme.contains("already have a workspace"));
     assert!(readme.contains("10-15 minutes"));
@@ -487,6 +488,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu validate"));
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
+    assert!(readme.contains("syu doctor ."));
     assert!(readme.contains("### Command chooser"));
     assert!(readme.contains("check whether your workspace currently validates"));
     assert!(readme.contains("syu validate ."));
@@ -579,9 +581,11 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("latest published alpha"));
     assert_newcomer_template_examples(&getting_started);
     assert!(getting_started.contains("syu templates"));
+    assert!(getting_started.contains("syu doctor ."));
     assert!(getting_started.contains("--id-prefix"));
     assert!(getting_started.contains("syu validate . --fix"));
     assert!(getting_started.contains("syu browse ."));
+    assert!(getting_started.contains("doctor → init → validate → browse"));
     assert!(getting_started.contains("If you only remember the task and not the command name yet"));
     assert!(
         getting_started
@@ -642,6 +646,7 @@ fn repository_declares_documentation_guides() {
     assert!(command_card.contains("# syu command card"));
     assert!(command_card.contains("| Task | Command | Choose it when |"));
     assert!(command_card.contains("syu templates"));
+    assert!(command_card.contains("syu doctor ."));
     assert!(command_card.contains("syu validate . --id FEAT-CHECK-001"));
     assert!(command_card.contains("syu audit ."));
     assert!(command_card.contains("syu report ."));


### PR DESCRIPTION
Closes #604\n\nTighten the first-run onboarding path around doctor, init, validate, and browse.