### PR TITLE
[Feature]: Add a dry-run planning mode for syu validate --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,8 +708,16 @@ The `syu` repository itself enables `validate.require_non_orphaned_items`,
 
 ## Safe autofix
 
-`syu validate --fix` is intentionally conservative. Today it only repairs
-documentation-style trace gaps that can be updated mechanically:
+`syu validate --fix` is intentionally conservative. Use `--dry-run` when you
+want to preview the same fix set without writing files:
+
+```bash
+syu validate . --fix --dry-run
+syu validate . --format json --fix --dry-run
+```
+
+Today autofix only repairs documentation-style trace gaps that can be updated
+mechanically:
 
 - missing requirement / feature IDs in symbol documentation
 - missing `doc_contains` snippets for Rust, Python, Go, and TypeScript symbols

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -77,6 +77,7 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/help_command.rs
         - **symbols**:
           - validate_help_mentions_spec_only_mode
+          - validate_help_mentions_dry_run_mode
       - **file**: src/command/check.rs
         - **symbols**:
           - *
@@ -185,13 +186,16 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
         - **symbols**:
           - *
 - **id**: REQ-CORE-003
-  - **title**: Support conservative autofix and config-driven default_fix
+  - **title**: Support conservative autofix, dry-run planning, and config-driven default_fix
   - **description**:
     - |
       The `validate` command MUST provide a `--fix` mode that performs safe,
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
+      mechanical repairs for documentation-style trace gaps. It MUST also
+      provide a dry-run planning mode that previews the same fix set without
+      writing files, with both machine-readable and reviewer-friendly output.
+      `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
+      MUST disable it. Autofix MUST stay conservative and avoid speculative
+      structural edits.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -308,6 +312,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - validate_help_mentions_spec_only_mode
+            - validate_help_mentions_dry_run_mode
         - file: src/command/check.rs
           symbols:
             - '*'
@@ -415,12 +420,15 @@ requirements:
           symbols:
             - '*'
   - id: REQ-CORE-003
-    title: Support conservative autofix and config-driven default_fix
+    title: Support conservative autofix, dry-run planning, and config-driven default_fix
     description: |
       The `validate` command MUST provide a `--fix` mode that performs safe,
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
+      mechanical repairs for documentation-style trace gaps. It MUST also
+      provide a dry-run planning mode that previews the same fix set without
+      writing files, with both machine-readable and reviewer-friendly output.
+      `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
+      MUST disable it. Autofix MUST stay conservative and avoid speculative
+      structural edits.
     priority: high
     status: implemented
     linked_policies:

--- a/docs/guide/existing-repository.md
+++ b/docs/guide/existing-repository.md
@@ -170,9 +170,10 @@ For already-shipped behavior, mark the requirement and feature as
 implementation symbols truthfully. If a spec item is accepted but you are not
 ready to claim traces yet, leave it `planned`.
 
-Use `syu validate . --fix` only after you have decided the owning IDs. Autofix
-is good at inserting required doc-comment snippets; it does not choose the right
-graph links for you.
+Use `syu validate . --fix --dry-run` when you want to preview the autofix plan
+before changing files. Once you have decided the owning IDs, `syu validate .
+--fix` is good at inserting required doc-comment snippets; it does not choose
+the right graph links for you.
 
 If one small file is intentionally owned by one requirement or feature, you can
 use `symbols: ['*']` instead of enumerating every public symbol by hand.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -535,6 +535,8 @@ syu validate . --fix
 
 Autofix is conservative. It currently repairs documentation-style trace gaps
 for Rust, Python, Go, and TypeScript without guessing at larger structural changes.
+If you want to preview the same fix set without writing files, use
+`syu validate . --fix --dry-run` and review the printed plan instead.
 
 ## 6. Generate a report
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -205,6 +205,10 @@ implementations:
         - authenticate_user
 ```
 
+If you want to preview the doc-comment repair path before it writes files, run
+`syu validate . --fix --dry-run`. The dry run prints the plan in text or JSON
+but leaves the workspace unchanged.
+
 ---
 
 ## Trace errors

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -60,6 +60,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - validate_help_mentions_spec_only_mode
+            - validate_help_mentions_dry_run_mode
         - file: src/command/check.rs
           symbols:
             - '*'
@@ -167,12 +168,15 @@ requirements:
           symbols:
             - '*'
   - id: REQ-CORE-003
-    title: Support conservative autofix and config-driven default_fix
+    title: Support conservative autofix, dry-run planning, and config-driven default_fix
     description: |
       The `validate` command MUST provide a `--fix` mode that performs safe,
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
+      mechanical repairs for documentation-style trace gaps. It MUST also
+      provide a dry-run planning mode that previews the same fix set without
+      writing files, with both machine-readable and reviewer-friendly output.
+      `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
+      MUST disable it. Autofix MUST stay conservative and avoid speculative
+      structural edits.
     priority: high
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -581,6 +581,10 @@ pub struct ValidateArgs {
     #[arg(long, action = ArgAction::SetTrue)]
     pub fix: bool,
 
+    #[arg(help = "Preview autofixes without writing files")]
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub dry_run: bool,
+
     #[arg(help = "Disable autofix even when syu.yaml enables it by default")]
     #[arg(long, action = ArgAction::SetTrue)]
     pub no_fix: bool,

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -889,6 +889,7 @@ fn apply_autofix_for_reference(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_autofix_for_reference_with_transaction(
     root: &Path,
     config: &SyuConfig,

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -70,6 +70,32 @@ struct AutofixSummary {
     symbol_updates: usize,
 }
 
+#[derive(Debug, Default, Clone, Serialize)]
+struct AutofixPlan {
+    planned_updates: usize,
+    updated_files: BTreeSet<PathBuf>,
+    changes: Vec<AutofixPlanChange>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AutofixPlanChange {
+    path: PathBuf,
+    rules: Vec<&'static str>,
+    summary: String,
+}
+
+#[derive(Debug, Default)]
+struct AutofixRun {
+    summary: AutofixSummary,
+    plan: Option<AutofixPlan>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutofixMode {
+    Apply,
+    Plan,
+}
+
 #[derive(Debug, Clone)]
 enum OwnershipDeclaration {
     Satisfied,
@@ -111,6 +137,8 @@ struct JsonCheckOutput<'a> {
     result: &'a CheckResult,
     #[serde(skip_serializing_if = "Option::is_none")]
     filtered_view: Option<&'a FilteredIssueView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    autofix_plan: Option<&'a AutofixPlan>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,11 +374,15 @@ fn workspace_item_count(definition_counts: &DefinitionCounts) -> usize {
 
 // FEAT-CHECK-001
 pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
-    let (result, fix_summary, text_summary) = match load_workspace(&args.workspace) {
+    let (result, autofix_run, text_summary) = match load_workspace(&args.workspace) {
         Ok(workspace) => {
             let should_fix = effective_fix(args, &workspace.config);
-            let fix_summary = if should_fix {
-                Some(apply_autofix(&workspace)?)
+            let autofix_run = if should_fix {
+                Some(if args.dry_run {
+                    plan_autofix(&workspace)?
+                } else {
+                    apply_autofix_run(&workspace)?
+                })
             } else {
                 None
             };
@@ -364,7 +396,7 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             apply_cli_override_issue_guidance(&mut result, args);
             let text_summary =
                 TextReportSummary::from_config(&workspace.config, &result.definition_counts);
-            (result, fix_summary, Some(text_summary))
+            (result, autofix_run, Some(text_summary))
         }
         Err(error) => (
             CheckResult::from_load_error(args.workspace.to_path_buf(), error.to_string()),
@@ -383,14 +415,25 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
 
     match args.format {
         OutputFormat::Text => {
-            if let Some(summary) = fix_summary
-                && !summary.updated_files.is_empty()
-            {
-                println!(
-                    "applied {} autofix updates across {} files",
-                    summary.symbol_updates,
-                    summary.updated_files.len()
-                );
+            if let Some(run) = autofix_run.as_ref() {
+                if args.dry_run {
+                    if let Some(plan) = run.plan.as_ref()
+                        && !plan.updated_files.is_empty()
+                    {
+                        println!(
+                            "planned {} autofix updates across {} files (dry run; no files changed)",
+                            plan.planned_updates,
+                            plan.updated_files.len()
+                        );
+                        print!("{}", render_autofix_plan(plan));
+                    }
+                } else if !run.summary.updated_files.is_empty() {
+                    println!(
+                        "applied {} autofix updates across {} files",
+                        run.summary.symbol_updates,
+                        run.summary.updated_files.len()
+                    );
+                }
             }
             print!(
                 "{}",
@@ -409,6 +452,7 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             let output = JsonCheckOutput {
                 result: &result,
                 filtered_view: filtered_view.as_ref(),
+                autofix_plan: autofix_run.as_ref().and_then(|run| run.plan.as_ref()),
             };
             println!(
                 "{}",
@@ -672,41 +716,55 @@ fn apply_cli_override_issue_guidance(result: &mut CheckResult, args: &CheckArgs)
     }
 }
 
+#[cfg(test)]
 #[allow(clippy::question_mark)]
 fn apply_autofix(workspace: &Workspace) -> Result<AutofixSummary> {
-    let mut summary = AutofixSummary::default();
+    Ok(apply_autofix_run(workspace)?.summary)
+}
+
+fn apply_autofix_run(workspace: &Workspace) -> Result<AutofixRun> {
+    run_autofix(workspace, AutofixMode::Apply)
+}
+
+fn plan_autofix(workspace: &Workspace) -> Result<AutofixRun> {
+    run_autofix(workspace, AutofixMode::Plan)
+}
+
+fn run_autofix(workspace: &Workspace, mode: AutofixMode) -> Result<AutofixRun> {
+    let mut run = AutofixRun::default();
+    if mode == AutofixMode::Plan {
+        run.plan = Some(AutofixPlan::default());
+    }
 
     for requirement in &workspace.requirements {
         if normalize_delivery_status(&requirement.status) != Some(DeliveryStatus::Implemented) {
             continue;
         }
-        if let Err(error) = apply_autofix_for_trace_map(
+        apply_autofix_for_trace_map(
             &workspace.root,
             &workspace.config,
             &requirement.id,
             &requirement.tests,
-            &mut summary,
-        ) {
-            return Err(error);
-        }
+            &mut run,
+            mode,
+        )?;
     }
 
     for feature in &workspace.features {
         if normalize_delivery_status(&feature.status) != Some(DeliveryStatus::Implemented) {
             continue;
         }
-        if let Err(error) = apply_autofix_for_trace_map(
+        apply_autofix_for_trace_map(
             &workspace.root,
             &workspace.config,
             &feature.id,
             &feature.implementations,
-            &mut summary,
-        ) {
-            return Err(error);
-        }
+            &mut run,
+            mode,
+        )?;
     }
 
-    Ok(summary)
+    Ok(run)
 }
 
 #[allow(clippy::question_mark)]
@@ -715,15 +773,12 @@ fn apply_autofix_for_trace_map(
     config: &SyuConfig,
     owner_id: &str,
     references_by_language: &BTreeMap<String, Vec<TraceReference>>,
-    summary: &mut AutofixSummary,
+    run: &mut AutofixRun,
+    mode: AutofixMode,
 ) -> Result<()> {
     for (language, references) in references_by_language {
         for reference in references {
-            if let Err(error) =
-                apply_autofix_for_reference(root, config, owner_id, language, reference, summary)
-            {
-                return Err(error);
-            }
+            apply_autofix_for_reference(root, config, owner_id, language, reference, run, mode)?;
         }
     }
 
@@ -736,7 +791,8 @@ fn apply_autofix_for_reference(
     owner_id: &str,
     language: &str,
     reference: &TraceReference,
-    summary: &mut AutofixSummary,
+    run: &mut AutofixRun,
+    mode: AutofixMode,
 ) -> Result<()> {
     let Some(adapter) = adapter_for_language(language) else {
         return Ok(());
@@ -755,11 +811,11 @@ fn apply_autofix_for_reference(
         Ok(contents) => contents,
         Err(_) => return Ok(()),
     };
-    let mut changed = false;
     let mut updated_symbols = 0;
+    let mut changed = false;
 
     if config.validate.trace_ownership_mode == TraceOwnershipMode::Sidecar {
-        ensure_sidecar_ownership_manifest(root, owner_id, &path, reference, summary)?;
+        ensure_sidecar_ownership_manifest(root, owner_id, &path, reference, run, mode)?;
     }
 
     for symbol in reference
@@ -769,8 +825,9 @@ fn apply_autofix_for_reference(
         .filter(|symbol| !symbol.is_empty() && *symbol != "*")
     {
         let mut required = reference.doc_contains.clone();
-        if config.validate.trace_ownership_mode == TraceOwnershipMode::Inline
-            && !contents.contains(owner_id)
+        let needs_inline_owner = config.validate.trace_ownership_mode == TraceOwnershipMode::Inline
+            && !contents.contains(owner_id);
+        if config.validate.trace_ownership_mode == TraceOwnershipMode::Inline && needs_inline_owner
         {
             required.push(owner_id.to_string());
         }
@@ -779,23 +836,37 @@ fn apply_autofix_for_reference(
         }
 
         let updated =
-            match apply_symbol_doc_fix(language, config, &path, &contents, symbol, &required) {
-                Ok(Some(updated)) => updated,
-                Ok(None) => continue,
-                Err(error) => return Err(error),
+            match apply_symbol_doc_fix(language, config, &path, &contents, symbol, &required)? {
+                Some(updated) => updated,
+                None => continue,
             };
 
         contents = updated;
-        if let Err(error) = fs::write(&path, &contents) {
-            return Err(error.into());
+        if mode == AutofixMode::Apply {
+            fs::write(&path, &contents)?;
+        } else if let Some(plan) = run.plan.as_mut() {
+            let mut rules = Vec::new();
+            if !reference.doc_contains.is_empty() {
+                rules.push("SYU-trace-doc-001");
+            }
+            if needs_inline_owner {
+                rules.push("SYU-trace-id-001");
+            }
+            record_planned_change(
+                plan,
+                root,
+                &path,
+                rules,
+                format!("update `{symbol}` in `{}` for `{owner_id}`", path.display()),
+            );
         }
         changed = true;
         updated_symbols += 1;
     }
 
     if changed {
-        record_updated_file(summary, root, &path);
-        summary.symbol_updates += updated_symbols;
+        record_updated_file(&mut run.summary, root, &path);
+        run.summary.symbol_updates += updated_symbols;
     }
 
     Ok(())
@@ -807,6 +878,55 @@ fn record_updated_file(summary: &mut AutofixSummary, root: &Path, path: &Path) {
             .map(Path::to_path_buf)
             .unwrap_or_else(|_| path.to_path_buf()),
     );
+}
+
+fn record_planned_change(
+    plan: &mut AutofixPlan,
+    root: &Path,
+    path: &Path,
+    rules: Vec<&'static str>,
+    summary: String,
+) {
+    plan.planned_updates += 1;
+    plan.updated_files.insert(
+        path.strip_prefix(root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| path.to_path_buf()),
+    );
+    plan.changes.push(AutofixPlanChange {
+        path: path
+            .strip_prefix(root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| path.to_path_buf()),
+        rules,
+        summary,
+    });
+}
+
+fn render_autofix_plan(plan: &AutofixPlan) -> String {
+    let mut output = String::new();
+    if plan.changes.is_empty() {
+        return output;
+    }
+
+    writeln!(&mut output, "planned fixes:").expect("writing to String must succeed");
+    for change in &plan.changes {
+        let rules = if change.rules.is_empty() {
+            String::from("no direct rule match")
+        } else {
+            change.rules.join(", ")
+        };
+        writeln!(
+            &mut output,
+            "- {} [{}]: {}",
+            change.path.display(),
+            rules,
+            change.summary
+        )
+        .expect("writing to String must succeed");
+    }
+
+    output
 }
 
 fn render_text_report(
@@ -1548,7 +1668,8 @@ fn ensure_sidecar_ownership_manifest(
     owner_id: &str,
     traced_file: &Path,
     reference: &TraceReference,
-    summary: &mut AutofixSummary,
+    run: &mut AutofixRun,
+    mode: AutofixMode,
 ) -> Result<()> {
     let manifest_path = ownership_manifest_path(traced_file);
     let mut manifest = if manifest_path.is_file() {
@@ -1567,9 +1688,22 @@ fn ensure_sidecar_ownership_manifest(
     }
 
     let raw = serde_yaml::to_string(&manifest)?;
-    fs::write(&manifest_path, raw)?;
-    record_updated_file(summary, root, &manifest_path);
-    summary.symbol_updates += 1;
+    if mode == AutofixMode::Apply {
+        fs::write(&manifest_path, raw)?;
+    } else if let Some(plan) = run.plan.as_mut() {
+        record_planned_change(
+            plan,
+            root,
+            &manifest_path,
+            vec!["SYU-trace-id-001"],
+            format!(
+                "update sidecar ownership for `{owner_id}` in `{}`",
+                manifest_path.display()
+            ),
+        );
+    }
+    record_updated_file(&mut run.summary, root, &manifest_path);
+    run.summary.symbol_updates += 1;
     Ok(())
 }
 
@@ -2691,14 +2825,14 @@ mod tests {
     use super::{
         FilteredIssueView, IssueFilters, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
         RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
-        apply_autofix, apply_autofix_for_reference, collect_check_result,
-        collect_feature_yaml_paths, describe_trace_reference, entry_covers_symbols,
-        filter_check_result, format_reference_location, looks_like_feature_document,
-        merge_ownership_entry, ownership_symbols_hint, preferred_trace_file_path,
-        render_text_report, required_ownership_symbols, run_check_command,
-        validate_duplicate_links, validate_duplicate_trace_references, validate_feature,
-        validate_feature_registry_entries, validate_non_empty_field, validate_philosophy,
-        validate_policy, validate_requirement, validate_unique_ids, verify_trace_reference,
+        apply_autofix, collect_check_result, collect_feature_yaml_paths, describe_trace_reference,
+        entry_covers_symbols, filter_check_result, format_reference_location,
+        looks_like_feature_document, merge_ownership_entry, ownership_symbols_hint,
+        preferred_trace_file_path, render_text_report, required_ownership_symbols,
+        run_check_command, validate_duplicate_links, validate_duplicate_trace_references,
+        validate_feature, validate_feature_registry_entries, validate_non_empty_field,
+        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
+        verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -2764,6 +2898,31 @@ mod tests {
         }
     }
 
+    fn apply_autofix_for_reference(
+        root: &Path,
+        config: &SyuConfig,
+        owner_id: &str,
+        language: &str,
+        reference: &TraceReference,
+        summary: &mut super::AutofixSummary,
+    ) -> anyhow::Result<()> {
+        let mut run = super::AutofixRun {
+            summary: std::mem::take(summary),
+            plan: None,
+        };
+        super::apply_autofix_for_reference(
+            root,
+            config,
+            owner_id,
+            language,
+            reference,
+            &mut run,
+            super::AutofixMode::Apply,
+        )?;
+        *summary = run.summary;
+        Ok(())
+    }
+
     fn write_valid_planned_workspace(root: &Path) {
         fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
         fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
@@ -2826,6 +2985,7 @@ mod tests {
             id: Vec::new(),
             spec_only: false,
             fix: false,
+            dry_run: false,
             no_fix: false,
             allow_planned: None,
             require_non_orphaned_items: None,
@@ -2894,6 +3054,7 @@ mod tests {
             id: Vec::new(),
             spec_only: false,
             fix: true,
+            dry_run: false,
             no_fix: false,
             allow_planned: None,
             require_non_orphaned_items: None,
@@ -2921,6 +3082,7 @@ mod tests {
             id: Vec::new(),
             spec_only: false,
             fix: true,
+            dry_run: false,
             no_fix: false,
             allow_planned: Some(false),
             require_non_orphaned_items: None,
@@ -4704,6 +4866,7 @@ mod tests {
         let mut config = SyuConfig::default();
         config.validate.trace_ownership_mode = TraceOwnershipMode::Sidecar;
 
+        let mut summary = super::AutofixSummary::default();
         let error = apply_autofix_for_reference(
             root,
             &config,
@@ -4714,7 +4877,7 @@ mod tests {
                 symbols: vec!["expected".to_string()],
                 doc_contains: Vec::new(),
             },
-            &mut super::AutofixSummary::default(),
+            &mut summary,
         )
         .expect_err("invalid sidecar manifests should fail autofix");
         assert!(error.to_string().contains("failed to load"));
@@ -4736,6 +4899,7 @@ mod tests {
         let mut config = SyuConfig::default();
         config.validate.trace_ownership_mode = TraceOwnershipMode::Sidecar;
 
+        let mut summary = super::AutofixSummary::default();
         let error = apply_autofix_for_reference(
             root,
             &config,
@@ -4746,7 +4910,7 @@ mod tests {
                 symbols: vec!["expected".to_string()],
                 doc_contains: Vec::new(),
             },
-            &mut super::AutofixSummary::default(),
+            &mut summary,
         )
         .expect_err("duplicate owner manifests should fail autofix");
         assert!(error.to_string().contains("failed to load"));

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -958,7 +958,11 @@ fn apply_autofix_for_reference_with_transaction(
         contents = updated;
         if mode == AutofixMode::Apply {
             transaction.write(&path, &contents)?;
-        } else if let Some(plan) = run.plan.as_mut() {
+        } else {
+            let plan = run
+                .plan
+                .as_mut()
+                .expect("plan mode should initialize a plan");
             let mut rules = Vec::new();
             if !reference.doc_contains.is_empty() {
                 rules.push("SYU-trace-doc-001");

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -5240,6 +5240,43 @@ mod tests {
     }
 
     #[test]
+    fn apply_autofix_for_reference_records_planned_changes() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let root = tempdir.path();
+        let source_path = root.join("trace.rs");
+        fs::write(&source_path, "pub fn expected() {}\n").expect("trace file should exist");
+
+        let mut summary = super::AutofixRun {
+            summary: Default::default(),
+            plan: Some(Default::default()),
+        };
+        super::apply_autofix_for_reference(
+            root,
+            &SyuConfig::default(),
+            "REQ-1",
+            "rust",
+            &TraceReference {
+                file: PathBuf::from("trace.rs"),
+                symbols: vec!["expected".to_string()],
+                doc_contains: vec!["Explain expected".to_string()],
+            },
+            &mut summary,
+            super::AutofixMode::Plan,
+        )
+        .expect("plan mode should succeed");
+
+        assert_eq!(summary.summary.symbol_updates, 1);
+        let plan = summary.plan.as_ref().expect("plan should exist");
+        assert_eq!(plan.planned_updates, 1);
+        assert!(plan.updated_files.contains(Path::new("trace.rs")));
+        assert!(source_path.exists());
+        assert_eq!(
+            fs::read_to_string(&source_path).expect("source contents"),
+            "pub fn expected() {}\n"
+        );
+    }
+
+    #[test]
     fn apply_autofix_updates_requirement_and_feature_traces() {
         let tempdir = tempdir().expect("tempdir should exist");
         let root = tempdir.path().to_path_buf();

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -819,7 +819,9 @@ fn run_autofix(workspace: &Workspace, mode: AutofixMode) -> Result<AutofixRun> {
 
     match result {
         Ok(()) => Ok(run),
-        Err(error) if mode == AutofixMode::Apply => Err(finalize_autofix_error(&transaction, error)),
+        Err(error) if mode == AutofixMode::Apply => {
+            Err(finalize_autofix_error(&transaction, error))
+        }
         Err(error) => Err(error),
     }
 }
@@ -2935,9 +2937,9 @@ mod tests {
     };
 
     use super::{
-        AutofixPlan, AutofixPlanChange, FilteredIssueView, IssueFilters, ORPHAN_RULE_CODES,
-        RECIPROCAL_RULE_CODES, RequirementValidationIndex, TextReportSummary, TraceRole,
-        AutofixTransaction, ValidationResources, apply_autofix, collect_check_result,
+        AutofixPlan, AutofixPlanChange, AutofixTransaction, FilteredIssueView, IssueFilters,
+        ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES, RequirementValidationIndex, TextReportSummary,
+        TraceRole, ValidationResources, apply_autofix, collect_check_result,
         collect_feature_yaml_paths, describe_trace_reference, entry_covers_symbols,
         filter_check_result, finalize_autofix_error, format_reference_location,
         looks_like_feature_document, merge_ownership_entry, ownership_symbols_hint,

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -2823,16 +2823,16 @@ mod tests {
     };
 
     use super::{
-        FilteredIssueView, IssueFilters, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
-        RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
-        apply_autofix, collect_check_result, collect_feature_yaml_paths, describe_trace_reference,
-        entry_covers_symbols, filter_check_result, format_reference_location,
-        looks_like_feature_document, merge_ownership_entry, ownership_symbols_hint,
-        preferred_trace_file_path, render_text_report, required_ownership_symbols,
-        run_check_command, validate_duplicate_links, validate_duplicate_trace_references,
-        validate_feature, validate_feature_registry_entries, validate_non_empty_field,
-        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
-        verify_trace_reference,
+        AutofixPlan, AutofixPlanChange, FilteredIssueView, IssueFilters, ORPHAN_RULE_CODES,
+        RECIPROCAL_RULE_CODES, RequirementValidationIndex, TextReportSummary, TraceRole,
+        ValidationResources, apply_autofix, collect_check_result, collect_feature_yaml_paths,
+        describe_trace_reference, entry_covers_symbols, filter_check_result,
+        format_reference_location, looks_like_feature_document, merge_ownership_entry,
+        ownership_symbols_hint, preferred_trace_file_path, render_autofix_plan, render_text_report,
+        required_ownership_symbols, run_check_command, validate_duplicate_links,
+        validate_duplicate_trace_references, validate_feature, validate_feature_registry_entries,
+        validate_non_empty_field, validate_philosophy, validate_policy, validate_requirement,
+        validate_unique_ids, verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -5514,5 +5514,24 @@ mod tests {
             format_reference_location("rust", &reference),
             "rust:src/lib.rs"
         );
+    }
+
+    #[test]
+    fn render_autofix_plan_returns_empty_output_for_empty_plan() {
+        assert!(render_autofix_plan(&AutofixPlan::default()).is_empty());
+    }
+
+    #[test]
+    fn render_autofix_plan_labels_changes_without_rule_matches() {
+        let mut plan = AutofixPlan::default();
+        plan.changes.push(AutofixPlanChange {
+            path: PathBuf::from("trace.rs"),
+            rules: Vec::new(),
+            summary: "update trace.rs".to_string(),
+        });
+
+        let rendered = render_autofix_plan(&plan);
+        assert!(rendered.contains("no direct rule match"));
+        assert!(rendered.contains("trace.rs"));
     }
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -377,6 +377,11 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
     let (result, autofix_run, text_summary) = match load_workspace(&args.workspace) {
         Ok(workspace) => {
             let should_fix = effective_fix(args, &workspace.config);
+            if args.dry_run && !should_fix {
+                return Err(anyhow::anyhow!(
+                    "`--dry-run` requires an effective autofix path; pass `--fix` or remove `--no-fix`."
+                ));
+            }
             let autofix_run = if should_fix {
                 Some(if args.dry_run {
                     plan_autofix(&workspace)?
@@ -3094,6 +3099,38 @@ mod tests {
         .expect("command should complete");
 
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn run_check_command_rejects_dry_run_without_an_effective_fix_path() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+
+        let error = run_check_command(&crate::cli::CheckArgs {
+            workspace: tempdir.path().to_path_buf(),
+            format: crate::cli::OutputFormat::Text,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
+            id: Vec::new(),
+            spec_only: false,
+            fix: false,
+            dry_run: true,
+            no_fix: false,
+            allow_planned: None,
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
+            warning_exit_code: None,
+            quiet: false,
+        })
+        .expect_err("dry-run without fix should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires an effective autofix path")
+        );
     }
 
     #[test]

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1642,6 +1642,7 @@ mod tests {
             id: Vec::new(),
             spec_only: false,
             fix: false,
+            dry_run: false,
             no_fix: false,
             allow_planned: None,
             require_non_orphaned_items: None,

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -84,6 +84,22 @@ fn workspace_help_uses_current_directory_default_consistently() {
 }
 
 #[test]
+// REQ-CORE-003
+fn validate_help_mentions_dry_run_mode() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "validate help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--dry-run"));
+    assert!(stdout.contains("Preview autofixes without writing files"));
+}
+
+#[test]
 fn doctor_help_mentions_local_readiness_and_json_output() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -423,6 +423,7 @@ fn repository_declares_documentation_guides() {
     let examples_and_templates = read_file("docs/guide/examples-and-templates.md");
     let merge_queue_playbook = read_file("docs/guide/merge-queue-playbook.md");
     let getting_started = read_file("docs/guide/getting-started.md");
+    let existing_repository = read_file("docs/guide/existing-repository.md");
     let node_workflow = read_file("docs/guide/node-workflow.md");
     let lsp_guide = read_file("docs/guide/lsp.md");
     let command_card = read_file("docs/guide/command-card.md");
@@ -442,6 +443,8 @@ fn repository_declares_documentation_guides() {
     let generated_site_index = read_file("docs/generated/site-spec/index.md");
     let generated_validation =
         read_file("docs/generated/site-spec/features/validation/validation.md");
+    let generated_validation_requirement =
+        read_file("docs/generated/site-spec/requirements/core/validation.md");
     let generated_docs_freshness = read_file("scripts/ci/check-generated-docs-freshness.sh");
     let ci_workflow = read_file(".github/workflows/ci.yml");
     let docs_deploy_workflow = read_file(".github/workflows/deploy-pages.yml");
@@ -495,6 +498,7 @@ fn repository_declares_documentation_guides() {
     assert!(readme.contains("syu templates"));
     assert!(readme.contains("starter-only"));
     assert!(readme.contains("syu validate"));
+    assert!(readme.contains("--dry-run"));
     assert!(readme.contains("syu browse"));
     assert!(readme.contains("syu list"));
     assert!(readme.contains("syu doctor ."));
@@ -594,6 +598,7 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("syu doctor ."));
     assert!(getting_started.contains("--id-prefix"));
     assert!(getting_started.contains("syu validate . --fix"));
+    assert!(getting_started.contains("--dry-run"));
     assert!(getting_started.contains("syu browse ."));
     assert!(getting_started.contains("doctor → init → validate → browse"));
     assert!(getting_started.contains("If you only remember the task and not the command name yet"));
@@ -771,6 +776,7 @@ fn repository_declares_documentation_guides() {
     assert!(generated_validation.contains(
         "Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files"
     ));
+    assert!(generated_validation_requirement.contains("dry-run planning mode"));
     assert!(generated_docs_freshness.contains("FEAT-QUALITY-001"));
     assert!(generated_docs_freshness.contains("check_generated_docs_freshness"));
     assert!(generated_docs_freshness.contains("python3 scripts/generate-site-docs.py"));
@@ -822,6 +828,8 @@ fn repository_declares_documentation_guides() {
         troubleshooting.contains("[trace adapter capability matrix](./trace-adapter-support.md)")
     );
     assert!(troubleshooting.contains("[spec anti-patterns guide](./spec-antipatterns.md)"));
+    assert!(troubleshooting.contains("--dry-run"));
+    assert!(existing_repository.contains("--dry-run"));
 }
 
 #[test]

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -199,6 +199,69 @@ fn validate_fix_dry_run_reports_inline_owner_changes_without_writing_files() {
 
 #[test]
 // REQ-CORE-003
+fn validate_fix_dry_run_propagates_autofix_errors() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    fs::create_dir_all(workspace.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(workspace.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(workspace.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(workspace.join("docs/syu/features")).expect("features dir");
+
+    fs::write(
+        workspace.join("syu.yaml"),
+        "version: 1\nruntimes:\n  python:\n    command: false\n",
+    )
+    .expect("config should exist");
+    fs::write(
+        workspace.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Foundations\nversion: 1\n\nphilosophies:\n  - id: PHIL-1\n    title: Foundation\n    product_design_principle: Keep it clear.\n    coding_guideline: Keep it explicit.\n    linked_policies:\n      - POL-1\n",
+    )
+    .expect("philosophy should exist");
+    fs::write(
+        workspace.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\n\npolicies:\n  - id: POL-1\n    title: Policy\n    summary: Rule summary.\n    description: Rule description.\n    linked_philosophies:\n      - PHIL-1\n    linked_requirements:\n      - REQ-1\n",
+    )
+    .expect("policy should exist");
+    fs::write(
+        workspace.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-1\n    title: Requirement\n    description: Requirement description.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-1\n    linked_features:\n      - FEAT-1\n    tests:\n      python:\n        - file: tests/test_sample.py\n          symbols:\n            - requirement_test\n          doc_contains:\n            - Requirement docs\n",
+    )
+    .expect("requirement should exist");
+    fs::write(
+        workspace.join("docs/syu/features/features.yaml"),
+        "version: 1\nfiles:\n  - kind: core\n    file: core.yaml\n",
+    )
+    .expect("feature registry should exist");
+    fs::write(
+        workspace.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-1\n    title: Feature\n    summary: Feature summary.\n    status: implemented\n    linked_requirements:\n      - REQ-1\n    implementations: {}\n",
+    )
+    .expect("feature should exist");
+    fs::create_dir_all(workspace.join("tests")).expect("tests dir");
+    fs::write(
+        workspace.join("tests/test_sample.py"),
+        "def requirement_test():\n    return 1\n",
+    )
+    .expect("python test should exist");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(&workspace)
+        .arg("--fix")
+        .arg("--dry-run")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "dry-run autofix errors should bubble up"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Python inspector failed"));
+}
+
+#[test]
+// REQ-CORE-003
 fn validate_fix_dry_run_exposes_machine_readable_plan() {
     let tempdir = tempdir().expect("tempdir should exist");
     write_workspace_with_ownership_mode(tempdir.path(), false, "sidecar");

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -170,6 +170,35 @@ fn validate_fix_dry_run_reports_planned_changes_without_writing_files() {
 
 #[test]
 // REQ-CORE-003
+fn validate_fix_dry_run_reports_inline_owner_changes_without_writing_files() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace_with_ownership_mode(tempdir.path(), false, "inline");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .arg("--dry-run")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "dry run should not mutate the workspace"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("src/trace.rs"));
+    assert!(stdout.contains("SYU-trace-doc-001"));
+    assert!(stdout.contains("SYU-trace-id-001"));
+
+    let source = fs::read_to_string(tempdir.path().join("src/trace.rs")).expect("source");
+    assert_eq!(source, "pub fn req_trace() {}\n");
+}
+
+#[test]
+// REQ-CORE-003
 fn validate_fix_dry_run_exposes_machine_readable_plan() {
     let tempdir = tempdir().expect("tempdir should exist");
     write_workspace_with_ownership_mode(tempdir.path(), false, "sidecar");

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -1,4 +1,5 @@
 use assert_cmd::cargo::CommandCargoExt;
+use serde_json::Value;
 use std::{fs, path::Path, process::Command};
 use tempfile::tempdir;
 
@@ -127,6 +128,99 @@ fn validate_uses_config_default_fix_and_no_fix_disables_it() {
         String::from_utf8_lossy(&default_fix.stderr)
     );
     assert!(String::from_utf8_lossy(&default_fix.stdout).contains("applied 2 autofix updates"));
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_dry_run_reports_planned_changes_without_writing_files() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace_with_ownership_mode(tempdir.path(), false, "sidecar");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .arg("--dry-run")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "dry run should not mutate the workspace"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("planned 4 autofix updates across 2 files"));
+    assert!(stdout.contains("dry run; no files changed"));
+    assert!(stdout.contains("planned fixes:"));
+    assert!(stdout.contains("src/trace.rs.syu-ownership.yaml"));
+    assert!(stdout.contains("SYU-trace-doc-001"));
+    assert!(stdout.contains("SYU-trace-id-001"));
+
+    let source = fs::read_to_string(tempdir.path().join("src/trace.rs")).expect("source");
+    assert_eq!(source, "pub fn req_trace() {}\n");
+    assert!(
+        !tempdir
+            .path()
+            .join("src/trace.rs.syu-ownership.yaml")
+            .exists()
+    );
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_dry_run_exposes_machine_readable_plan() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_workspace_with_ownership_mode(tempdir.path(), false, "sidecar");
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        !output.status.success(),
+        "dry run should still preserve files"
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("output should be valid JSON");
+    let plan = json["autofix_plan"].as_object().expect("plan should exist");
+    assert_eq!(plan["planned_updates"].as_u64(), Some(4));
+    assert_eq!(
+        plan["updated_files"]
+            .as_array()
+            .expect("updated files should be an array")
+            .len(),
+        2
+    );
+
+    let changes = plan["changes"]
+        .as_array()
+        .expect("changes should be an array");
+    assert_eq!(changes.len(), 4);
+    assert!(changes.iter().any(|change| {
+        change["path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("src/trace.rs"))
+            && change["rules"]
+                .as_array()
+                .is_some_and(|rules| rules.iter().any(|rule| rule == "SYU-trace-doc-001"))
+    }));
+    assert!(changes.iter().any(|change| {
+        change["path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("src/trace.rs.syu-ownership.yaml"))
+            && change["rules"]
+                .as_array()
+                .is_some_and(|rules| rules.iter().any(|rule| rule == "SYU-trace-id-001"))
+    }));
 }
 
 #[test]


### PR DESCRIPTION
Closes #656\n\nAdds dry-run planning for validate --fix, including machine-readable and text plan output, docs, and tests.