### PR TITLE
[Feature]: Bring Kotlin trace support up to doc_contains and autofix parity

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -158,8 +158,9 @@ If you want a gradual C# rollout, borrow the lighter starter shape from the
 That example keeps the higher-layer spec and surrounding automation explicit
 without requiring every checked-in C# file to be traced immediately. Use
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
-or `syu init . --template go-only` as a reminder that Go now supports
-symbol checks, coverage ownership, and `doc_contains`.
+or `syu init . --template go-only` as a reminder that Go now supports symbol
+checks, coverage ownership, and `doc_contains`, and that Java, C#, and Kotlin do
+too.
 
 ### `validate.trace_ownership_mode`
 

--- a/docs/guide/doc-contains.md
+++ b/docs/guide/doc-contains.md
@@ -41,14 +41,17 @@ the few symbols where comment-level evidence genuinely helps.
 - **Rust**
 - **Python**
 - **Go**
+- **Java**
+- **C#**
+- **Kotlin**
 - **TypeScript / JavaScript**
 
 For the full matrix, including strict ownership coverage and symbol-only
 adapters, use the [trace adapter capability matrix](./trace-adapter-support.md).
 
-Languages such as Java, C#, Ruby, Shell, YAML, JSON, Markdown, and Gitignore
-can still use explicit `file` + `symbols` traces, but they do not validate
-`doc_contains` yet.
+Languages such as Ruby, Shell, YAML, JSON, Markdown, and Gitignore can still use
+explicit `file` + `symbols` traces, but they do not validate `doc_contains`
+yet.
 
 ## Starter-level examples to copy from
 
@@ -59,6 +62,7 @@ scratch:
 | --- | --- |
 | [`examples/python-only`](https://github.com/ugoite/syu/tree/main/examples/python-only) | Smallest newcomer-friendly `doc_contains` story with Python docstrings in both tests and implementation. |
 | [`examples/rust-only`](https://github.com/ugoite/syu/tree/main/examples/rust-only) | Minimal Rust `///` comment example when your repository is Rust-first. |
+| [`examples/java-only`](https://github.com/ugoite/syu/tree/main/examples/java-only) | JVM-first `doc_contains` example with Javadoc around both the Java test and implementation symbols. |
 | [`examples/browser-ui`](https://github.com/ugoite/syu/tree/main/examples/browser-ui) | Frontend-oriented TypeScript example showing `doc_contains` in a UI component flow. |
 
 If you want the gentlest first adoption path, start with

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -34,8 +34,8 @@ Need a different level of guidance?
 - Open the [LSP guide](./lsp.md) when you are wiring `syu` into another editor
   client or want the low-level stdio / JSON-RPC server contract directly.
 - Use the [trace adapter capability matrix](./trace-adapter-support.md) when
-  you need to know which built-in languages support symbol validation only
-  versus `doc_contains` and strict coverage.
+  you need to know which built-in languages support `doc_contains` and strict
+  coverage.
 - Follow the [dedicated `doc_contains` adoption guide](./doc-contains.md) when
   you want a newcomer-friendly path for adding comment-level evidence one symbol
   at a time.
@@ -248,7 +248,7 @@ until you are ready to declare real tests and implementation traces.
 unsupported implementation languages can still adopt `syu` today, but they
 should treat code-level mappings for those files as future work.
 
-Go, Java, C#, and Kotlin already participate in strict `validate.require_symbol_trace_coverage` inventory. Go now supports `doc_contains` checks as well, while Java, C#, and Kotlin still stop at symbol validation. The [trace adapter capability matrix](./trace-adapter-support.md)
+Go, Java, C#, and Kotlin already participate in strict `validate.require_symbol_trace_coverage` inventory. Go, Java, C#, and Kotlin now support `doc_contains` checks as well. The [trace adapter capability matrix](./trace-adapter-support.md)
 summarizes that language-by-language support.
 
 Today you can still:

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -22,9 +22,9 @@ enable strict coverage in a mixed-language repository.
 | Python | `python`, `py`, `pytest`, `unittest` / `.py` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
 | Ruby | `ruby`, `rb`, `minitest`, `rspec` / `.rb` | ✅ Pattern-based symbol matching | ❌ | ❌ |
 | Go | `go`, `golang`, `gotest` / `.go` | ✅ Rich doc-comment inspection plus pattern fallback | ✅ | ✅ |
-| Java | `java`, `junit` / `.java` | ✅ Pattern-based symbol matching | ❌ | ✅ |
-| C# | `csharp`, `cs`, `dotnet`, `xunit`, `nunit`, `mstest` / `.cs` | ✅ Pattern-based symbol matching | ❌ | ✅ |
-| Kotlin | `kotlin`, `kt` / `.kt` | ✅ Pattern-based symbol matching | ❌ | ✅ |
+| Java | `java`, `junit` / `.java` | ✅ Pattern-based symbol matching plus declaration-adjacent Javadoc inspection | ✅ | ✅ |
+| C# | `csharp`, `cs`, `dotnet`, `xunit`, `nunit`, `mstest` / `.cs` | ✅ Pattern-based symbol matching plus declaration-adjacent XML doc inspection | ✅ | ✅ |
+| Kotlin | `kotlin`, `kt` / `.kt` | ✅ Pattern-based symbol matching plus declaration-adjacent KDoc inspection | ✅ | ✅ |
 | TypeScript / JavaScript | `typescript`, `ts`, `tsx`, `javascript`, `js`, `jsx`, `vitest`, `bun`, `bun-test` / `.ts`, `.tsx`, `.js`, `.jsx` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
 | Shell | `shell`, `sh`, `bash`, `zsh` / `.sh`, `.bash`, `.zsh` | ✅ Pattern-based symbol matching | ❌ | ❌ |
 | YAML | `yaml`, `yml` / `.yaml`, `.yml` | ✅ Pattern-based symbol matching | ❌ | ❌ |
@@ -58,7 +58,8 @@ they do **not** participate in the repository-wide strict ownership scan.
 
 ## How to choose the right promises
 
-- Need `doc_contains`? Rust, Python, Go, and TypeScript / JavaScript traces all
+- Need `doc_contains`? Rust, Python, Go, Java, C#, Kotlin, and TypeScript /
+  JavaScript traces all
   support it today. For a staged rollout, starter examples, and "when should I
   add this?" guidance, use the [dedicated `doc_contains` adoption guide](./doc-contains.md).
 - Need strict ownership coverage? Rust, Python, Go, Java, C#, Kotlin, and
@@ -97,7 +98,9 @@ When you need a concrete fallback shape, start from the closest checked-in
 example instead of inventing a migration path from scratch. For Kotlin/JVM
 repositories, start from `examples/java-only` when you want a JVM-shaped
 repository layout, then trace Kotlin source directly with the `kotlin` / `.kt`
-adapter alongside the philosophy, policy, requirement, and feature layers.
+adapter alongside the philosophy, policy, requirement, and feature layers. You
+can now also add `doc_contains` to those Kotlin traces when the KDoc stays next
+to the symbol.
 If you need a Go-first starting point today, study the
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 or scaffold `syu init . --template go-only`. Both keep real Go files in the
@@ -106,8 +109,8 @@ repository while validating explicit symbol mappings, and Go traces can now add
 If you need a Java-first starting point today, study the
 [`examples/java-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/java-only)
 or scaffold `syu init . --template java-only`. Both keep real Java files in the
-repository while validating explicit symbol mappings, but Java traces should
-still stay with `file` plus `symbols` because `doc_contains` is not supported yet.
+repository while validating explicit symbol mappings, and Java traces can now
+add `doc_contains` when the Javadoc stays adjacent to the symbol.
 If you need a Ruby-first starting point today, study the
 [`examples/ruby-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/ruby-only)
 or scaffold `syu init . --template ruby-only`. Both keep real Ruby files in the
@@ -117,7 +120,8 @@ If you want a concrete staged C# adoption shape today, study the
 [`examples/csharp-fallback` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/csharp-fallback).
 It keeps real C# files in the repository while validating supported shell and
 markdown evidence around them before you decide how aggressively to trace the
-rest of the C# codebase.
+rest of the C# codebase. C# traces can now also add `doc_contains` when the XML
+docs stay adjacent to the symbol.
 
 When the unsupported language matters enough that the staged fallback is no
 longer sufficient, open a feature request with:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -273,7 +273,8 @@ remove the `doc_contains:` assertion from the trace if it no longer applies.
 ### `SYU-trace-docsupport-001` — language not supported for doc inspection
 
 **What it means:** `doc_contains:` is only supported for `rust`, `python`,
-`go`, and `typescript`. You declared it on a `lang:` that `syu` cannot inspect.
+`go`, `java`, `csharp`, `kotlin`, and `typescript`. You declared it on a
+`lang:` that `syu` cannot inspect.
 
 **Fix:** Remove the `doc_contains:` assertion from that mapping, or switch to a
 supported language for rich doc inspection.
@@ -297,7 +298,7 @@ implementations:
 ```
 
 Use that lighter mapping until the language gains richer inspection support.
-If the mapping uses an unsupported implementation language such as `kotlin`,
+If the mapping uses an unsupported implementation language such as `ruby`,
 removing `doc_contains` is not enough: those entries still raise
 `SYU-trace-language-001`. Keep the higher-layer spec link in place and wait for
 adapter support before adding the code-level trace.

--- a/examples/java-only/README.md
+++ b/examples/java-only/README.md
@@ -6,7 +6,8 @@ Java trace adapter.
 It contains one philosophy, one policy, one requirement, and one feature, plus
 one `pom.xml`, one Java source file, and one Java test file. The example uses
 pattern-based symbol matching for the real `.java` files, so `syu validate .`
-proves the Java-backed links directly.
+proves the Java-backed links directly, and the checked-in Javadocs now also
+show how `doc_contains` can stay attached to Java traces.
 
 This workspace now matches the built-in `syu init --template java-only`
 starter, so you can either inspect the checked-in example first or generate the
@@ -51,8 +52,8 @@ traceability: requirements=1/1 traces validated; features=1/1 traces validated
   symbol for `REQ-JAVA-001`.
 - `JavaFeatureImpl` lives in `src/main/java/example/app/OrderSummary.java` and
   is the validated implementation symbol for `FEAT-JAVA-001`.
-- The Java adapter currently supports pattern-based symbol validation and
-  strict ownership coverage, but not `doc_contains` checks.
+- The Java adapter supports pattern-based symbol validation, `doc_contains`
+  checks, and strict ownership coverage.
 
 ## Key things to notice
 
@@ -60,5 +61,6 @@ traceability: requirements=1/1 traces validated; features=1/1 traces validated
   real `.java` files instead of a markdown workaround.
 - **The example stays small** — one source file and one test file are enough to
   demonstrate Java-backed requirement and feature ownership.
-- **`doc_contains` is still out of scope** — keep Java traces to `file` plus
-  `symbols` today, then add richer evidence only after adapter support grows.
+- **`doc_contains` keeps the trace readable** — the Javadocs in the example show
+  how to attach comment-level evidence to a Java symbol without changing the
+  ownership shape.

--- a/examples/java-only/docs/syu/features/languages/java.yaml
+++ b/examples/java-only/docs/syu/features/languages/java.yaml
@@ -13,3 +13,5 @@ features:
         - file: src/main/java/example/app/OrderSummary.java
           symbols:
             - JavaFeatureImpl
+          doc_contains:
+            - JavaFeatureImpl implements FEAT-JAVA-001 in the example workspace

--- a/examples/java-only/docs/syu/requirements/core/java.yaml
+++ b/examples/java-only/docs/syu/requirements/core/java.yaml
@@ -16,3 +16,5 @@ requirements:
         - file: src/test/java/example/app/OrderSummaryTest.java
           symbols:
             - JavaRequirementTest
+          doc_contains:
+            - JavaRequirementTest keeps the Java requirement trace readable

--- a/examples/java-only/src/main/java/example/app/OrderSummary.java
+++ b/examples/java-only/src/main/java/example/app/OrderSummary.java
@@ -1,7 +1,7 @@
 package example.app;
 
-/** JavaFeatureImpl implements FEAT-JAVA-001 in the example workspace. */
 public final class OrderSummary {
+    /** JavaFeatureImpl implements FEAT-JAVA-001 in the example workspace. */
     public String JavaFeatureImpl() {
         return "java-only example";
     }

--- a/examples/java-only/src/test/java/example/app/OrderSummaryTest.java
+++ b/examples/java-only/src/test/java/example/app/OrderSummaryTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
 
 class OrderSummaryTest {
+    /** JavaRequirementTest keeps the Java requirement trace readable. */
     @Test
     void JavaRequirementTest() {
         assertFalse(new OrderSummary().JavaFeatureImpl().isEmpty());

--- a/src/command/doctor.rs
+++ b/src/command/doctor.rs
@@ -1268,6 +1268,7 @@ mod tests {
             let mut permissions = fs::metadata(&path).expect("metadata").permissions();
             permissions.set_mode(0o755);
             fs::set_permissions(&path, permissions).expect("permissions");
+            std::thread::sleep(Duration::from_millis(10));
         }
         #[cfg(windows)]
         {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -78,6 +78,12 @@ pub struct SymbolInspection {
     pub line: usize,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum DocCommentStyle {
+    Block { start_marker: &'static str },
+    Line { prefix: &'static str },
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct PythonSymbolInspection {
     pub(crate) name: String,
@@ -123,7 +129,7 @@ struct PythonSymbolRecord {
 pub fn supports_rich_inspection(language: &str) -> bool {
     matches!(
         adapter_for_language(language).map(LanguageAdapter::canonical_name),
-        Some("rust" | "python" | "typescript" | "go")
+        Some("rust" | "python" | "typescript" | "go" | "java" | "csharp" | "kotlin")
     )
 }
 
@@ -162,6 +168,28 @@ pub fn inspect_symbol(
                 line: item.line,
             }),
         ),
+        Some("java") => Ok(inspect_language_symbol(
+            adapter_for_language(language).expect("java adapter should exist"),
+            contents,
+            symbol,
+            DocCommentStyle::Block {
+                start_marker: "/**",
+            },
+        )),
+        Some("csharp") => Ok(inspect_language_symbol(
+            adapter_for_language(language).expect("csharp adapter should exist"),
+            contents,
+            symbol,
+            DocCommentStyle::Line { prefix: "///" },
+        )),
+        Some("kotlin") => Ok(inspect_language_symbol(
+            adapter_for_language(language).expect("kotlin adapter should exist"),
+            contents,
+            symbol,
+            DocCommentStyle::Block {
+                start_marker: "/**",
+            },
+        )),
         _ => Ok(None),
     }
 }
@@ -185,7 +213,266 @@ pub fn apply_symbol_doc_fix(
         Some("python") => fix_python_symbol_docs(config, path, contents, symbol, &required),
         Some("typescript") => fix_typescript_symbol_docs(path, contents, symbol, &required),
         Some("go") => fix_go_symbol_docs(contents, symbol, &required),
+        Some("java") => fix_language_symbol_docs(
+            adapter_for_language(language).expect("java adapter should exist"),
+            contents,
+            symbol,
+            &required,
+            DocCommentStyle::Block {
+                start_marker: "/**",
+            },
+        ),
+        Some("csharp") => fix_language_symbol_docs(
+            adapter_for_language(language).expect("csharp adapter should exist"),
+            contents,
+            symbol,
+            &required,
+            DocCommentStyle::Line { prefix: "///" },
+        ),
+        Some("kotlin") => fix_language_symbol_docs(
+            adapter_for_language(language).expect("kotlin adapter should exist"),
+            contents,
+            symbol,
+            &required,
+            DocCommentStyle::Block {
+                start_marker: "/**",
+            },
+        ),
         _ => Ok(None),
+    }
+}
+
+fn inspect_language_symbol(
+    adapter: &dyn LanguageAdapter,
+    contents: &str,
+    symbol: &str,
+    style: DocCommentStyle,
+) -> Option<SymbolInspection> {
+    find_declaration_line(adapter, contents, symbol).map(|line| SymbolInspection {
+        docs: collect_doc_comments(contents, line, style),
+        line,
+    })
+}
+
+fn fix_language_symbol_docs(
+    adapter: &dyn LanguageAdapter,
+    contents: &str,
+    symbol: &str,
+    required: &[String],
+    style: DocCommentStyle,
+) -> Result<Option<String>> {
+    let Some(existing_line) = find_declaration_line(adapter, contents, symbol) else {
+        return Ok(None);
+    };
+    let existing_docs = collect_doc_comments(contents, existing_line, style);
+    let missing = missing_doc_snippets(&existing_docs, required);
+    if missing.is_empty() {
+        return Ok(None);
+    }
+
+    let mut lines = to_lines(contents);
+    let indent = line_indentation(&lines[existing_line - 1]);
+    let line_refs = lines.iter().map(String::as_str).collect::<Vec<_>>();
+    if let Some(block) = find_doc_block(&line_refs, existing_line, style) {
+        let inserts = render_missing_doc_lines(&indent, &missing, style);
+        lines.splice(block.end_line - 1..block.end_line - 1, inserts);
+    } else {
+        let inserts = render_new_doc_block(&indent, &missing, style);
+        let insertion_line = find_doc_insertion_line(&lines, existing_line);
+        lines.splice(insertion_line - 1..insertion_line - 1, inserts);
+    }
+
+    Ok(Some(join_lines(lines, contents.ends_with('\n'))))
+}
+
+fn find_declaration_line(
+    adapter: &dyn LanguageAdapter,
+    contents: &str,
+    symbol: &str,
+) -> Option<usize> {
+    let patterns = declaration_patterns(adapter, symbol);
+    find_line_by_patterns(contents, &patterns)
+}
+
+fn declaration_patterns(adapter: &dyn LanguageAdapter, symbol: &str) -> Vec<String> {
+    let mut patterns = adapter.patterns(symbol);
+    if patterns.len() > 1 {
+        patterns.pop();
+    }
+    patterns
+}
+
+fn collect_doc_comments(contents: &str, declaration_line: usize, style: DocCommentStyle) -> String {
+    let lines = contents.lines().collect::<Vec<_>>();
+    find_doc_block(&lines, declaration_line, style)
+        .map(|block| block.text)
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone)]
+struct DocBlock {
+    end_line: usize,
+    text: String,
+}
+
+fn find_doc_block(
+    lines: &[&str],
+    declaration_line: usize,
+    style: DocCommentStyle,
+) -> Option<DocBlock> {
+    match style {
+        DocCommentStyle::Block { start_marker } => {
+            find_block_doc_block(lines, declaration_line, start_marker)
+        }
+        DocCommentStyle::Line { prefix } => find_line_doc_block(lines, declaration_line, prefix),
+    }
+}
+
+fn find_block_doc_block(
+    lines: &[&str],
+    declaration_line: usize,
+    start_marker: &str,
+) -> Option<DocBlock> {
+    if declaration_line <= 1 {
+        return None;
+    }
+
+    let end = skip_declaration_annotations(lines, declaration_line - 2)?;
+    if end >= lines.len() {
+        return None;
+    }
+
+    if lines[end].trim().is_empty() || !lines[end].trim_end().ends_with("*/") {
+        return None;
+    }
+
+    let mut start = end;
+    while start > 0 && !lines[start].trim_start().starts_with(start_marker) {
+        start -= 1;
+    }
+
+    if !lines[start].trim_start().starts_with(start_marker) {
+        return None;
+    }
+
+    let text = lines[start..=end]
+        .iter()
+        .map(|line| {
+            line.trim()
+                .trim_start_matches(start_marker)
+                .trim_end_matches("*/")
+                .trim_start_matches('*')
+                .trim()
+                .to_string()
+        })
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(DocBlock {
+        end_line: end + 1,
+        text,
+    })
+}
+
+fn find_line_doc_block(lines: &[&str], declaration_line: usize, prefix: &str) -> Option<DocBlock> {
+    if declaration_line <= 1 {
+        return None;
+    }
+
+    let end = skip_declaration_annotations(lines, declaration_line - 2)?;
+    if end >= lines.len() || lines[end].trim().is_empty() {
+        return None;
+    }
+
+    if !lines[end].trim_start().starts_with(prefix) {
+        return None;
+    }
+
+    let mut start = end;
+    while start > 0 && lines[start - 1].trim_start().starts_with(prefix) {
+        start -= 1;
+    }
+
+    let text = lines[start..=end]
+        .iter()
+        .map(|line| {
+            line.trim_start()
+                .trim_start_matches(prefix)
+                .trim()
+                .to_string()
+        })
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(DocBlock {
+        end_line: end + 1,
+        text,
+    })
+}
+
+fn find_doc_insertion_line(lines: &[String], declaration_line: usize) -> usize {
+    if declaration_line <= 1 {
+        return 1;
+    }
+
+    let mut insertion_line = declaration_line;
+    while insertion_line > 1 && is_annotation_or_attribute_line(&lines[insertion_line - 2]) {
+        insertion_line -= 1;
+    }
+
+    insertion_line
+}
+
+fn skip_declaration_annotations(lines: &[&str], mut index: usize) -> Option<usize> {
+    if index >= lines.len() {
+        return None;
+    }
+
+    while is_annotation_or_attribute_line(lines[index]) {
+        if index == 0 {
+            return None;
+        }
+        index -= 1;
+    }
+
+    Some(index)
+}
+
+fn is_annotation_or_attribute_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('@')
+        || trimmed.starts_with("#[")
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+}
+
+fn render_missing_doc_lines(
+    indent: &str,
+    missing: &[String],
+    style: DocCommentStyle,
+) -> Vec<String> {
+    match style {
+        DocCommentStyle::Block { .. } => missing
+            .iter()
+            .map(|snippet| format!("{indent} * {snippet}"))
+            .collect(),
+        DocCommentStyle::Line { prefix } => missing
+            .iter()
+            .map(|snippet| format!("{indent}{prefix} {snippet}"))
+            .collect(),
+    }
+}
+
+fn render_new_doc_block(indent: &str, missing: &[String], style: DocCommentStyle) -> Vec<String> {
+    match style {
+        DocCommentStyle::Block { .. } => {
+            let mut block = vec![format!("{indent}/**")];
+            block.extend(render_missing_doc_lines(indent, missing, style));
+            block.push(format!("{indent} */"));
+            block
+        }
+        DocCommentStyle::Line { .. } => render_missing_doc_lines(indent, missing, style),
     }
 }
 
@@ -750,6 +1037,9 @@ mod tests {
         assert!(supports_rich_inspection("python"));
         assert!(supports_rich_inspection("typescript"));
         assert!(supports_rich_inspection("go"));
+        assert!(supports_rich_inspection("java"));
+        assert!(supports_rich_inspection("csharp"));
+        assert!(supports_rich_inspection("kotlin"));
         assert!(!supports_rich_inspection("shell"));
     }
 
@@ -1123,6 +1413,57 @@ mod external;
     }
 
     #[test]
+    fn java_inspection_reads_javadocs() {
+        let source = "/**\n * REQ-1\n * stable docs\n */\npublic class Sample {}\n";
+        let inspected = inspect_symbol(
+            "java",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.java"),
+            source,
+            "Sample",
+        )
+        .expect("inspection should succeed")
+        .expect("symbol should exist");
+        assert!(inspected.docs.contains("REQ-1"));
+        assert!(inspected.docs.contains("stable docs"));
+        assert_eq!(inspected.line, 5);
+    }
+
+    #[test]
+    fn csharp_inspection_reads_xml_docs() {
+        let source = "/// REQ-1\n/// stable docs\npublic class Sample {}\n";
+        let inspected = inspect_symbol(
+            "csharp",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.cs"),
+            source,
+            "Sample",
+        )
+        .expect("inspection should succeed")
+        .expect("symbol should exist");
+        assert!(inspected.docs.contains("REQ-1"));
+        assert!(inspected.docs.contains("stable docs"));
+        assert_eq!(inspected.line, 3);
+    }
+
+    #[test]
+    fn kotlin_inspection_reads_kdoc() {
+        let source = "/**\n * REQ-1\n * stable docs\n */\nfun sample(): Int = 1\n";
+        let inspected = inspect_symbol(
+            "kotlin",
+            &SyuConfig::default(),
+            std::path::Path::new("src/sample.kt"),
+            source,
+            "sample",
+        )
+        .expect("inspection should succeed")
+        .expect("symbol should exist");
+        assert!(inspected.docs.contains("REQ-1"));
+        assert!(inspected.docs.contains("stable docs"));
+        assert_eq!(inspected.line, 5);
+    }
+
+    #[test]
     fn go_inspection_reads_line_and_block_comments() {
         let line_comment_source =
             "// REQ-1\n// stable docs\nfunc sample() string {\n\treturn \"ok\"\n}\n";
@@ -1271,6 +1612,62 @@ mod external;
             .expect("fix should succeed"),
             None
         );
+    }
+
+    #[test]
+    fn java_fix_inserts_missing_javadoc_lines() {
+        let source = "public class Sample {}\n";
+        let updated = apply_symbol_doc_fix(
+            "java",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.java"),
+            source,
+            "Sample",
+            &["REQ-1".to_string(), "Explain sample".to_string()],
+        )
+        .expect("fix should succeed")
+        .expect("fix should update source");
+
+        assert!(updated.contains("/**"));
+        assert!(updated.contains(" * REQ-1"));
+        assert!(updated.contains(" * Explain sample"));
+    }
+
+    #[test]
+    fn csharp_fix_inserts_missing_xml_doc_lines() {
+        let source = "public class Sample {}\n";
+        let updated = apply_symbol_doc_fix(
+            "csharp",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.cs"),
+            source,
+            "Sample",
+            &["REQ-1".to_string(), "Explain sample".to_string()],
+        )
+        .expect("fix should succeed")
+        .expect("fix should update source");
+
+        assert!(updated.contains("/// REQ-1"));
+        assert!(updated.contains("/// Explain sample"));
+    }
+
+    #[test]
+    fn kotlin_fix_inserts_missing_kdoc_lines() {
+        let source = "fun sample(): Int = 1\n";
+        let updated = apply_symbol_doc_fix(
+            "kotlin",
+            &SyuConfig::default(),
+            std::path::Path::new("src/sample.kt"),
+            source,
+            "sample",
+            &["REQ-1".to_string(), "Explain sample".to_string()],
+        )
+        .expect("fix should succeed")
+        .expect("fix should update source");
+
+        assert!(updated.contains("/**"));
+        assert!(updated.contains(" * REQ-1"));
+        assert!(updated.contains(" * Explain sample"));
     }
 
     #[test]

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1692,22 +1692,19 @@ mod external;
         assert_eq!(already_documented, None);
 
         let block_lines = [" */"];
-        assert!(find_doc_block(
-            &block_lines,
-            2,
-            DocCommentStyle::Block {
-                start_marker: "/**"
-            }
-        )
-        .is_none());
+        assert!(
+            find_doc_block(
+                &block_lines,
+                2,
+                DocCommentStyle::Block {
+                    start_marker: "/**"
+                }
+            )
+            .is_none()
+        );
 
         let line_lines = ["", "public class Sample {}"];
-        assert!(find_doc_block(
-            &line_lines,
-            2,
-            DocCommentStyle::Line { prefix: "///" }
-        )
-        .is_none());
+        assert!(find_doc_block(&line_lines, 2, DocCommentStyle::Line { prefix: "///" }).is_none());
 
         let annotation_lines = vec!["@Test".to_string(), "public void sample() {}".to_string()];
         assert_eq!(find_doc_insertion_line(&annotation_lines, 2), 1);

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -338,10 +338,6 @@ fn find_block_doc_block(
     }
 
     let end = skip_declaration_annotations(lines, declaration_line - 2)?;
-    if end >= lines.len() {
-        return None;
-    }
-
     if lines[end].trim().is_empty() || !lines[end].trim_end().ends_with("*/") {
         return None;
     }
@@ -1026,9 +1022,10 @@ mod tests {
     use crate::config::SyuConfig;
 
     use super::{
-        apply_symbol_doc_fix, find_jsdoc_block, find_rust_declaration_line,
-        inspect_python_file_with_runtime, inspect_rust_symbol, inspect_symbol, merged_doc_lines,
-        render_python_docstring, supports_rich_inspection,
+        DocCommentStyle, apply_symbol_doc_fix, find_doc_block, find_doc_insertion_line,
+        find_jsdoc_block, find_rust_declaration_line, inspect_python_file_with_runtime,
+        inspect_rust_symbol, inspect_symbol, merged_doc_lines, render_python_docstring,
+        skip_declaration_annotations, supports_rich_inspection,
     };
 
     #[test]
@@ -1668,6 +1665,54 @@ mod external;
         assert!(updated.contains("/**"));
         assert!(updated.contains(" * REQ-1"));
         assert!(updated.contains(" * Explain sample"));
+    }
+
+    #[test]
+    fn helper_functions_cover_annotation_and_noop_paths() {
+        let missing_symbol = apply_symbol_doc_fix(
+            "java",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.java"),
+            "public class Sample {}\n",
+            "Missing",
+            &["REQ-1".to_string()],
+        )
+        .expect("fix should succeed");
+        assert_eq!(missing_symbol, None);
+
+        let already_documented = apply_symbol_doc_fix(
+            "java",
+            &SyuConfig::default(),
+            std::path::Path::new("src/Sample.java"),
+            "/**\n * REQ-1\n */\npublic class Sample {}\n",
+            "Sample",
+            &["REQ-1".to_string()],
+        )
+        .expect("fix should succeed");
+        assert_eq!(already_documented, None);
+
+        let block_lines = [" */"];
+        assert!(find_doc_block(
+            &block_lines,
+            2,
+            DocCommentStyle::Block {
+                start_marker: "/**"
+            }
+        )
+        .is_none());
+
+        let line_lines = ["", "public class Sample {}"];
+        assert!(find_doc_block(
+            &line_lines,
+            2,
+            DocCommentStyle::Line { prefix: "///" }
+        )
+        .is_none());
+
+        let annotation_lines = vec!["@Test".to_string(), "public void sample() {}".to_string()];
+        assert_eq!(find_doc_insertion_line(&annotation_lines, 2), 1);
+        assert_eq!(skip_declaration_annotations(&["@Test"], 0), None);
+        assert_eq!(skip_declaration_annotations(&[], 0), None);
     }
 
     #[test]

--- a/tests/validate_fix_command.rs
+++ b/tests/validate_fix_command.rs
@@ -62,6 +62,67 @@ fn write_workspace_with_ownership_mode(root: &Path, default_fix: bool, trace_own
     fs::write(root.join("src/trace.rs"), "pub fn req_trace() {}\n").expect("rust trace");
 }
 
+fn write_doc_contains_workspace(
+    root: &Path,
+    language_key: &str,
+    source_file: &str,
+    source_contents: &str,
+) {
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
+    fs::create_dir_all(root.join("docs/syu/requirements")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+
+    fs::write(
+        root.join("syu.yaml"),
+        format!(
+            "version: {version}\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  trace_ownership_mode: mapping\nruntimes:\n  python:\n    command: auto\n  node:\n    command: auto\n",
+            version = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("config");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\n\nphilosophies:\n  - id: PHIL-001\n    title: Keep the graph explicit\n    product_design_principle: Every layer should be connected.\n    coding_guideline: Prefer explicit ownership.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy");
+
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\n\npolicies:\n  - id: POL-001\n    title: Coverage can be enforced when needed\n    summary: Public symbols and tests may require ownership.\n    description: This fixture turns the strict coverage rule on.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-001\n",
+    )
+    .expect("policy");
+
+    fs::write(
+        root.join("docs/syu/requirements/core.yaml"),
+        format!(
+            "category: Core Requirements\nprefix: REQ\n\nrequirements:\n  - id: REQ-001\n    title: Validate a documented {language_key} trace\n    description: A {language_key} trace should expose the requirement in documentation.\n    priority: high\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n    tests:\n      {language_key}:\n        - file: {source_file}\n          symbols:\n            - trace_symbol\n          doc_contains:\n            - requirement doc line\n",
+        ),
+    )
+    .expect("requirement");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        format!(
+            "version: \"{}\"\nfiles:\n  - kind: core\n    file: core.yaml\n",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .expect("feature registry");
+
+    fs::write(
+        root.join("docs/syu/features/core.yaml"),
+        format!(
+            "category: Core Features\nversion: 1\n\nfeatures:\n  - id: FEAT-001\n    title: {language_key} trace implementation\n    summary: Keep the implementation symbol documented.\n    status: implemented\n    linked_requirements:\n      - REQ-001\n    implementations:\n      {language_key}:\n        - file: {source_file}\n          symbols:\n            - trace_symbol\n          doc_contains:\n            - feature doc line\n",
+        ),
+    )
+    .expect("feature");
+
+    fs::write(root.join(source_file), source_contents).expect("source");
+}
+
 fn write_graph_workspace(root: &Path) {
     fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
     fs::create_dir_all(root.join("docs/syu/policies")).expect("policies dir");
@@ -155,6 +216,101 @@ fn validate_fix_repairs_missing_trace_docs_for_rust_sources() {
     assert!(source.contains("/// feature doc line"));
     assert!(!source.contains("REQ-001"));
     assert!(!source.contains("FEAT-001"));
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_repairs_missing_trace_docs_for_java_sources() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_doc_contains_workspace(
+        tempdir.path(),
+        "java",
+        "src/Sample.java",
+        "public class Sample {\n    public void trace_symbol() {}\n}\n",
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let source = fs::read_to_string(tempdir.path().join("src/Sample.java")).expect("source");
+    assert!(source.contains("/**"));
+    assert!(source.contains("requirement doc line"));
+    assert!(source.contains("feature doc line"));
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_repairs_missing_trace_docs_for_csharp_sources() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_doc_contains_workspace(
+        tempdir.path(),
+        "csharp",
+        "src/Sample.cs",
+        "public class Sample {\n    public void trace_symbol() {}\n}\n",
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let source = fs::read_to_string(tempdir.path().join("src/Sample.cs")).expect("source");
+    assert!(source.contains("/// requirement doc line"));
+    assert!(source.contains("/// feature doc line"));
+}
+
+#[test]
+// REQ-CORE-003
+fn validate_fix_repairs_missing_trace_docs_for_kotlin_sources() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    write_doc_contains_workspace(
+        tempdir.path(),
+        "kotlin",
+        "src/Sample.kt",
+        "fun trace_symbol(): Int = 1\n",
+    );
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("validate")
+        .arg(tempdir.path())
+        .arg("--fix")
+        .output()
+        .expect("validate should run");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let source = fs::read_to_string(tempdir.path().join("src/Sample.kt")).expect("source");
+    assert!(source.contains("/**"));
+    assert!(source.contains("requirement doc line"));
+    assert!(source.contains("feature doc line"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #654