### PR TITLE
Show OpenAPI selectors in review range output

### DIFF
--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -44,8 +44,9 @@ If a pull request already exists, pair this page with the
 Use `syu audit .` before `syu report .` when you want the review handoff to read as one short loop instead of a loose list of checks.
 
 If a reviewed diff includes an OpenAPI contract file, the range summary still
-shows the owning requirements and features so the change stays connected to
-the traced spec items.
+shows the owning requirements and features and now prints the traced
+method/path selector so the change stays connected to the spec items that own
+the contract operation.
 
 ## Common command bundles
 

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -93,9 +93,10 @@ the follow-up `show`, `relate`, `log`, and `validate --id` commands close at
 hand.
 
 When a changed file is a contract file with traced operations, the range
-summary keeps the owning requirements and features visible instead of reducing
-the file to a bare path. That makes OpenAPI edits easier to review alongside
-the rest of the spec graph.
+summary keeps the owning requirements and features visible and also prints the
+OpenAPI method/path selector under the changed file instead of reducing it to a
+bare path. That makes contract edits easier to review alongside the rest of
+the spec graph.
 
 When you want the same selector flexibility but a more opinionated summary, run
 `syu explain TARGET`. It keeps the ID/path/symbol entry points from `syu

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -83,6 +83,10 @@ struct TraceOwnerMatch {
     file: String,
     declared_symbols: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     matched_symbol: Option<String>,
     match_mode: &'static str,
 }
@@ -321,11 +325,11 @@ fn render_range_text(
     )
     .unwrap();
 
-    let mut by_owner = BTreeMap::<String, Vec<&TraceLookupOutput>>::new();
+    let mut by_owner = BTreeMap::<(String, String), Vec<&TraceLookupOutput>>::new();
     for result in results {
         if result.matched_owners.is_empty() && result.file_only_owners.is_empty() {
             by_owner
-                .entry("UNOWNED".to_string())
+                .entry(("UNOWNED".to_string(), String::new()))
                 .or_default()
                 .push(result);
         } else {
@@ -336,17 +340,24 @@ fn render_range_text(
             };
             for owner in owners {
                 by_owner
-                    .entry(format!("{} {}", owner.kind, owner.id))
+                    .entry((owner.kind.to_string(), owner.id.clone()))
                     .or_default()
                     .push(result);
             }
         }
     }
 
-    for (owner, files) in &by_owner {
-        writeln!(output, "{owner}:").unwrap();
+    for ((kind, id), files) in &by_owner {
+        if kind == "UNOWNED" {
+            writeln!(output, "UNOWNED:").unwrap();
+        } else {
+            writeln!(output, "{kind} {id}:").unwrap();
+        }
         for file in files {
             writeln!(output, "  - {}", file.file).unwrap();
+            if let Some(owner_match) = find_owner_match(file, kind, id) {
+                push_range_owner_match(&mut output, owner_match);
+            }
         }
         writeln!(output).unwrap();
     }
@@ -568,6 +579,8 @@ fn trace_owner_match(
         language: language.to_string(),
         file: file_label.to_string(),
         declared_symbols: reference.symbols.clone(),
+        method: reference.method.clone(),
+        path: reference.path.clone(),
         matched_symbol,
         match_mode: match_mode.label(),
     }
@@ -784,6 +797,40 @@ fn push_owner_match(rendered: &mut String, owner: &TraceOwnerMatch) {
         )
         .expect("writing to a string should succeed");
     }
+    push_trace_operation(rendered, owner, "  ");
+}
+
+fn push_range_owner_match(rendered: &mut String, owner: &TraceOwnerMatch) {
+    push_trace_operation(rendered, owner, "    ");
+}
+
+fn push_trace_operation(rendered: &mut String, owner: &TraceOwnerMatch, indent: &str) {
+    if owner.method.is_none() && owner.path.is_none() {
+        return;
+    }
+
+    let mut parts = Vec::new();
+    if let Some(method) = owner.method.as_deref() {
+        parts.push(format!("method `{method}`"));
+    }
+    if let Some(path) = owner.path.as_deref() {
+        parts.push(format!("path `{path}`"));
+    }
+
+    writeln!(rendered, "{indent}operation: {}", parts.join(" "))
+        .expect("writing to a string should succeed");
+}
+
+fn find_owner_match<'a>(
+    result: &'a TraceLookupOutput,
+    kind: &str,
+    id: &str,
+) -> Option<&'a TraceOwnerMatch> {
+    result
+        .matched_owners
+        .iter()
+        .chain(result.file_only_owners.iter())
+        .find(|owner| owner.kind == kind && owner.id == id)
 }
 
 fn push_entity_section(rendered: &mut String, heading: &str, items: &[EntitySummary]) {
@@ -1031,6 +1078,8 @@ mod tests {
                 language: "rust".to_string(),
                 file: "src/lib.rs".to_string(),
                 declared_symbols: Vec::new(),
+                method: None,
+                path: None,
                 matched_symbol: None,
                 match_mode: "file",
             }],
@@ -1066,6 +1115,8 @@ mod tests {
                     language: "rust".to_string(),
                     file: "src/lib.rs".to_string(),
                     declared_symbols: Vec::new(),
+                    method: None,
+                    path: None,
                     matched_symbol: None,
                     match_mode: "file",
                 },
@@ -1077,6 +1128,8 @@ mod tests {
                     language: "rust".to_string(),
                     file: "src/lib.rs".to_string(),
                     declared_symbols: Vec::new(),
+                    method: None,
+                    path: None,
                     matched_symbol: None,
                     match_mode: "file",
                 },
@@ -1162,6 +1215,8 @@ mod tests {
                     language: "rust".to_string(),
                     file: "src/lib.rs".to_string(),
                     declared_symbols: vec!["run_trace_command".to_string()],
+                    method: None,
+                    path: None,
                     matched_symbol: Some("run_trace_command".to_string()),
                     match_mode: "symbol",
                 },
@@ -1173,6 +1228,8 @@ mod tests {
                     language: "rust".to_string(),
                     file: "src/lib.rs".to_string(),
                     declared_symbols: vec!["*".to_string()],
+                    method: None,
+                    path: None,
                     matched_symbol: Some("*".to_string()),
                     match_mode: "wildcard",
                 },
@@ -1187,6 +1244,35 @@ mod tests {
         assert!(rendered.contains("matched by symbol `run_trace_command`"));
         assert!(rendered.contains("matched by wildcard `*`"));
         assert!(rendered.contains("Requirements:\n- none"));
+    }
+
+    #[test]
+    fn render_text_output_shows_openapi_operation_details() {
+        let rendered = render_text_output(&TraceLookupOutput {
+            file: "api/openapi.yaml".to_string(),
+            symbol: None,
+            status: TraceLookupStatus::Owned,
+            matched_owners: vec![TraceOwnerMatch {
+                kind: "feature",
+                id: "FEAT-TRACE-001".to_string(),
+                title: "OpenAPI trace".to_string(),
+                trace_role: "implementation".to_string(),
+                language: "openapi".to_string(),
+                file: "api/openapi.yaml".to_string(),
+                declared_symbols: Vec::new(),
+                method: Some("get".to_string()),
+                path: Some("/pets/{petId}".to_string()),
+                matched_symbol: None,
+                match_mode: "file",
+            }],
+            file_only_owners: Vec::new(),
+            requirements: Vec::new(),
+            features: Vec::new(),
+            policies: Vec::new(),
+            philosophies: Vec::new(),
+        });
+
+        assert!(rendered.contains("operation: method `get` path `/pets/{petId}`"));
     }
 
     #[test]
@@ -1298,6 +1384,8 @@ mod tests {
                         language: "rust".to_string(),
                         file: "file-only.rs".to_string(),
                         declared_symbols: Vec::new(),
+                        method: None,
+                        path: None,
                         matched_symbol: None,
                         match_mode: "file",
                     }],
@@ -1338,6 +1426,61 @@ mod tests {
         assert!(rendered.contains("Inspected files: 2"));
         assert!(rendered.contains("Skipped files: 0"));
         assert!(rendered.contains("Features: 1"));
+    }
+
+    #[test]
+    fn render_range_text_shows_openapi_operation_details() {
+        let rendered = super::render_range_text(
+            "HEAD~1..HEAD",
+            &[TraceLookupOutput {
+                file: "api/openapi.yaml".to_string(),
+                symbol: None,
+                status: TraceLookupStatus::Owned,
+                matched_owners: vec![TraceOwnerMatch {
+                    kind: "feature",
+                    id: "FEAT-TRACE-001".to_string(),
+                    title: "OpenAPI trace".to_string(),
+                    trace_role: "implementation".to_string(),
+                    language: "openapi".to_string(),
+                    file: "api/openapi.yaml".to_string(),
+                    declared_symbols: Vec::new(),
+                    method: Some("get".to_string()),
+                    path: Some("/pets/{petId}".to_string()),
+                    matched_symbol: None,
+                    match_mode: "file",
+                }],
+                file_only_owners: Vec::new(),
+                requirements: vec![EntitySummary {
+                    id: "REQ-TRACE-001".to_string(),
+                    title: "Trace".to_string(),
+                    document_path: None,
+                }],
+                features: vec![EntitySummary {
+                    id: "FEAT-TRACE-001".to_string(),
+                    title: "OpenAPI trace".to_string(),
+                    document_path: None,
+                }],
+                policies: Vec::new(),
+                philosophies: Vec::new(),
+            }],
+            &[],
+            &super::TraceRangeSummary {
+                changed_files_total: 1,
+                inspected_files: 1,
+                skipped_files: 0,
+                owned_files: 1,
+                partial_files: 0,
+                unowned_files: 0,
+                total_requirements: 1,
+                total_features: 1,
+                total_policies: 0,
+                total_philosophies: 0,
+            },
+        );
+
+        assert!(rendered.contains("feature FEAT-TRACE-001:"));
+        assert!(rendered.contains("  - api/openapi.yaml"));
+        assert!(rendered.contains("operation: method `get` path `/pets/{petId}`"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Surface OpenAPI method/path selectors in trace review output so `syu review --range` no longer reduces contract ownership to a bare file path.
- Carry the OpenAPI selector metadata through trace owner matches and render it in single-file trace output too.
- Update reviewer docs to explain how contract-file changes appear in review output.

Validation:
- `cargo fmt --all`
- `cargo test openapi_operation_details --lib`
- `cargo test trace_command_reports_git_range_summary_for_changed_files --test trace_command`

Closes #635
