### PR TITLE
feat: track remaining version-managed manifests

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -94,6 +94,196 @@
               "replace": "version: \"{{version}}\""
             }
           ]
+        },
+        {
+          "type": "generic",
+          "file": "app/package.json",
+          "replacers": [
+            {
+              "search": "\"version\": \"(?<version>.*)\"",
+              "replace": "\"version\": \"{{version}}\""
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "website/package.json",
+          "replacers": [
+            {
+              "search": "\"version\": \"(?<version>.*)\"",
+              "replace": "\"version\": \"{{version}}\""
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "editors/vscode/package.json",
+          "replacers": [
+            {
+              "search": "\"version\": \"(?<version>.*)\"",
+              "replace": "\"version\": \"{{version}}\""
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "crates/syu-core/Cargo.toml",
+          "replacers": [
+            {
+              "search": "name = \"syu-core\"\nversion = \"(?<version>.*)\"",
+              "replace": "name = \"syu-core\"\nversion = \"{{version}}\""
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "app/wasm/Cargo.toml",
+          "replacers": [
+            {
+              "search": "name = \"syu-app-wasm\"\nversion = \"(?<version>.*)\"",
+              "replace": "name = \"syu-app-wasm\"\nversion = \"{{version}}\""
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/rust-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/browser-ui/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/csharp-fallback/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/generic/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/team-scale/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/typescript-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/go-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/python-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/java-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/ruby-only/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/docs-first/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "examples/polyglot/syu.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "tests/fixtures/workspaces/passing/docs/syu/features/features.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
+        },
+        {
+          "type": "generic",
+          "file": "tests/fixtures/workspaces/failing/docs/syu/features/features.yaml",
+          "replacers": [
+            {
+              "search": "^version: (?<version>.*)$",
+              "replace": "version: {{version}}"
+            }
+          ]
         }
       ]
     }

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -310,6 +310,19 @@ fn repository_declares_release_automation() {
     assert!(!release_config.contains("\"skip-changelog\": true"));
     assert!(release_config.contains("\"changelog-type\": \"github\""));
     assert!(!release_config.contains("\"initial-version\""));
+    assert!(release_config.contains("\"file\": \"app/package.json\""));
+    assert!(release_config.contains("\"file\": \"website/package.json\""));
+    assert!(release_config.contains("\"file\": \"editors/vscode/package.json\""));
+    assert!(release_config.contains("\"file\": \"crates/syu-core/Cargo.toml\""));
+    assert!(release_config.contains("\"file\": \"app/wasm/Cargo.toml\""));
+    assert!(release_config.contains("\"file\": \"examples/rust-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/polyglot/syu.yaml\""));
+    assert!(release_config.contains(
+        "\"file\": \"tests/fixtures/workspaces/passing/docs/syu/features/features.yaml\""
+    ));
+    assert!(release_config.contains(
+        "\"file\": \"tests/fixtures/workspaces/failing/docs/syu/features/features.yaml\""
+    ));
     assert!(manifest.contains("\".\": \"0.0.0\""));
     assert!(readme.contains("gh attestation verify"));
     assert!(readme.contains("--repo ugoite/syu"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -316,6 +316,16 @@ fn repository_declares_release_automation() {
     assert!(release_config.contains("\"file\": \"crates/syu-core/Cargo.toml\""));
     assert!(release_config.contains("\"file\": \"app/wasm/Cargo.toml\""));
     assert!(release_config.contains("\"file\": \"examples/rust-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/browser-ui/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/csharp-fallback/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/generic/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/team-scale/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/typescript-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/go-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/python-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/java-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/ruby-only/syu.yaml\""));
+    assert!(release_config.contains("\"file\": \"examples/docs-first/syu.yaml\""));
     assert!(release_config.contains("\"file\": \"examples/polyglot/syu.yaml\""));
     assert!(release_config.contains(
         "\"file\": \"tests/fixtures/workspaces/passing/docs/syu/features/features.yaml\""

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8583,9 +8583,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -13613,9 +13613,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Closes #620\n\nAdds release-please tracking for the remaining version-pinned manifests and example/fixture YAML files, and extends repository quality coverage to keep them listed.