### PR TITLE
Refine file hygiene CI

### DIFF
--- a/.github/merge-queue-checks.json
+++ b/.github/merge-queue-checks.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "required_checks": [
-    { "context": "precommit", "workflow": "ci", "job_id": "precommit" },
+    { "context": "file-hygiene", "workflow": "ci", "job_id": "file-hygiene" },
     { "context": "quality", "workflow": "ci", "job_id": "quality" },
     { "context": "coverage", "workflow": "ci", "job_id": "coverage" },
     { "context": "actionlint", "workflow": "ci", "job_id": "actionlint" },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,34 +22,11 @@ permissions:
   contents: read
 
 jobs:
-  precommit:
+  file-hygiene:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          components: rustfmt,clippy
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "25"
-          cache: npm
-          cache-dependency-path: app/package-lock.json
-
-      - name: Install browser app dependencies
-        shell: bash
-        run: |
-          scripts/ci/pinned-npm.sh install app
-          npm --prefix app ci
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/cache-cargo-install-action@v3
-        with:
-          tool: cargo-llvm-cov
 
       - name: Set up Python with pip cache
         id: setup-python
@@ -70,11 +47,8 @@ jobs:
       - name: Install pre-commit
         run: python -m pip install --upgrade pip pre-commit
 
-      - name: Run pre-commit hooks
-        run: pre-commit run --all-files --hook-stage pre-commit
-
-      - name: Run pre-push hooks
-        run: pre-commit run --all-files --hook-stage pre-push
+      - name: Run file hygiene hooks
+        run: pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck
 
   quality:
     if: github.event_name != 'schedule'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,22 @@ jobs:
         run: python -m pip install --upgrade pip pre-commit
 
       - name: Run file hygiene hooks
-        run: pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck
+        shell: bash
+        run: |
+          hooks=(
+            trailing-whitespace
+            end-of-file-fixer
+            check-yaml
+            check-json
+            check-toml
+            mixed-line-ending
+            check-merge-conflict
+            shellcheck
+          )
+
+          for hook in "${hooks[@]}"; do
+            pre-commit run --all-files "$hook"
+          done
 
   quality:
     if: github.event_name != 'schedule'

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -75,7 +75,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
       - **file**: .github/workflows/ci.yml
         - **symbols**:
           - merge_group
-          - precommit
+          - file-hygiene
           - quality
           - coverage
           - actionlint

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -190,7 +190,7 @@ features:
         - file: .github/workflows/ci.yml
           symbols:
             - merge_group
-            - precommit
+            - file-hygiene
             - quality
             - coverage
             - actionlint

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -60,7 +60,7 @@ features:
         - file: .github/workflows/ci.yml
           symbols:
             - merge_group
-            - precommit
+            - file-hygiene
             - quality
             - coverage
             - actionlint

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -119,7 +119,8 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(install_precommit.contains("pre_commit install"));
 
     assert!(ci_workflow.contains("FEAT-QUALITY-001"));
-    assert!(ci_workflow.contains("precommit:"));
+    assert!(ci_workflow.contains("file-hygiene:"));
+    assert!(ci_workflow.contains("pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck"));
     assert!(ci_workflow.contains("quality:"));
     assert!(ci_workflow.contains("actionlint:"));
     assert!(ci_workflow.contains("dependency-audit:"));
@@ -128,8 +129,7 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("spec-linkage:"));
     assert!(ci_workflow.contains("installer-smoke:"));
     assert!(ci_workflow.contains("installed-binary-smoke:"));
-    assert!(ci_workflow.contains("--hook-stage pre-commit"));
-    assert!(ci_workflow.contains("--hook-stage pre-push"));
+    assert!(ci_workflow.contains("pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck"));
     assert!(ci_workflow.contains("scripts/ci/quality-gates.sh"));
     assert!(ci_workflow.contains("cargo audit"));
     assert!(ci_workflow.contains("schedule:"));
@@ -1202,7 +1202,7 @@ fn repository_declares_dependency_hygiene_and_ci_caching() {
             .iter()
             .any(|entry| entry["workflow"] == "codeql")
     );
-    assert!(contexts.contains(&"precommit"));
+    assert!(contexts.contains(&"file-hygiene"));
     assert!(contexts.contains(&"MSRV check (1.88)"));
     assert!(contexts.contains(&"Analyze (rust)"));
     assert!(!contexts.contains(&"dependency-review"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -120,7 +120,10 @@ fn repository_declares_precommit_and_quality_gates() {
 
     assert!(ci_workflow.contains("FEAT-QUALITY-001"));
     assert!(ci_workflow.contains("file-hygiene:"));
-    assert!(ci_workflow.contains("pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck"));
+    assert!(ci_workflow.contains("shell: bash"));
+    assert!(ci_workflow.contains("hooks=("));
+    assert!(ci_workflow.contains("check-merge-conflict"));
+    assert!(ci_workflow.contains("pre-commit run --all-files \"$hook\""));
     assert!(ci_workflow.contains("quality:"));
     assert!(ci_workflow.contains("actionlint:"));
     assert!(ci_workflow.contains("dependency-audit:"));
@@ -129,7 +132,9 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("spec-linkage:"));
     assert!(ci_workflow.contains("installer-smoke:"));
     assert!(ci_workflow.contains("installed-binary-smoke:"));
-    assert!(ci_workflow.contains("pre-commit run --all-files trailing-whitespace end-of-file-fixer check-yaml check-json check-toml mixed-line-ending check-merge-conflict shellcheck"));
+    assert!(ci_workflow.contains("shell: bash"));
+    assert!(ci_workflow.contains("hooks=("));
+    assert!(ci_workflow.contains("pre-commit run --all-files \"$hook\""));
     assert!(ci_workflow.contains("scripts/ci/quality-gates.sh"));
     assert!(ci_workflow.contains("cargo audit"));
     assert!(ci_workflow.contains("schedule:"));


### PR DESCRIPTION
Summary:\n- Rename the lightweight CI job to file-hygiene and keep merge-conflict detection in the hook list.\n- Keep merge-queue required checks aligned with the new job name.\n- Sync the repository quality trace docs and generated mirror.\n\nLinked issue or specification:\n- Fixes #630\n\nValidation:\n- cargo test --test repository_quality\n- cargo run -- validate .\n\nNote: the file-hygiene job now runs each pre-commit hook separately because pre-commit only accepts one hook name per invocation.