### PR TITLE
Migrate short-running CI jobs to ubuntu-slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
 
   quality:
     if: github.event_name != 'schedule'
+    # Keep this on the larger runner; it exceeds ubuntu-slim's time budget.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -87,6 +88,7 @@ jobs:
 
   coverage:
     if: github.event_name != 'schedule'
+    # Keep this on the larger runner; it exceeds ubuntu-slim's time budget.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -133,7 +135,7 @@ jobs:
         uses: rhysd/actionlint@v1.7.12
 
   dependency-audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 
@@ -149,7 +151,7 @@ jobs:
         run: cargo audit
 
   npm-audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 
@@ -185,7 +187,7 @@ jobs:
 
   dependency-review:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: read
@@ -212,7 +214,7 @@ jobs:
 
   spec-linkage:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: read
@@ -227,7 +229,7 @@ jobs:
 
   squash-history-spec-ids:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: read
@@ -246,7 +248,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-slim
           - macos-15-intel
           - macos-14
           - windows-latest
@@ -271,7 +273,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-slim
           - macos-15-intel
           - macos-14
           - windows-latest
@@ -361,7 +363,7 @@ jobs:
   check-msrv:
     name: MSRV check (1.88)
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:
@@ -38,7 +38,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/merge-queue-reenroll.yml
+++ b/.github/workflows/merge-queue-reenroll.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   reenroll:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/merge-queue-watchdog.yml
+++ b/.github/workflows/merge-queue-watchdog.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   watchdog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check release-please permissions
         id: permissions


### PR DESCRIPTION
Closes #632\n\nMoved the short-running GitHub Actions jobs without runner-specific requirements from ubuntu-latest to ubuntu-slim.