### PR TITLE
Remove pinned release version strings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,8 +43,8 @@ body:
     id: version
     attributes:
       label: syu version
-      description: "Required for CLI or runtime bugs. Example: `0.0.1-alpha.8`, `v0.0.1-alpha.4`, or `main`"
-      placeholder: 0.0.1-alpha.8
+      description: "Required for CLI or runtime bugs. Example: a release tag like `v0.0.1-alpha.4` or a branch like `main`"
+      placeholder: v0.0.0
     validations:
       required: false
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Download both files, verify the checksum, then run the local copy:
 
 ```bash
 # x-release-please-start-version
-RELEASE=v0.0.1-alpha.8
+RELEASE="$(gh release view --json tagName -q .tagName --repo ugoite/syu)"
 # x-release-please-end
 curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" -o install-syu.sh
 curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/checksums.sha256" -o checksums.sha256
@@ -132,7 +132,7 @@ WSL just to install `syu`.
 
 ```powershell
 # x-release-please-start-version
-$release = 'v0.0.1-alpha.8'
+$release = gh release view --json tagName -q .tagName --repo ugoite/syu
 # x-release-please-end
 $asset = 'syu-x86_64-pc-windows-msvc.zip'
 $checksums = 'checksums.sha256'
@@ -198,7 +198,7 @@ If you jump straight to this section, set the checked-in release tag once before
 using any of these shortcuts:
 
 ```bash
-RELEASE=v0.0.1-alpha.8
+RELEASE="$(gh release view --json tagName -q .tagName --repo ugoite/syu)"
 ```
 
 Current installer entrypoint:

--- a/docs/guide/app.md
+++ b/docs/guide/app.md
@@ -305,7 +305,7 @@ Once the app has loaded the workspace successfully, `GET /health` returns:
 
 ```json
 <!-- x-release-please-start-version -->
-{"status":"ok","version":"0.0.1-alpha.8"}
+{"status":"ok","version":"<cli-version>"}
 <!-- x-release-please-end -->
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -57,7 +57,7 @@ coverage behavior.
 
 ```yaml
 # x-release-please-start-version
-version: 0.0.1-alpha.8
+version: "<cli-version>"
 # x-release-please-end
 spec:
   root: docs/syu

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -54,7 +54,7 @@ longer installer discussion in [Before you begin](#before-you-begin).
 
 ```bash
 # x-release-please-start-version
-RELEASE=v0.0.1-alpha.8
+RELEASE="$(gh release view --json tagName -q .tagName --repo ugoite/syu)"
 # x-release-please-end
 curl -fsSL "https://github.com/ugoite/syu/releases/download/${RELEASE}/install-syu.sh" | env SYU_VERSION=alpha bash
 syu doctor .

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -380,7 +380,7 @@ an explicit registry because implementation claims should stay deliberate and
 reviewable. That registry is a short YAML list of feature documents:
 
 ```yaml
-version: 0.0.1-alpha.8
+version: "<cli-version>"
 files:
   - kind: core
     file: core/core.yaml

--- a/scripts/install-syu.sh
+++ b/scripts/install-syu.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 DEFAULT_REPOSITORY="ugoite/syu"
 DEFAULT_PACKAGE_HOST="ghcr.io"
 DEFAULT_PACKAGE_SCHEME="https"
-DEFAULT_VERSION_SELECTOR="v0.0.1-alpha.8"
+DEFAULT_VERSION_SELECTOR="alpha"
 tmp_dir=""
 
 cleanup_tmp_dir() {

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -377,7 +377,7 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("install-syu.sh"));
     assert!(readme.contains("ugoite/syu"));
     assert!(readme.contains("SYU_VERSION"));
-    assert!(readme.contains(&format!("RELEASE=v{current_version}")));
+    assert!(readme.contains("gh release view --json tagName -q .tagName --repo ugoite/syu"));
     assert!(readme.contains("GitHub Packages"));
     assert!(readme.contains("security-sensitive environments"));
     assert!(readme.contains("checksums.sha256"));
@@ -731,7 +731,7 @@ fn repository_declares_documentation_guides() {
     assert!(configuration.contains("validate.allow_planned"));
     assert!(configuration.contains("Rust, Python, Go, Java, C#, and TypeScript/JavaScript"));
     assert!(configuration.contains("--spec-root"));
-    assert!(configuration.contains(&format!("version: {current_version}")));
+    assert!(configuration.contains("version: \"<cli-version>\""));
     assert!(configuration.contains("docs/syu/config/overview.yaml"));
     assert!(configuration.contains("docs/syu/config/validate.yaml"));
     assert!(config_overview.contains("syu.yaml"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -392,7 +392,9 @@ fn repository_declares_installer_contract() {
     assert!(!readme.contains("$asset.sha256"));
     assert!(readme.contains("syu.exe"));
     assert!(
-        readme.contains("RELEASE=\"$(gh release view --json tagName -q .tagName --repo ugoite/syu)\"")
+        readme.contains(
+            "RELEASE=\"$(gh release view --json tagName -q .tagName --repo ugoite/syu)\""
+        )
     );
     assert!(readme.contains("checked-in"));
     assert!(readme.contains("package track"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -336,7 +336,6 @@ fn repository_declares_release_automation() {
 #[test]
 // REQ-CORE-008
 fn repository_declares_installer_contract() {
-    let current_version = env!("CARGO_PKG_VERSION");
     let installer = read_file("scripts/install-syu.sh");
     let installer_smoke = read_file("scripts/ci/installer-smoke.sh");
     let installed_binary_smoke = read_file("scripts/ci/installed-binary-smoke.sh");
@@ -392,7 +391,9 @@ fn repository_declares_installer_contract() {
     assert!(readme.contains("If you are inside WSL"));
     assert!(!readme.contains("$asset.sha256"));
     assert!(readme.contains("syu.exe"));
-    assert!(readme.contains(&format!("RELEASE=v{current_version}")));
+    assert!(
+        readme.contains("RELEASE=\"$(gh release view --json tagName -q .tagName --repo ugoite/syu)\"")
+    );
     assert!(readme.contains("checked-in"));
     assert!(readme.contains("package track"));
     assert!(readme.contains("same release tag"));
@@ -408,7 +409,6 @@ fn repository_declares_installer_contract() {
 #[test]
 // REQ-CORE-010
 fn repository_declares_documentation_guides() {
-    let current_version = env!("CARGO_PKG_VERSION");
     let readme = read_file("README.md");
     let concepts = read_file("docs/guide/concepts.md");
     let anti_patterns = read_file("docs/guide/spec-antipatterns.md");
@@ -607,7 +607,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("--spec-root"));
     assert!(getting_started.contains("Requirements are discovered"));
     assert!(getting_started.contains("implementation claims should stay deliberate"));
-    assert!(getting_started.contains(&format!("version: {current_version}")));
+    assert!(getting_started.contains("version: \"<cli-version>\""));
     assert!(getting_started.contains("kind: core"));
     assert!(getting_started.contains("freshly initialized project will not have them yet"));
     assert!(generated_docs_freshness.contains("write_sha256"));


### PR DESCRIPTION
This PR removes the hard-coded release tag from the installer examples, switches the installer default selector to a track-based default, and updates the repository-quality contract tests to match the new placeholder/dynamic release wording.

Validation:
- 
- 
running 1 test
test repository_declares_installer_contract ... FAILED

failures:

---- repository_declares_installer_contract stdout ----

thread 'repository_declares_installer_contract' (54020) panicked at tests/repository_quality.rs:395:5:
assertion failed: readme.contains(&format!("RELEASE=v{current_version}"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    repository_declares_installer_contract

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.01s