### PR TITLE
feat(cli): add review alias for range tracing

### DIFF
--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -24,6 +24,7 @@ If a pull request already exists, pair this page with the
 | Generate the Markdown report | `syu report .` | save the current validation result as a shareable report |
 | Inspect one spec item | `syu show FEAT-CHECK-001` | read the title, links, traces, and status for one philosophy, policy, requirement, or feature |
 | Expand the nearby graph | `syu relate FEAT-CHECK-001` | see linked policies, requirements, features, files, and symbols around one selector |
+| Review a PR range | `syu review --range origin/main...HEAD` | summarize the changed files in one reviewer-friendly pass before you drill into `show`, `relate`, or `log` |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |
 | Search by keyword or ID | `syu search validation --kind feature` | find the right spec item before `show`, `relate`, or `log` |

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -12,8 +12,8 @@ history.
 2. **Which files and symbols currently claim that work?**
 3. **What changed recently in those traced paths?**
 
-The commands below answer those questions with `show`/`relate`, `trace`,
-`audit`, `report`, `explain`, and `log`.
+The commands below answer those questions with `show`/`relate`, `review`
+(`trace --range`), `trace`, `audit`, `report`, `explain`, and `log`.
 
 If you review from the terminal often, generate shell completions once so spec
 IDs and subcommands stay close at hand:
@@ -73,6 +73,18 @@ syu relate FEAT-CHECK-001
 Use this output to decide whether the PR still matches the connected policy and
 requirement context, or whether it is changing the behavior in a way that
 should have updated adjacent YAML too.
+
+When you already have a PR range and want one command that reads like a review
+summary, use the reviewer alias:
+
+```bash
+syu review --range origin/main...HEAD
+```
+
+`syu review` is a friendly entry point for the same range tracing logic. It
+summarizes changed files, surfaces unowned or skipped paths inline, and keeps
+the follow-up `show`, `relate`, `log`, and `validate --id` commands close at
+hand.
 
 When you want the same selector flexibility but a more opinionated summary, run
 `syu explain TARGET`. It keeps the ID/path/symbol entry points from `syu

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,6 +142,7 @@ Examples:
   syu trace src/rust_feature.rs
   syu trace src/rust_feature.rs --symbol feature_trace_rust
   syu trace src/rust_feature.rs path/to/workspace --format json
+  syu review --range origin/main...HEAD
   syu trace --range main..HEAD
   syu trace --range origin/main...HEAD --format json";
 
@@ -230,6 +231,7 @@ pub enum Commands {
     )]
     Relate(RelateArgs),
     #[command(
+        visible_alias = "review",
         about = "Resolve linked requirements, features, policies, and philosophies from a traced file or symbol",
         after_help = TRACE_AFTER_HELP
     )]

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -53,8 +53,8 @@ fn app_help_mentions_remote_bind_opt_in() {
 #[test]
 fn workspace_help_uses_current_directory_default_consistently() {
     for command in [
-        "browse", "show", "search", "trace", "app", "doctor", "validate", "check", "report", "add",
-        "relate", "log", "audit", "explain",
+        "browse", "show", "search", "trace", "review", "app", "doctor", "validate", "check",
+        "report", "add", "relate", "log", "audit", "explain",
     ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -645,6 +645,7 @@ fn repository_declares_documentation_guides() {
     assert!(command_card.contains("syu validate . --id FEAT-CHECK-001"));
     assert!(command_card.contains("syu audit ."));
     assert!(command_card.contains("syu report ."));
+    assert!(command_card.contains("syu review --range origin/main...HEAD"));
     assert!(command_card.contains("scan for likely overlap"));
     assert!(command_card.contains("syu app ."));
     assert!(command_card.contains("[reviewer workflow](./reviewer-workflow.md)"));
@@ -681,6 +682,7 @@ fn repository_declares_documentation_guides() {
     assert!(reviewer_workflow.contains("currently traced"));
     assert!(reviewer_workflow.contains("audit"));
     assert!(reviewer_workflow.contains("syu report"));
+    assert!(reviewer_workflow.contains("syu review --range origin/main...HEAD"));
     assert!(reviewer_workflow.contains("the whole PR diff is covered"));
     assert!(reviewer_workflow.contains("too-small log result with the PR diff"));
     assert!(reviewer_workflow.contains("filtered down to that item"));


### PR DESCRIPTION
Closes #584\n\nAdd a reviewer-friendly syu review alias for trace --range and document the range-review entry point.