### PR TITLE
feat: document implementation planning workflow

### DIFF
--- a/docs/generated/site-spec/features/documentation/docs.md
+++ b/docs/generated/site-spec/features/documentation/docs.md
@@ -65,6 +65,20 @@ description: "Generated reference for docs/syu/features/documentation/docs.yaml"
           - app.port
           - report.output
           - runtimes.python.command
+      - **file**: docs/guide/implementation-planning.md
+        - **symbols**:
+          - FEAT-DOCS-001
+          - syu show
+          - syu relate
+          - syu add
+          - syu validate
+      - **file**: docs/guide/request-artifact-format.md
+        - **symbols**:
+          - FEAT-DOCS-001
+          - request artifact
+          - repository_constraints
+          - linked_ids
+          - syu task workflows
 - **id**: FEAT-DOCS-002
   - **title**: Docusaurus documentation site
   - **summary**: Render and publish the checked-in docs tree as a documentation site without maintaining a separate content source.
@@ -154,6 +168,20 @@ features:
             - app.port
             - report.output
             - runtimes.python.command
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - FEAT-DOCS-001
+            - syu show
+            - syu relate
+            - syu add
+            - syu validate
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - FEAT-DOCS-001
+            - request artifact
+            - repository_constraints
+            - linked_ids
+            - syu task workflows
 
   - id: FEAT-DOCS-002
     title: Docusaurus documentation site

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 120/120
-- Feature-to-implementation traceability: 134/134
+- Feature-to-implementation traceability: 136/136
 
 ## Issues
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,6 +23,11 @@ Need a different level of guidance?
 - Follow [existing repository adoption](./existing-repository.md) when the
   repository already has code and history and you want to add `syu` without
   treating it like a blank workspace.
+- Use [implementation planning](./implementation-planning.md) when a request
+  still needs to become planned requirements and features before the code work
+  starts.
+- Use [request artifact format](./request-artifact-format.md) when you want a
+  small, repeatable request record before you touch the spec tree.
 - Stay on this page when you want the first workspace setup explained step by
   step, including why the manual YAML edits matter before validation and how the
   same commands fit together as one guided story.

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -1,0 +1,90 @@
+# Implementation planning with syu
+
+<!-- FEAT-DOCS-001 -->
+
+Use this guide when a new request is ready to become planned spec work before
+the implementation starts. If you already know the exact IDs and files, jump to
+[reviewer workflow](./reviewer-workflow.md). If you only have a request note,
+start with [request artifact format](./request-artifact-format.md).
+
+## When to use it
+
+- A request has enough detail to turn into planned requirements or features.
+- You need to review policies or philosophy before editing YAML.
+- The work should stay reviewable before code lands.
+
+## When not to use it
+
+- You already have a concrete spec diff.
+- The change is a tiny one-off fix.
+- You only need a request note and not the planning steps yet.
+
+## 1. Capture the request
+
+Keep the request short enough that one person can still read it without losing
+the thread. The request should say what outcome is wanted, what area of the
+repository is likely affected, and which constraints must stay true.
+
+## 2. Find the closest existing spec surface
+
+Use the existing navigation commands to find the best anchor before you edit
+anything:
+
+```bash
+syu show FEAT-CHECK-001
+syu relate FEAT-CHECK-001
+syu browse .
+syu search validation --kind requirement
+```
+
+At this point, decide whether the request belongs to an existing requirement or
+feature, or whether it needs a new one.
+
+## 3. Decide whether to create, expand, or delete a requirement
+
+- **Create** a requirement when the request adds durable behavior that no
+  current requirement explains.
+- **Expand** a requirement when the request changes the scope or acceptance
+  criteria of existing work without changing the core intent.
+- **Delete** a requirement only when the request has been fully superseded and
+  every linked feature, test, and reference can move cleanly to a new owner.
+
+When you create or expand, keep the new `planned` state explicit until the code
+and traces exist. When you delete, remove stale references first and then rerun
+validation so the graph stays honest.
+
+## 4. Review the policy and philosophy context
+
+Before editing the spec, use `syu relate` on the owning item and check the
+surrounding policies and philosophy. That keeps the request aligned with the
+repository's higher-level intent instead of adding a one-off exception.
+
+If the request would weaken an existing policy, make that change explicit in the
+spec instead of hiding it inside implementation notes.
+
+## 5. Turn the request into planned spec edits
+
+Use `syu add` when you need new planned requirements or features, then edit the
+generated YAML so the new work is reviewable:
+
+```bash
+syu add requirement REQ-PLANNING-001
+syu add feature FEAT-PLANNING-001 --kind planning
+```
+
+Keep the planned items small. If one request is trying to introduce multiple
+behaviors, split the request before you split the implementation.
+
+## 6. Implement and validate
+
+Once the spec shape is stable, add the code or docs that satisfy it, then trace
+the concrete files and run validation:
+
+```bash
+syu trace src/command/check.rs --symbol run_check_command
+syu log FEAT-CHECK-001 --kind implementation --path src/command
+syu validate .
+```
+
+That final pass should confirm the request, the spec, and the implementation all
+agree before the work moves into review.

--- a/docs/guide/request-artifact-format.md
+++ b/docs/guide/request-artifact-format.md
@@ -1,0 +1,53 @@
+# Request artifact format for syu task workflows
+
+<!-- FEAT-DOCS-001 -->
+
+Use this guide when you want a small, repeatable request record before you start
+editing the spec tree. If the request is already a concrete diff, raw spec edits
+are usually enough.
+
+## Recommended shape
+
+YAML keeps the request easy to read in the terminal and easy to reuse in later
+tooling:
+
+```yaml
+version: 1
+request: >
+  Expand syu validate --fix so it repairs the safe trace and ownership hygiene
+  cases that are already accepted by the validator.
+context:
+  affected_area: validation
+  repository_constraints:
+    - keep current CLI flags stable
+    - preserve text and JSON output
+    - stay compatible with the existing quality gates
+  linked_ids:
+    - FEAT-CHECK-001
+```
+
+## What each field is for
+
+- **version**: keeps the artifact format explicit when the shape changes later.
+- **request**: the short statement you would otherwise paste into chat or a
+  ticket.
+- **context.affected_area**: the part of the repository most likely to change.
+- **context.repository_constraints**: the rules that must stay true while the
+  request is being planned.
+- **context.linked_ids**: the IDs already known to be in scope.
+
+## When to use it
+
+- When a request needs to be handed around before the spec is edited.
+- When a later CLI or app flow should be able to load the same request again.
+- When you want to keep the intake step separate from the spec rewrite step.
+
+## When not to use it
+
+- When you already know the exact files and IDs that need to change.
+- When the change is tiny and one-off.
+- When the request is only useful as an inline note inside the PR description.
+
+The request artifact is intentionally smaller than the spec itself. Once the
+request is understood, move the real work into planned requirements and features
+with the planning guide.

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -15,6 +15,11 @@ history, and the reviewer-facing `audit` / `report` commands.
 The commands below answer those questions with `show`/`relate`, `review`
 (`trace --range`), `trace`, `audit`, `report`, `explain`, and `log`.
 
+If the work is still being shaped from a request into spec edits, start with
+[implementation planning](./implementation-planning.md). If you only need the
+request shape to stay consistent, use
+[request artifact format](./request-artifact-format.md).
+
 If you review from the terminal often, generate shell completions once so spec
 IDs and subcommands stay close at hand:
 

--- a/docs/syu/features/documentation/docs.yaml
+++ b/docs/syu/features/documentation/docs.yaml
@@ -50,6 +50,20 @@ features:
             - app.port
             - report.output
             - runtimes.python.command
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - FEAT-DOCS-001
+            - syu show
+            - syu relate
+            - syu add
+            - syu validate
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - FEAT-DOCS-001
+            - request artifact
+            - repository_constraints
+            - linked_ids
+            - syu task workflows
 
   - id: FEAT-DOCS-002
     title: Docusaurus documentation site

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -422,8 +422,10 @@ fn repository_declares_documentation_guides() {
     let app_guide = read_file("docs/guide/app.md");
     let examples_and_templates = read_file("docs/guide/examples-and-templates.md");
     let merge_queue_playbook = read_file("docs/guide/merge-queue-playbook.md");
+    let implementation_planning = read_file("docs/guide/implementation-planning.md");
     let getting_started = read_file("docs/guide/getting-started.md");
     let existing_repository = read_file("docs/guide/existing-repository.md");
+    let request_artifact_format = read_file("docs/guide/request-artifact-format.md");
     let node_workflow = read_file("docs/guide/node-workflow.md");
     let lsp_guide = read_file("docs/guide/lsp.md");
     let command_card = read_file("docs/guide/command-card.md");
@@ -559,6 +561,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("New to `syu`?"));
     assert!(getting_started.contains("Need a different level of guidance?"));
     assert!(getting_started.contains("[command card](./command-card.md)"));
+    assert!(getting_started.contains("implementation planning"));
+    assert!(getting_started.contains("request artifact format"));
     assert!(getting_started.contains("README quick start"));
     assert!(getting_started.contains("## Quick start path"));
     assert!(getting_started.contains("site-local route into `syu validate .`"));
@@ -630,6 +634,8 @@ fn repository_declares_documentation_guides() {
     assert!(getting_started.contains("status: implemented"));
     assert!(getting_started.contains("Keep exploring"));
     assert!(getting_started.contains("[reviewer workflow guide](./reviewer-workflow.md)"));
+    assert!(getting_started.contains("[implementation planning](./implementation-planning.md)"));
+    assert!(getting_started.contains("[request artifact format](./request-artifact-format.md)"));
     assert!(getting_started.contains("examples/rust-only"));
     assert!(getting_started.contains("examples/generic"));
     assert!(getting_started.contains("examples/python-only"));
@@ -690,6 +696,16 @@ fn repository_declares_documentation_guides() {
     assert!(vscode_guide.contains("[repository Node workflow guide](./node-workflow.md)"));
     assert!(vscode_guide.contains("scripts/ci/pinned-npm.sh install editors/vscode"));
     assert!(vscode_guide.contains("npm --prefix editors/vscode ci"));
+    assert!(implementation_planning.contains("# Implementation planning with syu"));
+    assert!(implementation_planning.contains("syu add requirement REQ-PLANNING-001"));
+    assert!(implementation_planning.contains("When to use it"));
+    assert!(implementation_planning.contains("When not to use it"));
+    assert!(implementation_planning.contains("create, expand, or delete"));
+    assert!(request_artifact_format.contains("# Request artifact format for syu task workflows"));
+    assert!(request_artifact_format.contains("version: 1"));
+    assert!(request_artifact_format.contains("repository_constraints"));
+    assert!(request_artifact_format.contains("When to use it"));
+    assert!(request_artifact_format.contains("When not to use it"));
     let tutorial = read_file("docs/guide/tutorial.md");
     assert!(tutorial.contains("Want a different entry point?"));
     assert!(tutorial.contains("[getting started](./getting-started.md)"));


### PR DESCRIPTION
Closes #645\n\nAdds a docsite guide for turning a request into planned requirements and features, plus links from the existing getting-started and reviewer guides.