### PR TITLE
Prefer git tag for syu --version output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,15 +37,15 @@ fn main() {
     fs::create_dir_all(&out_dir).expect("browser app dist directory should be creatable");
 
     let skip_browser_app_build = env::var_os("SYU_SKIP_BROWSER_APP_BUILD").is_some();
-    if !skip_browser_app_build {
-        if let Err(error) = required_npm_version(&app_dir).and_then(|required_npm| {
+    if !skip_browser_app_build
+        && let Err(error) = required_npm_version(&app_dir).and_then(|required_npm| {
             ensure_pinned_npm_ready(&manifest_dir, &app_dir)
                 .and_then(|_| ensure_app_dependencies(&app_dir, &required_npm))
                 .and_then(|_| rebuild_browser_wasm_bindings(&manifest_dir, &app_dir))
                 .and_then(|_| build_browser_bundle(&app_dir, &out_dir))
-        }) {
-            panic!("{error}");
-        }
+        })
+    {
+        panic!("{error}");
     }
 }
 
@@ -84,10 +84,10 @@ fn emit_git_watchers(manifest_dir: &Path) {
         watch_git_metadata(path, &mut watched);
     }
 
-    if let Some(path) = git_common_dir.as_deref() {
-        if Some(path) != git_dir.as_deref() {
-            watch_git_metadata(path, &mut watched);
-        }
+    if let Some(path) = git_common_dir.as_deref()
+        && Some(path) != git_dir.as_deref()
+    {
+        watch_git_metadata(path, &mut watched);
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,12 @@ fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR")).join("syu-app-dist");
 
     println!("cargo:rerun-if-changed=build.rs");
+    if manifest_dir.join(".git").exists() {
+        println!(
+            "cargo:rerun-if-changed={}",
+            manifest_dir.join(".git").display()
+        );
+    }
     emit_watch(&manifest_dir.join("Cargo.lock"));
     emit_watch(&app_dir.join("index.html"));
     emit_watch(&app_dir.join("package.json"));
@@ -31,13 +37,18 @@ fn main() {
     emit_watch(&shared_core_dir.join("Cargo.toml"));
     emit_watch_recursive(&shared_core_dir.join("src"));
 
-    if let Err(error) = required_npm_version(&app_dir).and_then(|required_npm| {
-        ensure_pinned_npm_ready(&manifest_dir, &app_dir)
-            .and_then(|_| ensure_app_dependencies(&app_dir, &required_npm))
-            .and_then(|_| rebuild_browser_wasm_bindings(&manifest_dir, &app_dir))
-            .and_then(|_| build_browser_bundle(&app_dir, &out_dir))
-    }) {
-        panic!("{error}");
+    emit_build_version();
+
+    let skip_browser_app_build = env::var_os("SYU_SKIP_BROWSER_APP_BUILD").is_some();
+    if !skip_browser_app_build {
+        if let Err(error) = required_npm_version(&app_dir).and_then(|required_npm| {
+            ensure_pinned_npm_ready(&manifest_dir, &app_dir)
+                .and_then(|_| ensure_app_dependencies(&app_dir, &required_npm))
+                .and_then(|_| rebuild_browser_wasm_bindings(&manifest_dir, &app_dir))
+                .and_then(|_| build_browser_bundle(&app_dir, &out_dir))
+        }) {
+            panic!("{error}");
+        }
     }
 }
 
@@ -65,6 +76,27 @@ fn emit_watch_recursive(path: &Path) {
             emit_watch(&child);
         }
     }
+}
+
+fn emit_build_version() {
+    let version = git_tag_version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+    println!("cargo:rustc-env=SYU_GIT_VERSION={version}");
+}
+
+fn git_tag_version() -> Option<String> {
+    Command::new("git")
+        .args(["describe", "--tags", "--exact-match"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 fn pinned_npm_script(manifest_dir: &Path) -> PathBuf {

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 // FEAT-APP-001
 
 use std::{
+    collections::BTreeSet,
     env, fs,
     path::{Path, PathBuf},
     process::Command,
@@ -16,12 +17,7 @@ fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR")).join("syu-app-dist");
 
     println!("cargo:rerun-if-changed=build.rs");
-    if manifest_dir.join(".git").exists() {
-        println!(
-            "cargo:rerun-if-changed={}",
-            manifest_dir.join(".git").display()
-        );
-    }
+    emit_git_watchers(&manifest_dir);
     emit_watch(&manifest_dir.join("Cargo.lock"));
     emit_watch(&app_dir.join("index.html"));
     emit_watch(&app_dir.join("package.json"));
@@ -38,6 +34,7 @@ fn main() {
     emit_watch_recursive(&shared_core_dir.join("src"));
 
     emit_build_version();
+    fs::create_dir_all(&out_dir).expect("browser app dist directory should be creatable");
 
     let skip_browser_app_build = env::var_os("SYU_SKIP_BROWSER_APP_BUILD").is_some();
     if !skip_browser_app_build {
@@ -75,6 +72,35 @@ fn emit_watch_recursive(path: &Path) {
         } else {
             emit_watch(&child);
         }
+    }
+}
+
+fn emit_git_watchers(manifest_dir: &Path) {
+    let git_dir = git_dir(manifest_dir);
+    let git_common_dir = git_common_dir(manifest_dir);
+    let mut watched = BTreeSet::new();
+
+    if let Some(path) = git_dir.as_deref() {
+        watch_git_metadata(path, &mut watched);
+    }
+
+    if let Some(path) = git_common_dir.as_deref() {
+        if Some(path) != git_dir.as_deref() {
+            watch_git_metadata(path, &mut watched);
+        }
+    }
+}
+
+fn watch_git_metadata(path: &Path, watched: &mut BTreeSet<PathBuf>) {
+    for candidate in [path.join("HEAD"), path.join("packed-refs")] {
+        if watched.insert(candidate.clone()) {
+            emit_watch(&candidate);
+        }
+    }
+
+    let refs_dir = path.join("refs");
+    if watched.insert(refs_dir.clone()) {
+        emit_watch_recursive(&refs_dir);
     }
 }
 
@@ -360,6 +386,25 @@ fn default_wasm_target_dir_from_common_dir(
 fn git_common_dir(manifest_dir: &Path) -> Option<PathBuf> {
     let output = Command::new("git")
         .args(["rev-parse", "--git-common-dir"])
+        .current_dir(manifest_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let path = PathBuf::from(raw.trim());
+    Some(if path.is_absolute() {
+        path
+    } else {
+        manifest_dir.join(path)
+    })
+}
+
+fn git_dir(manifest_dir: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
         .current_dir(manifest_dir)
         .output()
         .ok()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,8 @@ use std::{num::NonZeroU8, path::PathBuf, sync::OnceLock};
 
 use crate::command::init::{starter_template_example_commands, starter_template_names};
 
+const CLI_VERSION: &str = env!("SYU_GIT_VERSION");
+
 const ROOT_AFTER_HELP: &str = "\
 New here?
   1. syu templates   compare starter layouts before you scaffold
@@ -181,7 +183,7 @@ fn init_template_help() -> &'static str {
 #[derive(Debug, Parser)]
 #[command(
     name = "syu",
-    version,
+    version = CLI_VERSION,
     about = "Specification-driven development for real repositories",
     after_help = ROOT_AFTER_HELP,
     subcommand_required = false,


### PR DESCRIPTION
Use a git tag for  when the current commit is tagged, falling back to  version otherwise. Also add an optional build script flag  for local check-only builds where browser app dependencies are not installed.