### PR TITLE
Add graph registry autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,9 @@ documentation-style trace gaps that can be updated mechanically:
 
 - missing requirement / feature IDs in symbol documentation
 - missing `doc_contains` snippets for Rust, Python, Go, and TypeScript symbols
+- exact duplicate graph links in philosophy / policy / requirement / feature files
+- missing reciprocal graph links when the opposite side is already declared
+- drift between checked-in feature documents and `features/features.yaml`
 
 It does **not** attempt speculative edits like renaming symbols or inventing
 missing files.

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -192,6 +192,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
       able to configure default fix behavior, and `--no-fix` MUST disable it.
       Autofix MUST stay conservative and avoid speculative structural edits.
+      It MAY also remove exact duplicate graph links, restore already-declared
+      reciprocal links, and resynchronize the feature registry with checked-in
+      feature documents when one safe correction is obvious.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -421,6 +424,9 @@ requirements:
       mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
       able to configure default fix behavior, and `--no-fix` MUST disable it.
       Autofix MUST stay conservative and avoid speculative structural edits.
+      It MAY also remove exact duplicate graph links, restore already-declared
+      reciprocal links, and resynchronize the feature registry with checked-in
+      feature documents when one safe correction is obvious.
     priority: high
     status: implemented
     linked_policies:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -352,11 +352,15 @@ if it is obsolete.
 | What `--fix` does | Safe? |
 |---|---|
 | Inserts required `doc_contains` snippets using language-appropriate comment or doc-comment syntax | ✅ Yes |
+| Removes exact duplicate graph links or restores an already-declared reciprocal link | ✅ Yes |
+| Resynchronizes `features/features.yaml` with checked-in feature documents | ✅ Yes |
 | Rewrites or deletes symbols | ❌ No — `--fix` never does this |
 | Adds missing `linked_*` graph links | ❌ No — only you know the correct links |
 | Creates new spec entries | ❌ No |
 
-Run `git diff` after `--fix` to review every change before committing.
+Run `git diff` after `--fix` to review every change before committing. If the
+run fails, `syu` rolls back earlier writes instead of leaving a partial graph or
+registry update behind.
 
 ---
 

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -173,6 +173,9 @@ requirements:
       mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
       able to configure default fix behavior, and `--no-fix` MUST disable it.
       Autofix MUST stay conservative and avoid speculative structural edits.
+      It MAY also remove exact duplicate graph links, restore already-declared
+      reciprocal links, and resynchronize the feature registry with checked-in
+      feature documents when one safe correction is obvious.
     priority: high
     status: implemented
     linked_policies:

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -1166,19 +1166,29 @@ fn sync_feature_registry(
     documents: &[MutableLoadedDocument<FeatureDocument>],
 ) -> Result<Option<FeatureRegistryDocument>> {
     let registry_path = feature_root.join("features.yaml");
-    let raw = fs::read_to_string(&registry_path)?;
-    let registry: FeatureRegistryDocument = serde_yaml::from_str(&raw)?;
     let files = feature_registry_entries_for_documents(feature_root, documents);
+    match fs::read_to_string(&registry_path) {
+        Ok(raw) => {
+            let registry: FeatureRegistryDocument = serde_yaml::from_str(&raw)?;
+            if feature_registry_entries_match(&registry.files, &files) {
+                return Ok(None);
+            }
 
-    if feature_registry_entries_match(&registry.files, &files) {
-        return Ok(None);
+            Ok(Some(FeatureRegistryDocument {
+                version: registry.version,
+                updated: registry.updated,
+                files,
+            }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Some(
+            FeatureRegistryDocument {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                updated: None,
+                files,
+            },
+        )),
+        Err(error) => Err(error.into()),
     }
-
-    Ok(Some(FeatureRegistryDocument {
-        version: registry.version,
-        updated: registry.updated,
-        files,
-    }))
 }
 
 fn write_modified_documents<T: serde::Serialize>(
@@ -5621,6 +5631,30 @@ mod tests {
         assert_eq!(
             fs::read_to_string(root.join("feature.rs")).expect("feature contents"),
             "pub fn feature_impl() {}\n"
+        );
+    }
+
+    #[test]
+    fn apply_autofix_bootstraps_missing_feature_registry() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+        fs::remove_file(tempdir.path().join("docs/syu/features/features.yaml"))
+            .expect("feature registry should be removable");
+
+        let workspace =
+            crate::workspace::load_workspace(tempdir.path()).expect("workspace should still load");
+        let summary = apply_autofix(&workspace).expect("autofix should succeed");
+
+        let registry_contents = fs::read_to_string(tempdir.path().join("docs/syu/features/features.yaml"))
+            .expect("feature registry should be written");
+        assert!(registry_contents.contains("version:"));
+        assert!(registry_contents.contains("files:"));
+        assert!(registry_contents.contains("core.yaml"));
+        assert_eq!(summary.symbol_updates, 1);
+        assert!(
+            summary
+                .updated_files
+                .contains(Path::new("docs/syu/features/features.yaml"))
         );
     }
 

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -31,6 +31,7 @@ use crate::{
     workspace::{
         Workspace, load_philosophy_documents_with_paths, load_policy_documents_with_paths,
         load_requirement_documents_with_paths, load_workspace,
+        load_workspace_allowing_missing_feature_registry,
     },
 };
 
@@ -357,7 +358,20 @@ fn workspace_item_count(definition_counts: &DefinitionCounts) -> usize {
 
 // FEAT-CHECK-001
 pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
-    let (result, fix_summary, text_summary) = match load_workspace(&args.workspace) {
+    let workspace_result = load_workspace(&args.workspace).or_else(|error| {
+        if !error.to_string().contains("feature registry") {
+            return Err(error);
+        }
+
+        let workspace = load_workspace_allowing_missing_feature_registry(&args.workspace)?;
+        if effective_fix(args, &workspace.config) {
+            Ok(workspace)
+        } else {
+            Err(error)
+        }
+    });
+
+    let (result, fix_summary, text_summary) = match workspace_result {
         Ok(workspace) => {
             let should_fix = effective_fix(args, &workspace.config);
             let fix_summary = if should_fix {
@@ -3320,6 +3334,66 @@ mod tests {
     }
 
     #[test]
+    fn run_check_command_bootstraps_missing_registry_when_fixing() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+        fs::remove_file(tempdir.path().join("docs/syu/features/features.yaml"))
+            .expect("feature registry should be removable");
+
+        let code = run_check_command(&crate::cli::CheckArgs {
+            workspace: tempdir.path().to_path_buf(),
+            format: crate::cli::OutputFormat::Json,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
+            id: Vec::new(),
+            spec_only: false,
+            fix: true,
+            no_fix: false,
+            allow_planned: None,
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
+            warning_exit_code: None,
+            quiet: false,
+        })
+        .expect("command should complete");
+
+        assert_eq!(code, 0);
+        assert!(tempdir.path().join("docs/syu/features/features.yaml").is_file());
+    }
+
+    #[test]
+    fn run_check_command_reports_missing_registry_without_fixing() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+        fs::remove_file(tempdir.path().join("docs/syu/features/features.yaml"))
+            .expect("feature registry should be removable");
+
+        let code = run_check_command(&crate::cli::CheckArgs {
+            workspace: tempdir.path().to_path_buf(),
+            format: crate::cli::OutputFormat::Json,
+            severity: Vec::new(),
+            genre: Vec::new(),
+            rule: Vec::new(),
+            id: Vec::new(),
+            spec_only: false,
+            fix: false,
+            no_fix: false,
+            allow_planned: None,
+            require_non_orphaned_items: None,
+            require_reciprocal_links: None,
+            require_symbol_trace_coverage: None,
+            warning_exit_code: None,
+            quiet: false,
+        })
+        .expect("command should render load errors");
+
+        assert_eq!(code, 1);
+        assert!(!tempdir.path().join("docs/syu/features/features.yaml").is_file());
+    }
+
+    #[test]
     fn run_check_command_propagates_autofix_errors() {
         let tempdir = tempdir().expect("tempdir should exist");
         let workspace = tempdir.path().join("workspace");
@@ -3412,6 +3486,23 @@ mod tests {
         .expect("command should complete");
 
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn apply_autofix_reports_registry_read_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        write_valid_planned_workspace(tempdir.path());
+        let registry_path = tempdir.path().join("docs/syu/features/features.yaml");
+        fs::remove_file(&registry_path).expect("feature registry should be removable");
+        fs::create_dir(&registry_path).expect("directory registry path should be creatable");
+
+        let workspace = crate::workspace::load_workspace_allowing_missing_feature_registry(
+            tempdir.path(),
+        )
+        .expect("workspace should still load");
+        let error = apply_autofix(&workspace).expect_err("registry read failure should bubble up");
+
+        assert!(error.to_string().contains("Is a directory"));
     }
 
     #[test]
@@ -5641,8 +5732,10 @@ mod tests {
         fs::remove_file(tempdir.path().join("docs/syu/features/features.yaml"))
             .expect("feature registry should be removable");
 
-        let workspace =
-            crate::workspace::load_workspace(tempdir.path()).expect("workspace should still load");
+        let workspace = crate::workspace::load_workspace_allowing_missing_feature_registry(
+            tempdir.path(),
+        )
+        .expect("workspace should still load");
         let summary = apply_autofix(&workspace).expect("autofix should succeed");
 
         let registry_contents = fs::read_to_string(tempdir.path().join("docs/syu/features/features.yaml"))

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -839,6 +839,10 @@ fn run_autofix(workspace: &Workspace, mode: AutofixMode) -> Result<AutofixRun> {
             )?;
         }
 
+        if mode == AutofixMode::Apply {
+            apply_graph_autofix(workspace, &mut run.summary, &mut transaction)?;
+        }
+
         Ok(())
     })();
 
@@ -990,11 +994,16 @@ fn apply_autofix_for_trace_map_with_transaction(
 fn load_feature_documents_for_autofix(
     feature_root: &Path,
 ) -> Result<Vec<MutableLoadedDocument<FeatureDocument>>> {
+    let registry_path = feature_root.join("features.yaml");
+    if registry_path.exists() {
+        let raw = fs::read_to_string(&registry_path)?;
+        let _registry: FeatureRegistryDocument = serde_yaml::from_str(&raw)?;
+    }
+
     let mut discovered_paths = Vec::new();
     collect_feature_yaml_paths(feature_root, &mut discovered_paths)?;
     discovered_paths.sort();
 
-    let registry_path = feature_root.join("features.yaml");
     let mut documents = Vec::new();
     for path in discovered_paths {
         if path == registry_path {

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -3446,20 +3446,19 @@ mod tests {
     };
 
     use super::{
+        AutofixPlan, AutofixPlanChange, AutofixTransaction, FilteredIssueView, IssueFilters,
+        ItemLocation, MutableLoadedDocument, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
+        RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
         apply_autofix, apply_feature_reciprocals, apply_philosophy_reciprocals,
         apply_policy_reciprocals, apply_requirement_reciprocals, collect_check_result,
         collect_feature_yaml_paths, describe_trace_reference, entry_covers_symbols,
         feature_registry_kind, filter_check_result, finalize_autofix_error,
         format_reference_location, looks_like_feature_document, merge_ownership_entry,
         ownership_symbols_hint, preferred_trace_file_path, render_autofix_plan, render_text_report,
-        required_ownership_symbols, run_check_command, validate_duplicate_links,
-        validate_duplicate_trace_references, validate_feature, validate_feature_registry_entries,
-        validate_non_empty_field, validate_philosophy, validate_policy, validate_requirement,
-        validate_unique_ids, verify_trace_reference, sync_feature_registry, AutofixPlan,
-        AutofixPlanChange,
-        AutofixTransaction, FilteredIssueView, IssueFilters, ItemLocation,
-        MutableLoadedDocument, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
-        RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
+        required_ownership_symbols, run_check_command, sync_feature_registry,
+        validate_duplicate_links, validate_duplicate_trace_references, validate_feature,
+        validate_feature_registry_entries, validate_non_empty_field, validate_philosophy,
+        validate_policy, validate_requirement, validate_unique_ids, verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -3823,7 +3822,8 @@ mod tests {
         fs::create_dir(feature_root.join("features.yaml"))
             .expect("registry path should be creatable as a directory");
 
-        let error = sync_feature_registry(&feature_root, &[]).expect_err("read failure should bubble up");
+        let error =
+            sync_feature_registry(&feature_root, &[]).expect_err("read failure should bubble up");
         assert!(error.to_string().contains("Is a directory"));
     }
 

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -3148,24 +3148,27 @@ mod tests {
         cli::{ValidationGenreFilter, ValidationSeverityFilter},
         config::{SyuConfig, TraceOwnershipMode},
         model::{
-            DefinitionCounts, Feature, Issue, OwnershipEntry, OwnershipManifest, Philosophy,
-            Policy, Requirement, TraceReference,
+            DefinitionCounts, Feature, FeatureDocument, Issue, OwnershipEntry, OwnershipManifest,
+            Philosophy, PhilosophyDocument, Policy, PolicyDocument, Requirement,
+            RequirementDocument, TraceReference,
         },
         rules::{all_rules, referenced_rules},
         workspace::Workspace,
     };
 
     use super::{
-        FilteredIssueView, IssueFilters, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
-        RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
-        apply_autofix, apply_autofix_for_reference, collect_check_result,
-        collect_feature_yaml_paths, describe_trace_reference, entry_covers_symbols,
-        filter_check_result, format_reference_location, looks_like_feature_document,
-        merge_ownership_entry, ownership_symbols_hint, preferred_trace_file_path,
-        render_text_report, required_ownership_symbols, run_check_command,
-        validate_duplicate_links, validate_duplicate_trace_references, validate_feature,
-        validate_feature_registry_entries, validate_non_empty_field, validate_philosophy,
-        validate_policy, validate_requirement, validate_unique_ids, verify_trace_reference,
+        FilteredIssueView, IssueFilters, MutableLoadedDocument, ORPHAN_RULE_CODES,
+        RECIPROCAL_RULE_CODES, RequirementValidationIndex, TextReportSummary, TraceRole,
+        ValidationResources, apply_autofix, apply_autofix_for_reference, apply_feature_reciprocals,
+        apply_philosophy_reciprocals, apply_policy_reciprocals, apply_requirement_reciprocals,
+        collect_check_result, collect_feature_yaml_paths, describe_trace_reference,
+        entry_covers_symbols, filter_check_result, format_reference_location,
+        looks_like_feature_document, merge_ownership_entry, ownership_symbols_hint,
+        preferred_trace_file_path, render_text_report, required_ownership_symbols,
+        run_check_command, validate_duplicate_links, validate_duplicate_trace_references,
+        validate_feature, validate_feature_registry_entries, validate_non_empty_field,
+        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
+        verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -5817,5 +5820,93 @@ mod tests {
             format_reference_location("rust", &reference),
             "rust:src/lib.rs"
         );
+    }
+
+    #[test]
+    fn graph_autofix_skips_missing_targets_without_changes() {
+        let philosophies = vec![MutableLoadedDocument {
+            path: PathBuf::from("philosophy.yaml"),
+            document: PhilosophyDocument {
+                category: "Philosophy".to_string(),
+                version: 1,
+                language: Some("en".to_string()),
+                philosophies: vec![Philosophy {
+                    id: "PHIL-1".to_string(),
+                    title: "Title".to_string(),
+                    product_design_principle: "Principle".to_string(),
+                    coding_guideline: "Guideline".to_string(),
+                    linked_policies: vec!["POL-missing".to_string()],
+                }],
+            },
+            changed: false,
+        }];
+        let mut policies = vec![MutableLoadedDocument {
+            path: PathBuf::from("policy.yaml"),
+            document: PolicyDocument {
+                category: "Policies".to_string(),
+                version: 1,
+                language: Some("en".to_string()),
+                policies: vec![Policy {
+                    id: "POL-1".to_string(),
+                    title: "Title".to_string(),
+                    summary: "Summary".to_string(),
+                    description: "Description".to_string(),
+                    linked_philosophies: vec!["PHIL-missing".to_string()],
+                    linked_requirements: vec!["REQ-missing".to_string()],
+                }],
+            },
+            changed: false,
+        }];
+        let mut requirements = vec![MutableLoadedDocument {
+            path: PathBuf::from("requirement.yaml"),
+            document: RequirementDocument {
+                category: "Core Requirements".to_string(),
+                prefix: "REQ".to_string(),
+                requirements: vec![Requirement {
+                    id: "REQ-1".to_string(),
+                    title: "Title".to_string(),
+                    description: "Description".to_string(),
+                    priority: "high".to_string(),
+                    status: "planned".to_string(),
+                    linked_policies: vec!["POL-missing".to_string()],
+                    linked_features: vec!["FEAT-missing".to_string()],
+                    tests: BTreeMap::new(),
+                }],
+            },
+            changed: false,
+        }];
+        let mut features = vec![MutableLoadedDocument {
+            path: PathBuf::from("feature.yaml"),
+            document: FeatureDocument {
+                category: "Core Features".to_string(),
+                version: 1,
+                features: vec![Feature {
+                    id: "FEAT-1".to_string(),
+                    title: "Title".to_string(),
+                    summary: "Summary".to_string(),
+                    status: "planned".to_string(),
+                    linked_requirements: vec!["REQ-missing".to_string()],
+                    implementations: BTreeMap::new(),
+                }],
+            },
+            changed: false,
+        }];
+
+        let empty = HashMap::new();
+        let mut empty_philosophies: Vec<MutableLoadedDocument<PhilosophyDocument>> = Vec::new();
+        apply_philosophy_reciprocals(&philosophies, &mut policies, &empty);
+        apply_policy_reciprocals(
+            &policies,
+            &mut empty_philosophies,
+            &empty,
+            &mut requirements,
+            &empty,
+        );
+        apply_requirement_reciprocals(&requirements, &mut features, &empty);
+        apply_feature_reciprocals(&features, &mut requirements, &empty);
+
+        assert!(!policies[0].changed);
+        assert!(!requirements[0].changed);
+        assert!(!features[0].changed);
     }
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -22,12 +22,16 @@ use crate::{
     inspect::{apply_symbol_doc_fix, inspect_symbol, supports_rich_inspection},
     language::adapter_for_language,
     model::{
-        CheckResult, DefinitionCounts, Feature, FeatureRegistryDocument, Issue, OwnershipEntry,
-        OwnershipManifest, Philosophy, Policy, Requirement, Severity, TraceCount, TraceReference,
-        TraceSummary,
+        CheckResult, DefinitionCounts, Feature, FeatureDocument, FeatureRegistryDocument,
+        FeatureRegistryEntry, Issue, OwnershipEntry, OwnershipManifest, Philosophy,
+        PhilosophyDocument, Policy, PolicyDocument, Requirement, RequirementDocument, Severity,
+        TraceCount, TraceReference, TraceSummary,
     },
     rules::{all_rules, attach_referenced_rules, referenced_rules, rule_genre},
-    workspace::{Workspace, load_workspace},
+    workspace::{
+        Workspace, load_philosophy_documents_with_paths, load_policy_documents_with_paths,
+        load_requirement_documents_with_paths, load_workspace,
+    },
 };
 
 use super::issue_text::{TextIssueFormat, format_text_issue};
@@ -68,6 +72,13 @@ struct RequirementValidationIndex<'a> {
 struct AutofixSummary {
     updated_files: BTreeSet<PathBuf>,
     symbol_updates: usize,
+}
+
+#[derive(Debug)]
+struct MutableLoadedDocument<T> {
+    path: PathBuf,
+    document: T,
+    changed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -706,7 +717,101 @@ fn apply_autofix(workspace: &Workspace) -> Result<AutofixSummary> {
         }
     }
 
+    apply_graph_autofix(workspace, &mut summary)?;
+
     Ok(summary)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ItemLocation {
+    doc_index: usize,
+    item_index: usize,
+}
+
+fn apply_graph_autofix(workspace: &Workspace, summary: &mut AutofixSummary) -> Result<()> {
+    let philosophy_root = workspace.spec_root.join("philosophy");
+    let policy_root = workspace.spec_root.join("policies");
+    let requirement_root = workspace.spec_root.join("requirements");
+    let feature_root = workspace.spec_root.join("features");
+
+    let mut philosophy_docs = if philosophy_root.is_dir() {
+        load_philosophy_documents_with_paths(&philosophy_root)?
+            .into_iter()
+            .map(|loaded| MutableLoadedDocument {
+                path: loaded.path,
+                document: loaded.document,
+                changed: false,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mut policy_docs = if policy_root.is_dir() {
+        load_policy_documents_with_paths(&policy_root)?
+            .into_iter()
+            .map(|loaded| MutableLoadedDocument {
+                path: loaded.path,
+                document: loaded.document,
+                changed: false,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mut requirement_docs = if requirement_root.is_dir() {
+        load_requirement_documents_with_paths(&requirement_root)?
+            .into_iter()
+            .map(|loaded| MutableLoadedDocument {
+                path: loaded.path,
+                document: loaded.document,
+                changed: false,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mut feature_docs = if feature_root.is_dir() {
+        load_feature_documents_for_autofix(&feature_root)?
+    } else {
+        Vec::new()
+    };
+
+    dedupe_philosophy_links(&mut philosophy_docs);
+    dedupe_policy_links(&mut policy_docs);
+    dedupe_requirement_links(&mut requirement_docs);
+    dedupe_feature_links(&mut feature_docs);
+
+    let philosophy_index = index_philosophies(&philosophy_docs);
+    let policy_index = index_policies(&policy_docs);
+    let requirement_index = index_requirements(&requirement_docs);
+    let feature_index = index_features(&feature_docs);
+
+    apply_philosophy_reciprocals(&philosophy_docs, &mut policy_docs, &policy_index);
+    apply_policy_reciprocals(
+        &policy_docs,
+        &mut philosophy_docs,
+        &philosophy_index,
+        &mut requirement_docs,
+        &requirement_index,
+    );
+    apply_requirement_reciprocals(&requirement_docs, &mut feature_docs, &feature_index);
+    apply_feature_reciprocals(&feature_docs, &mut requirement_docs, &requirement_index);
+
+    if feature_root.is_dir()
+        && let Some(updated_registry) = sync_feature_registry(&feature_root, &feature_docs)?
+    {
+        let registry_path = feature_root.join("features.yaml");
+        fs::write(&registry_path, serde_yaml::to_string(&updated_registry)?)?;
+        record_updated_file(summary, &workspace.root, &registry_path);
+        summary.symbol_updates += 1;
+    }
+
+    write_modified_documents(&philosophy_docs, summary, &workspace.root)?;
+    write_modified_documents(&policy_docs, summary, &workspace.root)?;
+    write_modified_documents(&requirement_docs, summary, &workspace.root)?;
+    write_modified_documents(&feature_docs, summary, &workspace.root)?;
+
+    Ok(())
 }
 
 #[allow(clippy::question_mark)]
@@ -727,6 +832,368 @@ fn apply_autofix_for_trace_map(
         }
     }
 
+    Ok(())
+}
+
+fn load_feature_documents_for_autofix(
+    feature_root: &Path,
+) -> Result<Vec<MutableLoadedDocument<FeatureDocument>>> {
+    let mut discovered_paths = Vec::new();
+    collect_feature_yaml_paths(feature_root, &mut discovered_paths)?;
+    discovered_paths.sort();
+
+    let registry_path = feature_root.join("features.yaml");
+    let mut documents = Vec::new();
+    for path in discovered_paths {
+        if path == registry_path {
+            continue;
+        }
+        if !looks_like_feature_document(&path)? {
+            continue;
+        }
+        let raw = fs::read_to_string(&path)?;
+        let document: FeatureDocument = serde_yaml::from_str(&raw)?;
+        documents.push(MutableLoadedDocument {
+            path,
+            document,
+            changed: false,
+        });
+    }
+
+    Ok(documents)
+}
+
+fn dedupe_philosophy_links(documents: &mut [MutableLoadedDocument<PhilosophyDocument>]) {
+    for document in documents {
+        for philosophy in &mut document.document.philosophies {
+            if dedupe_unique_values(&mut philosophy.linked_policies) {
+                document.changed = true;
+            }
+        }
+    }
+}
+
+fn dedupe_policy_links(documents: &mut [MutableLoadedDocument<PolicyDocument>]) {
+    for document in documents {
+        for policy in &mut document.document.policies {
+            let changed_philosophies = dedupe_unique_values(&mut policy.linked_philosophies);
+            let changed_requirements = dedupe_unique_values(&mut policy.linked_requirements);
+            if changed_philosophies || changed_requirements {
+                document.changed = true;
+            }
+        }
+    }
+}
+
+fn dedupe_requirement_links(documents: &mut [MutableLoadedDocument<RequirementDocument>]) {
+    for document in documents {
+        for requirement in &mut document.document.requirements {
+            let changed_policies = dedupe_unique_values(&mut requirement.linked_policies);
+            let changed_features = dedupe_unique_values(&mut requirement.linked_features);
+            if changed_policies || changed_features {
+                document.changed = true;
+            }
+        }
+    }
+}
+
+fn dedupe_feature_links(documents: &mut [MutableLoadedDocument<FeatureDocument>]) {
+    for document in documents {
+        for feature in &mut document.document.features {
+            if dedupe_unique_values(&mut feature.linked_requirements) {
+                document.changed = true;
+            }
+        }
+    }
+}
+
+fn dedupe_unique_values(values: &mut Vec<String>) -> bool {
+    let before = values.len();
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+    values.len() != before
+}
+
+fn index_philosophies(
+    documents: &[MutableLoadedDocument<PhilosophyDocument>],
+) -> HashMap<String, ItemLocation> {
+    let mut index = HashMap::new();
+    for (doc_index, document) in documents.iter().enumerate() {
+        for (item_index, philosophy) in document.document.philosophies.iter().enumerate() {
+            index.insert(
+                philosophy.id.clone(),
+                ItemLocation {
+                    doc_index,
+                    item_index,
+                },
+            );
+        }
+    }
+    index
+}
+
+fn index_policies(
+    documents: &[MutableLoadedDocument<PolicyDocument>],
+) -> HashMap<String, ItemLocation> {
+    let mut index = HashMap::new();
+    for (doc_index, document) in documents.iter().enumerate() {
+        for (item_index, policy) in document.document.policies.iter().enumerate() {
+            index.insert(
+                policy.id.clone(),
+                ItemLocation {
+                    doc_index,
+                    item_index,
+                },
+            );
+        }
+    }
+    index
+}
+
+fn index_requirements(
+    documents: &[MutableLoadedDocument<RequirementDocument>],
+) -> HashMap<String, ItemLocation> {
+    let mut index = HashMap::new();
+    for (doc_index, document) in documents.iter().enumerate() {
+        for (item_index, requirement) in document.document.requirements.iter().enumerate() {
+            index.insert(
+                requirement.id.clone(),
+                ItemLocation {
+                    doc_index,
+                    item_index,
+                },
+            );
+        }
+    }
+    index
+}
+
+fn index_features(
+    documents: &[MutableLoadedDocument<FeatureDocument>],
+) -> HashMap<String, ItemLocation> {
+    let mut index = HashMap::new();
+    for (doc_index, document) in documents.iter().enumerate() {
+        for (item_index, feature) in document.document.features.iter().enumerate() {
+            index.insert(
+                feature.id.clone(),
+                ItemLocation {
+                    doc_index,
+                    item_index,
+                },
+            );
+        }
+    }
+    index
+}
+
+fn apply_philosophy_reciprocals(
+    philosophies: &[MutableLoadedDocument<PhilosophyDocument>],
+    policies: &mut [MutableLoadedDocument<PolicyDocument>],
+    policy_index: &HashMap<String, ItemLocation>,
+) {
+    for document in philosophies {
+        for philosophy in &document.document.philosophies {
+            for policy_id in &philosophy.linked_policies {
+                let Some(location) = policy_index.get(policy_id) else {
+                    continue;
+                };
+                if insert_unique_value(
+                    &mut policies[location.doc_index].document.policies[location.item_index]
+                        .linked_philosophies,
+                    &philosophy.id,
+                ) {
+                    policies[location.doc_index].changed = true;
+                }
+            }
+        }
+    }
+}
+
+fn apply_policy_reciprocals(
+    policies: &[MutableLoadedDocument<PolicyDocument>],
+    philosophies: &mut [MutableLoadedDocument<PhilosophyDocument>],
+    philosophy_index: &HashMap<String, ItemLocation>,
+    requirements: &mut [MutableLoadedDocument<RequirementDocument>],
+    requirement_index: &HashMap<String, ItemLocation>,
+) {
+    for document in policies {
+        for policy in &document.document.policies {
+            for philosophy_id in &policy.linked_philosophies {
+                let Some(location) = philosophy_index.get(philosophy_id) else {
+                    continue;
+                };
+                if insert_unique_value(
+                    &mut philosophies[location.doc_index].document.philosophies
+                        [location.item_index]
+                        .linked_policies,
+                    &policy.id,
+                ) {
+                    philosophies[location.doc_index].changed = true;
+                }
+            }
+
+            for requirement_id in &policy.linked_requirements {
+                let Some(location) = requirement_index.get(requirement_id) else {
+                    continue;
+                };
+                if insert_unique_value(
+                    &mut requirements[location.doc_index].document.requirements
+                        [location.item_index]
+                        .linked_policies,
+                    &policy.id,
+                ) {
+                    requirements[location.doc_index].changed = true;
+                }
+            }
+        }
+    }
+}
+
+fn apply_requirement_reciprocals(
+    requirements: &[MutableLoadedDocument<RequirementDocument>],
+    features: &mut [MutableLoadedDocument<FeatureDocument>],
+    feature_index: &HashMap<String, ItemLocation>,
+) {
+    for document in requirements {
+        for requirement in &document.document.requirements {
+            for feature_id in &requirement.linked_features {
+                let Some(location) = feature_index.get(feature_id) else {
+                    continue;
+                };
+                if insert_unique_value(
+                    &mut features[location.doc_index].document.features[location.item_index]
+                        .linked_requirements,
+                    &requirement.id,
+                ) {
+                    features[location.doc_index].changed = true;
+                }
+            }
+        }
+    }
+}
+
+fn apply_feature_reciprocals(
+    features: &[MutableLoadedDocument<FeatureDocument>],
+    requirements: &mut [MutableLoadedDocument<RequirementDocument>],
+    requirement_index: &HashMap<String, ItemLocation>,
+) {
+    for document in features {
+        for feature in &document.document.features {
+            for requirement_id in &feature.linked_requirements {
+                let Some(location) = requirement_index.get(requirement_id) else {
+                    continue;
+                };
+                if insert_unique_value(
+                    &mut requirements[location.doc_index].document.requirements
+                        [location.item_index]
+                        .linked_features,
+                    &feature.id,
+                ) {
+                    requirements[location.doc_index].changed = true;
+                }
+            }
+        }
+    }
+}
+
+fn insert_unique_value(values: &mut Vec<String>, value: &str) -> bool {
+    if values.iter().any(|existing| existing == value) {
+        return false;
+    }
+    values.push(value.to_string());
+    true
+}
+
+fn feature_registry_kind(feature_root: &Path, path: &Path) -> String {
+    let relative = path.strip_prefix(feature_root).unwrap_or(path);
+    if let Some(parent) = relative.parent()
+        && let Some(component) = parent.components().find_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+            _ => None,
+        })
+    {
+        return component;
+    }
+    relative
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "feature".to_string())
+}
+
+fn feature_registry_entries_for_documents(
+    feature_root: &Path,
+    documents: &[MutableLoadedDocument<FeatureDocument>],
+) -> Vec<FeatureRegistryEntry> {
+    let mut entries = documents
+        .iter()
+        .map(|document| {
+            let relative = normalize_relative_path(
+                document
+                    .path
+                    .strip_prefix(feature_root)
+                    .unwrap_or(&document.path),
+            );
+            FeatureRegistryEntry {
+                kind: feature_registry_kind(feature_root, &document.path),
+                file: relative,
+            }
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.kind.cmp(&right.kind).then(left.file.cmp(&right.file)));
+    entries
+}
+
+fn feature_registry_entries_match(
+    left: &[FeatureRegistryEntry],
+    right: &[FeatureRegistryEntry],
+) -> bool {
+    let mut left = left
+        .iter()
+        .map(|entry| (entry.kind.clone(), entry.file.clone()))
+        .collect::<Vec<_>>();
+    let mut right = right
+        .iter()
+        .map(|entry| (entry.kind.clone(), entry.file.clone()))
+        .collect::<Vec<_>>();
+    left.sort();
+    right.sort();
+    left == right
+}
+
+fn sync_feature_registry(
+    feature_root: &Path,
+    documents: &[MutableLoadedDocument<FeatureDocument>],
+) -> Result<Option<FeatureRegistryDocument>> {
+    let registry_path = feature_root.join("features.yaml");
+    let raw = fs::read_to_string(&registry_path)?;
+    let registry: FeatureRegistryDocument = serde_yaml::from_str(&raw)?;
+    let files = feature_registry_entries_for_documents(feature_root, documents);
+
+    if feature_registry_entries_match(&registry.files, &files) {
+        return Ok(None);
+    }
+
+    Ok(Some(FeatureRegistryDocument {
+        version: registry.version,
+        updated: registry.updated,
+        files,
+    }))
+}
+
+fn write_modified_documents<T: serde::Serialize>(
+    documents: &[MutableLoadedDocument<T>],
+    summary: &mut AutofixSummary,
+    root: &Path,
+) -> Result<()> {
+    for document in documents {
+        if !document.changed {
+            continue;
+        }
+        fs::write(&document.path, serde_yaml::to_string(&document.document)?)?;
+        record_updated_file(summary, root, &document.path);
+        summary.symbol_updates += 1;
+    }
     Ok(())
 }
 

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -3157,18 +3157,18 @@ mod tests {
     };
 
     use super::{
-        FilteredIssueView, IssueFilters, MutableLoadedDocument, ORPHAN_RULE_CODES,
+        FilteredIssueView, IssueFilters, ItemLocation, MutableLoadedDocument, ORPHAN_RULE_CODES,
         RECIPROCAL_RULE_CODES, RequirementValidationIndex, TextReportSummary, TraceRole,
         ValidationResources, apply_autofix, apply_autofix_for_reference, apply_feature_reciprocals,
         apply_philosophy_reciprocals, apply_policy_reciprocals, apply_requirement_reciprocals,
         collect_check_result, collect_feature_yaml_paths, describe_trace_reference,
-        entry_covers_symbols, filter_check_result, format_reference_location,
-        looks_like_feature_document, merge_ownership_entry, ownership_symbols_hint,
-        preferred_trace_file_path, render_text_report, required_ownership_symbols,
-        run_check_command, validate_duplicate_links, validate_duplicate_trace_references,
-        validate_feature, validate_feature_registry_entries, validate_non_empty_field,
-        validate_philosophy, validate_policy, validate_requirement, validate_unique_ids,
-        verify_trace_reference,
+        entry_covers_symbols, feature_registry_kind, filter_check_result,
+        format_reference_location, looks_like_feature_document, merge_ownership_entry,
+        ownership_symbols_hint, preferred_trace_file_path, render_text_report,
+        required_ownership_symbols, run_check_command, validate_duplicate_links,
+        validate_duplicate_trace_references, validate_feature, validate_feature_registry_entries,
+        validate_non_empty_field, validate_philosophy, validate_policy, validate_requirement,
+        validate_unique_ids, verify_trace_reference,
     };
 
     fn philosophy(id: &str) -> Philosophy {
@@ -5908,5 +5908,115 @@ mod tests {
         assert!(!policies[0].changed);
         assert!(!requirements[0].changed);
         assert!(!features[0].changed);
+    }
+
+    #[test]
+    fn graph_autofix_adds_missing_reciprocals_and_falls_back_for_registry_kind() {
+        let mut philosophies = vec![MutableLoadedDocument {
+            path: PathBuf::from("philosophy.yaml"),
+            document: PhilosophyDocument {
+                category: "Philosophy".to_string(),
+                version: 1,
+                language: Some("en".to_string()),
+                philosophies: vec![Philosophy {
+                    id: "PHIL-1".to_string(),
+                    title: "Title".to_string(),
+                    product_design_principle: "Principle".to_string(),
+                    coding_guideline: "Guideline".to_string(),
+                    linked_policies: Vec::new(),
+                }],
+            },
+            changed: false,
+        }];
+        let policies = vec![MutableLoadedDocument {
+            path: PathBuf::from("policy.yaml"),
+            document: PolicyDocument {
+                category: "Policies".to_string(),
+                version: 1,
+                language: Some("en".to_string()),
+                policies: vec![Policy {
+                    id: "POL-1".to_string(),
+                    title: "Title".to_string(),
+                    summary: "Summary".to_string(),
+                    description: "Description".to_string(),
+                    linked_philosophies: vec!["PHIL-1".to_string()],
+                    linked_requirements: Vec::new(),
+                }],
+            },
+            changed: false,
+        }];
+        let mut requirements = vec![MutableLoadedDocument {
+            path: PathBuf::from("requirement.yaml"),
+            document: RequirementDocument {
+                category: "Core Requirements".to_string(),
+                prefix: "REQ".to_string(),
+                requirements: vec![Requirement {
+                    id: "REQ-1".to_string(),
+                    title: "Title".to_string(),
+                    description: "Description".to_string(),
+                    priority: "high".to_string(),
+                    status: "planned".to_string(),
+                    linked_policies: Vec::new(),
+                    linked_features: Vec::new(),
+                    tests: BTreeMap::new(),
+                }],
+            },
+            changed: false,
+        }];
+        let features = vec![MutableLoadedDocument {
+            path: PathBuf::from("feature.yaml"),
+            document: FeatureDocument {
+                category: "Core Features".to_string(),
+                version: 1,
+                features: vec![Feature {
+                    id: "FEAT-1".to_string(),
+                    title: "Title".to_string(),
+                    summary: "Summary".to_string(),
+                    status: "planned".to_string(),
+                    linked_requirements: vec!["REQ-1".to_string()],
+                    implementations: BTreeMap::new(),
+                }],
+            },
+            changed: false,
+        }];
+
+        let philosophy_index = HashMap::from([(
+            "PHIL-1".to_string(),
+            ItemLocation {
+                doc_index: 0,
+                item_index: 0,
+            },
+        )]);
+        let requirement_index = HashMap::from([(
+            "REQ-1".to_string(),
+            ItemLocation {
+                doc_index: 0,
+                item_index: 0,
+            },
+        )]);
+
+        apply_policy_reciprocals(
+            &policies,
+            &mut philosophies,
+            &philosophy_index,
+            &mut requirements,
+            &requirement_index,
+        );
+        apply_feature_reciprocals(&features, &mut requirements, &requirement_index);
+
+        assert!(philosophies[0].changed);
+        assert!(requirements[0].changed);
+        assert_eq!(
+            philosophies[0].document.philosophies[0].linked_policies,
+            vec!["POL-1"]
+        );
+        assert_eq!(
+            requirements[0].document.requirements[0].linked_features,
+            vec!["FEAT-1"]
+        );
+        assert_eq!(
+            feature_registry_kind(Path::new("features"), Path::new("features/../core.yaml")),
+            "core"
+        );
     }
 }

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -3455,7 +3455,8 @@ mod tests {
         required_ownership_symbols, run_check_command, validate_duplicate_links,
         validate_duplicate_trace_references, validate_feature, validate_feature_registry_entries,
         validate_non_empty_field, validate_philosophy, validate_policy, validate_requirement,
-        validate_unique_ids, verify_trace_reference, AutofixPlan, AutofixPlanChange,
+        validate_unique_ids, verify_trace_reference, sync_feature_registry, AutofixPlan,
+        AutofixPlanChange,
         AutofixTransaction, FilteredIssueView, IssueFilters, ItemLocation,
         MutableLoadedDocument, ORPHAN_RULE_CODES, RECIPROCAL_RULE_CODES,
         RequirementValidationIndex, TextReportSummary, TraceRole, ValidationResources,
@@ -3811,6 +3812,18 @@ mod tests {
                 .expect("workspace should still load");
         let error = apply_autofix(&workspace).expect_err("registry read failure should bubble up");
 
+        assert!(error.to_string().contains("Is a directory"));
+    }
+
+    #[test]
+    fn sync_feature_registry_reports_read_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let feature_root = tempdir.path().join("docs/syu/features");
+        fs::create_dir_all(&feature_root).expect("feature root should exist");
+        fs::create_dir(feature_root.join("features.yaml"))
+            .expect("registry path should be creatable as a directory");
+
+        let error = sync_feature_registry(&feature_root, &[]).expect_err("read failure should bubble up");
         assert!(error.to_string().contains("Is a directory"));
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,7 @@ pub struct Requirement {
 #[serde(deny_unknown_fields)]
 pub struct FeatureRegistryDocument {
     pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated: Option<String>,
     pub files: Vec<FeatureRegistryEntry>,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::rules::ReferencedRule;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PhilosophyDocument {
     pub category: String,
@@ -26,7 +26,7 @@ pub struct Philosophy {
     pub linked_policies: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PolicyDocument {
     pub category: String,
@@ -48,7 +48,7 @@ pub struct Policy {
     pub linked_requirements: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RequirementDocument {
     pub category: String,
@@ -72,7 +72,7 @@ pub struct Requirement {
     pub tests: BTreeMap<String, Vec<TraceReference>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureRegistryDocument {
     pub version: String,
@@ -80,14 +80,14 @@ pub struct FeatureRegistryDocument {
     pub files: Vec<FeatureRegistryEntry>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureRegistryEntry {
     pub kind: String,
     pub file: PathBuf,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureDocument {
     pub category: String,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -164,24 +164,33 @@ pub(crate) fn load_feature_documents_with_paths(
     feature_root: &Path,
 ) -> Result<Vec<LoadedDocument<FeatureDocument>>> {
     let registry_path = feature_root.join("features.yaml");
-    if registry_path.is_file() {
-        let registry = load_feature_registry(&registry_path)?;
-        if registry.files.is_empty() {
-            bail!(
-                "feature registry `{}` does not declare any feature files",
-                registry_path.display()
-            );
-        }
-
-        let mut documents = Vec::new();
-        for file in registry.files {
-            let path = resolve_feature_document_path(feature_root, &file.file)?;
-            let document = load_feature_document(&path, &file.kind)?;
-            documents.push(LoadedDocument { path, document });
-        }
-        return Ok(documents);
+    let registry = load_feature_registry(&registry_path)?;
+    if registry.files.is_empty() {
+        bail!(
+            "feature registry `{}` does not declare any feature files",
+            registry_path.display()
+        );
     }
 
+    let mut documents = Vec::new();
+    for file in registry.files {
+        let path = resolve_feature_document_path(feature_root, &file.file)?;
+        let document = load_feature_document(&path, &file.kind)?;
+        documents.push(LoadedDocument { path, document });
+    }
+    Ok(documents)
+}
+
+fn load_feature_document(path: &Path, kind: &str) -> Result<FeatureDocument> {
+    let label = format!("feature document `{}` ({kind})", path.display());
+    let raw = read_yaml_text(path, &label)?;
+    serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse {label} from `{}`", path.display()))
+}
+
+pub(crate) fn load_feature_documents_without_registry(
+    feature_root: &Path,
+) -> Result<Vec<LoadedDocument<FeatureDocument>>> {
     let mut documents = Vec::new();
     for path in yaml_file_paths_recursive(feature_root)? {
         if path.file_name().and_then(|name| name.to_str()) == Some("features.yaml") {
@@ -197,18 +206,11 @@ pub(crate) fn load_feature_documents_with_paths(
     if documents.is_empty() {
         bail!(
             "missing feature registry `{}`",
-            registry_path.display()
+            feature_root.join("features.yaml").display()
         );
     }
 
     Ok(documents)
-}
-
-fn load_feature_document(path: &Path, kind: &str) -> Result<FeatureDocument> {
-    let label = format!("feature document `{}` ({kind})", path.display());
-    let raw = read_yaml_text(path, &label)?;
-    serde_yaml::from_str(&raw)
-        .with_context(|| format!("failed to parse {label} from `{}`", path.display()))
 }
 
 fn looks_like_feature_document(path: &Path) -> Result<bool> {
@@ -218,6 +220,55 @@ fn looks_like_feature_document(path: &Path) -> Result<bool> {
     Ok(value.as_mapping().is_some_and(|mapping| {
         mapping.contains_key(serde_yaml::Value::String("features".to_string()))
     }))
+}
+
+pub(crate) fn load_workspace_allowing_missing_feature_registry(root: &Path) -> Result<Workspace> {
+    let root = resolve_workspace_root(root)?;
+    let loaded_config = load_config(&root)?;
+    let spec_root = resolve_spec_root(&root, &loaded_config.config);
+    let philosophy_docs = load_philosophy_documents_with_paths(&spec_root.join("philosophy"))?;
+    let policy_docs = load_policy_documents_with_paths(&spec_root.join("policies"))?;
+    let requirement_docs = load_requirement_documents_with_paths(&spec_root.join("requirements"))?;
+    let feature_root = spec_root.join("features");
+    let feature_docs = if feature_root.join("features.yaml").is_file() {
+        load_feature_documents_with_paths(&feature_root)?
+    } else {
+        load_feature_documents_without_registry(&feature_root)?
+    };
+
+    let philosophies = philosophy_docs
+        .into_iter()
+        .flat_map(|loaded| loaded.document.philosophies)
+        .collect();
+    let policies = policy_docs
+        .into_iter()
+        .flat_map(|loaded| loaded.document.policies)
+        .collect();
+    let requirements = requirement_docs
+        .into_iter()
+        .flat_map(|loaded| loaded.document.requirements)
+        .collect();
+    let features = feature_docs
+        .into_iter()
+        .flat_map(|loaded| loaded.document.features)
+        .collect::<Vec<_>>();
+
+    if features.is_empty() {
+        bail!(
+            "no feature definitions were found under `{}`",
+            spec_root.join("features").display()
+        );
+    }
+
+    Ok(Workspace {
+        root,
+        spec_root,
+        config: loaded_config.config,
+        philosophies,
+        policies,
+        requirements,
+        features,
+    })
 }
 
 fn ensure_yaml_directory(directory: &Path, label: &str) -> Result<Vec<PathBuf>> {
@@ -342,7 +393,8 @@ mod tests {
         ensure_yaml_directory, ensure_yaml_directory_recursive, load_feature_document,
         load_feature_registry, load_philosophy_documents_with_paths,
         load_policy_documents_with_paths, load_requirement_documents_with_paths, load_workspace,
-        read_yaml_text, resolve_feature_document_path, resolve_workspace_root, yaml_file_paths,
+        load_workspace_allowing_missing_feature_registry, read_yaml_text,
+        resolve_feature_document_path, resolve_workspace_root, yaml_file_paths,
         yaml_file_paths_recursive,
     };
 
@@ -358,6 +410,13 @@ mod tests {
         assert_eq!(workspace.philosophies.len(), 1);
         assert_eq!(workspace.policies.len(), 2);
         assert_eq!(workspace.requirements.len(), 6);
+        assert_eq!(workspace.features.len(), 6);
+    }
+
+    #[test]
+    fn load_workspace_allowing_missing_feature_registry_reads_existing_registry() {
+        let workspace = load_workspace_allowing_missing_feature_registry(&fixture_root("passing"))
+            .expect("fixture should load");
         assert_eq!(workspace.features.len(), 6);
     }
 
@@ -401,6 +460,84 @@ mod tests {
         assert_eq!(workspace.features.len(), 1);
         assert_eq!(workspace.requirements[0].id, "REQ-1");
         assert_eq!(workspace.features[0].id, "FEAT-1");
+    }
+
+    #[test]
+    fn load_workspace_allowing_missing_feature_registry_reports_missing_registry_when_no_feature_docs_exist(
+    ) {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let spec_root = tempdir.path().join("docs/syu");
+        fs::create_dir_all(spec_root.join("philosophy")).expect("dir");
+        fs::create_dir_all(spec_root.join("policies")).expect("dir");
+        fs::create_dir_all(spec_root.join("requirements")).expect("dir");
+        fs::create_dir_all(spec_root.join("features")).expect("dir");
+
+        fs::write(tempdir.path().join("syu.yaml"), "version: 1\nspec:\n  root: docs/syu\n")
+            .expect("config");
+        fs::write(
+            spec_root.join("philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nphilosophies:\n  - id: PHIL-1\n    title: T\n    product_design_principle: A\n    coding_guideline: B\n    linked_policies:\n      - POL-1\n",
+        )
+        .expect("write");
+        fs::write(
+            spec_root.join("policies/policies.yaml"),
+            "category: Policies\nversion: 1\npolicies:\n  - id: POL-1\n    title: T\n    summary: S\n    description: D\n    linked_philosophies:\n      - PHIL-1\n    linked_requirements:\n      - REQ-1\n",
+        )
+        .expect("write");
+        fs::write(
+            spec_root.join("requirements/core.yaml"),
+            "category: Core\nprefix: REQ\nrequirements:\n  - id: REQ-1\n    title: T\n    description: D\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-1\n    linked_features:\n      - FEAT-1\n    tests: {}\n",
+        )
+        .expect("write");
+        fs::create_dir_all(spec_root.join("features/extra")).expect("dir");
+        fs::write(
+            spec_root.join("features/extra/features.yaml"),
+            "category: Notes\nsummary: S\n",
+        )
+            .expect("write");
+
+        let error = load_workspace_allowing_missing_feature_registry(tempdir.path())
+            .expect_err("missing feature docs should fail");
+        assert!(error.to_string().contains("missing feature registry"));
+    }
+
+    #[test]
+    fn load_workspace_allowing_missing_feature_registry_reports_empty_feature_sets() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let spec_root = tempdir.path().join("docs/syu");
+        fs::create_dir_all(spec_root.join("philosophy")).expect("dir");
+        fs::create_dir_all(spec_root.join("policies")).expect("dir");
+        fs::create_dir_all(spec_root.join("requirements")).expect("dir");
+        fs::create_dir_all(spec_root.join("features")).expect("dir");
+
+        fs::write(tempdir.path().join("syu.yaml"), "version: 1\nspec:\n  root: docs/syu\n")
+            .expect("config");
+        fs::write(
+            spec_root.join("philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nphilosophies:\n  - id: PHIL-1\n    title: T\n    product_design_principle: A\n    coding_guideline: B\n    linked_policies:\n      - POL-1\n",
+        )
+        .expect("write");
+        fs::write(
+            spec_root.join("policies/policies.yaml"),
+            "category: Policies\nversion: 1\npolicies:\n  - id: POL-1\n    title: T\n    summary: S\n    description: D\n    linked_philosophies:\n      - PHIL-1\n    linked_requirements:\n      - REQ-1\n",
+        )
+        .expect("write");
+        fs::write(
+            spec_root.join("requirements/core.yaml"),
+            "category: Core\nprefix: REQ\nrequirements:\n  - id: REQ-1\n    title: T\n    description: D\n    priority: high\n    status: planned\n    linked_policies:\n      - POL-1\n    linked_features:\n      - FEAT-1\n    tests: {}\n",
+        )
+        .expect("write");
+        fs::write(
+            spec_root.join("features/empty.yaml"),
+            "category: Core Features\nversion: 1\nfeatures: []\n",
+        )
+        .expect("write");
+        fs::write(spec_root.join("features/notes.yaml"), "category: Notes\nsummary: S\n")
+            .expect("write");
+
+        let error = load_workspace_allowing_missing_feature_registry(tempdir.path())
+            .expect_err("empty feature sets should fail");
+        assert!(error.to_string().contains("no feature definitions"));
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -164,20 +164,43 @@ pub(crate) fn load_feature_documents_with_paths(
     feature_root: &Path,
 ) -> Result<Vec<LoadedDocument<FeatureDocument>>> {
     let registry_path = feature_root.join("features.yaml");
-    let registry = load_feature_registry(&registry_path)?;
-    if registry.files.is_empty() {
+    if registry_path.is_file() {
+        let registry = load_feature_registry(&registry_path)?;
+        if registry.files.is_empty() {
+            bail!(
+                "feature registry `{}` does not declare any feature files",
+                registry_path.display()
+            );
+        }
+
+        let mut documents = Vec::new();
+        for file in registry.files {
+            let path = resolve_feature_document_path(feature_root, &file.file)?;
+            let document = load_feature_document(&path, &file.kind)?;
+            documents.push(LoadedDocument { path, document });
+        }
+        return Ok(documents);
+    }
+
+    let mut documents = Vec::new();
+    for path in yaml_file_paths_recursive(feature_root)? {
+        if path.file_name().and_then(|name| name.to_str()) == Some("features.yaml") {
+            continue;
+        }
+        if !looks_like_feature_document(&path)? {
+            continue;
+        }
+        let document = load_feature_document(&path, "feature")?;
+        documents.push(LoadedDocument { path, document });
+    }
+
+    if documents.is_empty() {
         bail!(
-            "feature registry `{}` does not declare any feature files",
+            "missing feature registry `{}`",
             registry_path.display()
         );
     }
 
-    let mut documents = Vec::new();
-    for file in registry.files {
-        let path = resolve_feature_document_path(feature_root, &file.file)?;
-        let document = load_feature_document(&path, &file.kind)?;
-        documents.push(LoadedDocument { path, document });
-    }
     Ok(documents)
 }
 
@@ -186,6 +209,15 @@ fn load_feature_document(path: &Path, kind: &str) -> Result<FeatureDocument> {
     let raw = read_yaml_text(path, &label)?;
     serde_yaml::from_str(&raw)
         .with_context(|| format!("failed to parse {label} from `{}`", path.display()))
+}
+
+fn looks_like_feature_document(path: &Path) -> Result<bool> {
+    let raw = read_yaml_text(path, "feature candidate")?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to inspect feature candidate `{}`", path.display()))?;
+    Ok(value.as_mapping().is_some_and(|mapping| {
+        mapping.contains_key(serde_yaml::Value::String("features".to_string()))
+    }))
 }
 
 fn ensure_yaml_directory(directory: &Path, label: &str) -> Result<Vec<PathBuf>> {

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -11,6 +11,7 @@ fn write_workspace_with_ownership_mode(root: &Path, default_fix: bool, trace_own
     fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
     fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
     fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("docs/syu/features/core")).expect("core features dir");
     fs::create_dir_all(root.join("src")).expect("src dir");
 
     fs::write(
@@ -65,6 +66,8 @@ fn write_graph_workspace(root: &Path) {
     fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
     fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
     fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("docs/syu/features/core")).expect("core features dir");
+    fs::create_dir_all(root.join("docs/syu/features/extra")).expect("extra features dir");
 
     fs::write(
         root.join("syu.yaml"),
@@ -109,10 +112,16 @@ fn write_graph_workspace(root: &Path) {
     .expect("core feature");
 
     fs::write(
-        root.join("docs/syu/features/extra.yaml"),
+        root.join("docs/syu/features/extra/extra.yaml"),
         "category: Extra Features\nversion: 1\n\nfeatures:\n  - id: FEAT-EXTRA-001\n    title: Extra feature\n    summary: Keep the extra feature available.\n    status: planned\n    linked_requirements:\n      - REQ-001\n      - REQ-001\n    implementations: {}\n",
     )
     .expect("extra feature");
+
+    fs::write(
+        root.join("docs/syu/features/notes.yaml"),
+        "category: Notes\nversion: 1\nnotes:\n  - this file should be ignored by the registry sync\n",
+    )
+    .expect("notes");
 }
 
 #[test]
@@ -263,12 +272,13 @@ fn validate_fix_repairs_graph_links_and_feature_registry_drift() {
         .expect("core feature");
     assert!(core_feature.contains("REQ-001"));
 
-    let extra_feature = fs::read_to_string(tempdir.path().join("docs/syu/features/extra.yaml"))
-        .expect("extra feature");
+    let extra_feature =
+        fs::read_to_string(tempdir.path().join("docs/syu/features/extra/extra.yaml"))
+            .expect("extra feature");
     assert_eq!(extra_feature.matches("REQ-001").count(), 1);
 
     let registry = fs::read_to_string(tempdir.path().join("docs/syu/features/features.yaml"))
         .expect("registry");
     assert!(registry.contains("file: core.yaml"));
-    assert!(registry.contains("file: extra.yaml"));
+    assert!(registry.contains("file: extra/extra.yaml"));
 }

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -60,6 +60,61 @@ fn write_workspace_with_ownership_mode(root: &Path, default_fix: bool, trace_own
     fs::write(root.join("src/trace.rs"), "pub fn req_trace() {}\n").expect("rust trace");
 }
 
+fn write_graph_workspace(root: &Path) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_reciprocal_links: true\n  trace_ownership_mode: mapping\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Executable agreement\n    product_design_principle: Keep change traceable.\n    coding_guideline: Prefer explicit links.\n    linked_policies:\n      - POL-001\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Keep symbols documented\n    summary: Requirements and features should remain explainable.\n    description: Every trace should point to a documented symbol.\n    linked_philosophies: []\n    linked_requirements:\n      - REQ-001\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Validate documented features\n    description: Requirements should point at the shipped feature evidence.\n    priority: high\n    status: planned\n    linked_policies: []\n    linked_features:\n      - FEAT-CORE-001\n      - FEAT-EXTRA-001\n      - FEAT-EXTRA-001\n    tests: {}\n",
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-CORE-001\n    title: Core feature\n    summary: Keep the core feature available.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n",
+    )
+    .expect("core feature");
+
+    fs::write(
+        root.join("docs/syu/features/extra.yaml"),
+        "category: Extra Features\nversion: 1\n\nfeatures:\n  - id: FEAT-EXTRA-001\n    title: Extra feature\n    summary: Keep the extra feature available.\n    status: planned\n    linked_requirements:\n      - REQ-001\n      - REQ-001\n    implementations: {}\n",
+    )
+    .expect("extra feature");
+}
+
 #[test]
 // REQ-CORE-003
 fn validate_fix_repairs_missing_trace_docs_for_rust_sources() {
@@ -165,4 +220,55 @@ fn validate_fix_writes_sidecar_ownership_manifests_when_configured() {
     assert!(manifest.contains("id: FEAT-001"));
     assert!(manifest.contains("id: REQ-001"));
     assert!(manifest.contains("- req_trace"));
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_repairs_graph_links_and_feature_registry_drift() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_graph_workspace(tempdir.path());
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("syu validate passed"));
+
+    let philosophy = fs::read_to_string(tempdir.path().join("docs/syu/philosophy/foundation.yaml"))
+        .expect("philosophy");
+    assert_eq!(philosophy.matches("POL-001").count(), 1);
+
+    let policy =
+        fs::read_to_string(tempdir.path().join("docs/syu/policies/policies.yaml")).expect("policy");
+    assert_eq!(policy.matches("REQ-001").count(), 1);
+    assert!(policy.contains("PHIL-001"));
+
+    let requirement = fs::read_to_string(tempdir.path().join("docs/syu/requirements/core.yaml"))
+        .expect("requirement");
+    assert_eq!(requirement.matches("FEAT-EXTRA-001").count(), 1);
+    assert_eq!(requirement.matches("FEAT-CORE-001").count(), 1);
+    assert!(requirement.contains("POL-001"));
+
+    let core_feature = fs::read_to_string(tempdir.path().join("docs/syu/features/core.yaml"))
+        .expect("core feature");
+    assert!(core_feature.contains("REQ-001"));
+
+    let extra_feature = fs::read_to_string(tempdir.path().join("docs/syu/features/extra.yaml"))
+        .expect("extra feature");
+    assert_eq!(extra_feature.matches("REQ-001").count(), 1);
+
+    let registry = fs::read_to_string(tempdir.path().join("docs/syu/features/features.yaml"))
+        .expect("registry");
+    assert!(registry.contains("file: core.yaml"));
+    assert!(registry.contains("file: extra.yaml"));
 }


### PR DESCRIPTION
## Summary
- dedupe graph links and restore missing reciprocals during syu validate --fix
- resync the feature registry from discovered feature documents
- add regression coverage for reciprocal repair and registry-kind fallback

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Linked issue or specification
FEAT-CHECK-001