### PR TITLE
Add git-backed historical ID index

### DIFF
--- a/crates/syu-core/src/lib.rs
+++ b/crates/syu-core/src/lib.rs
@@ -86,12 +86,22 @@ pub struct ValidationSnapshot {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HistoricalIdSnapshot {
+    pub enabled: bool,
+    pub available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_ref: Option<String>,
+    pub ids_by_section: BTreeMap<SectionKind, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppPayload {
     pub workspace_root: String,
     pub spec_root: String,
     pub app_server: AppServer,
     pub source_documents: Vec<SourceDocument>,
     pub validation: ValidationSnapshot,
+    pub historical_ids: HistoricalIdSnapshot,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -109,6 +119,7 @@ pub struct BrowserWorkspace {
     pub sections: Vec<BrowserSection>,
     pub item_index: BTreeMap<String, BrowserIndexEntry>,
     pub validation: ValidationSnapshot,
+    pub historical_ids: HistoricalIdSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -326,6 +337,7 @@ pub fn build_browser_workspace(payload: AppPayload) -> BrowserWorkspace {
         sections,
         item_index,
         validation: payload.validation,
+        historical_ids: payload.historical_ids,
     }
 }
 
@@ -552,8 +564,8 @@ fn folder_segments(path: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppPayload, AppServer, DefinitionCounts, ReferencedRule, SectionKind, Severity,
-        SourceDocument, TraceCount, TraceSummary, ValidationIssue, ValidationSnapshot,
+        AppPayload, AppServer, DefinitionCounts, HistoricalIdSnapshot, ReferencedRule, SectionKind,
+        Severity, SourceDocument, TraceCount, TraceSummary, ValidationIssue, ValidationSnapshot,
         build_browser_workspace,
     };
 
@@ -627,6 +639,7 @@ mod tests {
                 },
             ],
             validation: sample_validation(),
+            historical_ids: HistoricalIdSnapshot::default(),
         });
 
         assert_eq!(workspace.sections.len(), 4);
@@ -680,6 +693,7 @@ mod tests {
                 content: "category: Broken\nversion: [\n".to_string(),
             }],
             validation: ValidationSnapshot::default(),
+            historical_ids: HistoricalIdSnapshot::default(),
         });
 
         let document = &workspace.sections[2].documents[0];

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -442,6 +442,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: src/command/log.rs
         - **symbols**:
           - *
+      - **file**: src/history.rs
+        - **symbols**:
+          - *
 - **id**: REQ-CORE-025
   - **title**: Provide a heuristic audit command for cross-layer overlap and tension review
   - **description**:
@@ -977,6 +980,9 @@ requirements:
           symbols:
             - dispatches_log_subcommands_without_rewriting_them
         - file: src/command/log.rs
+          symbols:
+            - '*'
+        - file: src/history.rs
           symbols:
             - '*'
   - id: REQ-CORE-025

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 121/121
+- Requirement-to-test traceability: 122/122
 - Feature-to-implementation traceability: 136/136
 
 ## Issues

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 120/120
+- Requirement-to-test traceability: 121/121
 - Feature-to-implementation traceability: 136/136
 
 ## Issues

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -416,6 +416,9 @@ requirements:
         - file: src/command/log.rs
           symbols:
             - '*'
+        - file: src/history.rs
+          symbols:
+            - '*'
   - id: REQ-CORE-025
     title: Provide a heuristic audit command for cross-layer overlap and tension review
     description: |

--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result, bail};
 use crate::{
     cli::{AddArgs, LookupKind},
     coverage::normalize_relative_path,
+    history::build_historical_id_index,
     model::{
         FeatureDocument, FeatureRegistryDocument, PhilosophyDocument, PolicyDocument,
         RequirementDocument,
@@ -45,6 +46,18 @@ pub fn run_add_command(args: &AddArgs) -> Result<i32> {
     {
         bail!(
             "{} `{}` already exists in `{}`",
+            args.layer.label(),
+            resolved.parsed_id.normalized,
+            workspace.root.display()
+        );
+    }
+    let historical_ids = build_historical_id_index(&workspace.root, &workspace.config)?;
+    if historical_ids.enabled()
+        && historical_ids.available()
+        && historical_ids.contains(&resolved.parsed_id.normalized)
+    {
+        bail!(
+            "{} `{}` has already existed in the git-backed historical index for `{}`",
             args.layer.label(),
             resolved.parsed_id.normalized,
             workspace.root.display()
@@ -926,6 +939,7 @@ mod tests {
         collections::VecDeque,
         fs,
         path::{Path, PathBuf},
+        process::Command,
     };
 
     use tempfile::{TempDir, tempdir};
@@ -993,6 +1007,15 @@ mod tests {
             fs::create_dir_all(parent).expect("parent directory should exist");
         }
         fs::write(path, contents).expect("test fixture file should be written");
+    }
+
+    fn git(path: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(path)
+            .args(args)
+            .status()
+            .expect("git command should run");
+        assert!(status.success(), "git {:?} failed", args);
     }
 
     #[test]
@@ -1440,6 +1463,70 @@ mod tests {
             workspace
                 .join("docs/syu/requirements/auth/auth.yaml")
                 .exists()
+        );
+    }
+
+    #[test]
+    fn run_add_command_rejects_historical_ids_that_no_longer_exist_currently() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path().join("workspace");
+        fs::create_dir_all(workspace.join("docs/syu/philosophy")).expect("philosophy dir");
+        fs::create_dir_all(workspace.join("docs/syu/policies")).expect("policies dir");
+        fs::create_dir_all(workspace.join("docs/syu/requirements/core")).expect("requirements dir");
+        fs::create_dir_all(workspace.join("docs/syu/features/core")).expect("features dir");
+        write_file(
+            &workspace.join("syu.yaml"),
+            "version: 1\nspec:\n  root: docs/syu\nvalidate:\n  default_fix: false\n  allow_planned: true\n  require_non_orphaned_items: true\n  require_reciprocal_links: true\n  require_symbol_trace_coverage: false\n",
+        );
+        write_file(
+            &workspace.join("docs/syu/philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nphilosophies:\n  - id: PHIL-001\n    title: Stable value\n    product_design_principle: Keep it explainable.\n    coding_guideline: Share logic.\n",
+        );
+        write_file(
+            &workspace.join("docs/syu/policies/policies.yaml"),
+            "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-001\n    title: Keep links explicit\n    summary: summary\n    description: description\n    linked_philosophies:\n      - PHIL-001\n",
+        );
+        write_file(
+            &workspace.join("docs/syu/requirements/core/req.yaml"),
+            "category: Core\nprefix: REQ\nrequirements:\n  - id: REQ-001\n    title: Historical requirement\n    description: old\n    priority: medium\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n",
+        );
+        write_file(
+            &workspace.join("docs/syu/features/features.yaml"),
+            "version: \"1\"\nfiles:\n  - kind: core\n    file: core/feature.yaml\n",
+        );
+        write_file(
+            &workspace.join("docs/syu/features/core/feature.yaml"),
+            "category: Core\nversion: 1\nfeatures:\n  - id: FEAT-001\n    title: Historical feature\n    summary: summary\n    status: planned\n    linked_requirements:\n      - REQ-001\n",
+        );
+        git(&workspace, &["init"]);
+        git(&workspace, &["config", "user.email", "codex@example.com"]);
+        git(&workspace, &["config", "user.name", "Codex"]);
+        git(&workspace, &["add", "."]);
+        git(&workspace, &["commit", "-m", "initial historical id"]);
+
+        write_file(
+            &workspace.join("docs/syu/requirements/core/req.yaml"),
+            "category: Core\nprefix: REQ\nrequirements:\n  - id: REQ-002\n    title: Historical requirement\n    description: new\n    priority: medium\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-001\n",
+        );
+        git(&workspace, &["add", "docs/syu/requirements/core/req.yaml"]);
+        git(
+            &workspace,
+            &["commit", "-m", "replace historical requirement"],
+        );
+
+        let error = run_add_command(&AddArgs {
+            layer: LookupKind::Requirement,
+            id: Some("REQ-001".to_string()),
+            workspace: workspace.clone(),
+            interactive: false,
+            file: None,
+            kind: None,
+        })
+        .expect_err("historical ids should be rejected");
+
+        assert!(
+            error.to_string().contains("git-backed historical index"),
+            "{error:#}"
         );
     }
 

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -633,7 +633,11 @@ fn git_head(workspace_root: &Path) -> Result<String> {
         );
     }
 
-    let head = String::from_utf8(output.stdout).context("git HEAD should be valid UTF-8")?;
+    parse_git_head_stdout(output.stdout, workspace_root)
+}
+
+fn parse_git_head_stdout(stdout: Vec<u8>, workspace_root: &Path) -> Result<String> {
+    let head = String::from_utf8(stdout).context("git HEAD should be valid UTF-8")?;
     let head = head.trim().to_string();
     if head.is_empty() {
         bail!(
@@ -1366,12 +1370,13 @@ mod tests {
         bind_failure_message, browser_root_labels, build_app_payload, canonical_workspace_root,
         collect_feature_sources, collect_snapshot_files_with_extensions,
         collect_yaml_sources_recursive, content_type_for_path, dev_server_probe_request_sent,
-        dev_server_probe_succeeds, is_asset_like, load_current_snapshot,
+        dev_server_probe_succeeds, git_head, is_asset_like, load_current_snapshot,
         non_loopback_warning_lines, normalized_asset_path, normalized_trace_snapshot_path,
-        readiness_probe_request_sent, readiness_probe_succeeds, redacted_relative_label,
-        redacted_root_label, refresh_current_once, relative_display, require_remote_bind_opt_in,
-        resolve_app_server_settings, spec_snapshot, startup_lines, trailing_path_components_label,
-        validation_snapshot, wait_for_dev_server_with_retry, wait_for_ready_with_retry,
+        parse_git_head_stdout, readiness_probe_request_sent, readiness_probe_succeeds,
+        redacted_relative_label, redacted_root_label, refresh_current_once, relative_display,
+        require_remote_bind_opt_in, resolve_app_server_settings, spec_snapshot, startup_lines,
+        trailing_path_components_label, validation_snapshot, wait_for_dev_server_with_retry,
+        wait_for_ready_with_retry,
     };
 
     fn fixture_root(name: &str) -> PathBuf {
@@ -2363,6 +2368,42 @@ mod tests {
 
         let second = load_current_snapshot(tempdir.path(), &config).expect("snapshot");
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn git_head_surfaces_non_repository_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+
+        let error = git_head(tempdir.path()).expect_err("non-repository HEAD lookup should fail");
+
+        assert!(
+            error.to_string().contains("failed to read HEAD"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn git_head_surfaces_spawn_and_empty_stdout_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let file_workspace = tempdir.path().join("not-a-directory");
+        fs::write(&file_workspace, "not a directory\n").expect("workspace file");
+
+        let spawn_error =
+            git_head(&file_workspace).expect_err("file current_dir should fail to spawn git");
+        assert!(
+            spawn_error.to_string().contains("failed to run"),
+            "unexpected error: {spawn_error}"
+        );
+
+        let empty_error =
+            parse_git_head_stdout(Vec::new(), tempdir.path()).expect_err("empty HEAD should fail");
+
+        assert!(
+            empty_error
+                .to_string()
+                .contains("git rev-parse returned an empty HEAD"),
+            "unexpected error: {empty_error}"
+        );
     }
 
     #[test]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -8,6 +8,7 @@ use std::{
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
     path::{Component, Path, PathBuf},
+    process::Command,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -30,8 +31,9 @@ use syu_core::{
 use crate::{
     cli::AppArgs,
     command::check::collect_check_result,
-    config::{SyuConfig, load_config, resolve_spec_root},
+    config::{SyuConfig, config_path, load_config, resolve_spec_root},
     coverage::normalize_relative_path,
+    history::build_historical_id_index,
     model::{CheckResult, FeatureRegistryDocument, TraceReference},
     workspace::{
         load_feature_documents_with_paths, load_requirement_documents_with_paths,
@@ -539,6 +541,7 @@ fn spec_snapshot(spec_root: &Path) -> Result<String> {
 enum SnapshotDependency {
     File(PathBuf),
     ReadDirError(PathBuf, String),
+    GitHead(String),
 }
 
 impl SnapshotDependency {
@@ -563,6 +566,10 @@ impl SnapshotDependency {
                 path.hash(hasher);
                 kind.hash(hasher);
             }
+            Self::GitHead(head) => {
+                "git_head".hash(hasher);
+                head.hash(hasher);
+            }
         }
     }
 }
@@ -573,6 +580,7 @@ fn app_snapshot_dependencies(
     config: &SyuConfig,
 ) -> BTreeSet<SnapshotDependency> {
     let mut dependencies = BTreeSet::new();
+    dependencies.insert(SnapshotDependency::File(config_path(workspace_root)));
 
     if let Ok(documents) = load_requirement_documents_with_paths(&spec_root.join("requirements")) {
         for document in documents {
@@ -597,7 +605,50 @@ fn app_snapshot_dependencies(
         collect_coverage_snapshot_dependencies(workspace_root, &mut dependencies);
     }
 
+    if config.validate.historical_ids.enabled
+        && let Ok(head) = git_head(workspace_root)
+    {
+        dependencies.insert(SnapshotDependency::GitHead(head));
+    }
+
     dependencies
+}
+
+fn git_head(workspace_root: &Path) -> Result<String> {
+    let output = git_command(workspace_root)
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git rev-parse HEAD` in `{}`",
+                workspace_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "failed to read HEAD for `{}`: {}",
+            workspace_root.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let head = String::from_utf8(output.stdout).context("git HEAD should be valid UTF-8")?;
+    let head = head.trim().to_string();
+    if head.is_empty() {
+        bail!(
+            "git rev-parse returned an empty HEAD for `{}`",
+            workspace_root.display()
+        );
+    }
+
+    Ok(head)
+}
+
+fn git_command(workspace_root: &Path) -> Command {
+    let mut command = Command::new("git");
+    command.current_dir(workspace_root);
+    command
 }
 
 fn collect_trace_map_snapshot_dependencies(
@@ -1000,6 +1051,7 @@ fn build_app_payload_from_config(workspace_root: &Path, config: &SyuConfig) -> R
         app_server: AppServer::default(),
         source_documents,
         validation: validation_snapshot(collect_check_result(workspace_root)),
+        historical_ids: build_historical_id_index(workspace_root, config)?.snapshot(),
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,8 @@ pub struct ValidateConfig {
     #[serde(default)]
     pub require_symbol_trace_coverage: bool,
     #[serde(default)]
+    pub historical_ids: HistoricalIdsConfig,
+    #[serde(default)]
     pub trace_ownership_mode: TraceOwnershipMode,
     #[serde(default = "default_symbol_trace_coverage_ignored_paths")]
     pub symbol_trace_coverage_ignored_paths: Vec<PathBuf>,
@@ -100,8 +102,27 @@ impl Default for ValidateConfig {
             require_non_orphaned_items: default_require_non_orphaned_items(),
             require_reciprocal_links: default_require_reciprocal_links(),
             require_symbol_trace_coverage: false,
+            historical_ids: HistoricalIdsConfig::default(),
             trace_ownership_mode: TraceOwnershipMode::Mapping,
             symbol_trace_coverage_ignored_paths: default_symbol_trace_coverage_ignored_paths(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HistoricalIdsConfig {
+    #[serde(default = "default_historical_ids_enabled")]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_ref: Option<String>,
+}
+
+impl Default for HistoricalIdsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_historical_ids_enabled(),
+            start_ref: None,
         }
     }
 }
@@ -204,6 +225,10 @@ fn default_require_non_orphaned_items() -> bool {
 }
 
 fn default_require_reciprocal_links() -> bool {
+    true
+}
+
+fn default_historical_ids_enabled() -> bool {
     true
 }
 
@@ -386,7 +411,7 @@ mod tests {
         fs::write(
             tempdir.path().join(CONFIG_FILE_NAME),
             format!(
-                "version: {version}\nspec:\n  root: spec/contracts\nvalidate:\n  default_fix: true\n  allow_planned: false\n  require_non_orphaned_items: false\n  require_reciprocal_links: false\n  require_symbol_trace_coverage: true\n  trace_ownership_mode: sidecar\nreport:\n  output: docs/generated/syu-report.md\napp:\n  bind: 0.0.0.0\n  port: 4321\nruntimes:\n  python:\n    command: python3\n  node:\n    command: node\n",
+                "version: {version}\nspec:\n  root: spec/contracts\nvalidate:\n  default_fix: true\n  allow_planned: false\n  require_non_orphaned_items: false\n  require_reciprocal_links: false\n  require_symbol_trace_coverage: true\n  historical_ids:\n    enabled: false\n    start_ref: origin/main\n  trace_ownership_mode: sidecar\nreport:\n  output: docs/generated/syu-report.md\napp:\n  bind: 0.0.0.0\n  port: 4321\nruntimes:\n  python:\n    command: python3\n  node:\n    command: node\n",
                 version = current_cli_version()
             ),
         )
@@ -403,6 +428,11 @@ mod tests {
         assert!(!loaded.config.validate.require_non_orphaned_items);
         assert!(!loaded.config.validate.require_reciprocal_links);
         assert!(loaded.config.validate.require_symbol_trace_coverage);
+        assert!(!loaded.config.validate.historical_ids.enabled);
+        assert_eq!(
+            loaded.config.validate.historical_ids.start_ref.as_deref(),
+            Some("origin/main")
+        );
         assert_eq!(
             loaded.config.validate.trace_ownership_mode,
             TraceOwnershipMode::Sidecar
@@ -461,6 +491,8 @@ mod tests {
         assert!(rendered.contains("require_non_orphaned_items: true"));
         assert!(rendered.contains("require_reciprocal_links: true"));
         assert!(rendered.contains("require_symbol_trace_coverage: false"));
+        assert!(rendered.contains("historical_ids:"));
+        assert!(rendered.contains("enabled: true"));
         assert!(rendered.contains("trace_ownership_mode: mapping"));
         assert!(rendered.contains("symbol_trace_coverage_ignored_paths:"));
         assert!(rendered.contains("- build"));

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,339 @@
+// FEAT-LOG-001
+// REQ-CORE-636
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+use syu_core::{HistoricalIdSnapshot, SectionKind};
+
+use crate::{
+    config::SyuConfig,
+    config::resolve_spec_root,
+    model::{FeatureDocument, PhilosophyDocument, PolicyDocument, RequirementDocument},
+    workspace::resolve_workspace_root,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct HistoricalIdIndex {
+    enabled: bool,
+    available: bool,
+    start_ref: Option<String>,
+    ids_by_section: BTreeMap<SectionKind, BTreeSet<String>>,
+    ids_by_value: BTreeSet<String>,
+}
+
+impl HistoricalIdIndex {
+    pub(crate) fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn available(&self) -> bool {
+        self.available
+    }
+
+    pub(crate) fn contains(&self, id: &str) -> bool {
+        self.ids_by_value.contains(id)
+    }
+
+    pub(crate) fn snapshot(&self) -> HistoricalIdSnapshot {
+        HistoricalIdSnapshot {
+            enabled: self.enabled,
+            available: self.available,
+            start_ref: self.start_ref.clone(),
+            ids_by_section: self
+                .ids_by_section
+                .iter()
+                .map(|(kind, ids)| (*kind, ids.iter().cloned().collect()))
+                .collect(),
+        }
+    }
+}
+
+pub(crate) fn build_historical_id_index(
+    workspace_root: &Path,
+    config: &SyuConfig,
+) -> Result<HistoricalIdIndex> {
+    let mut index = HistoricalIdIndex {
+        enabled: config.validate.historical_ids.enabled,
+        available: false,
+        start_ref: config.validate.historical_ids.start_ref.clone(),
+        ids_by_section: BTreeMap::from([
+            (SectionKind::Philosophy, BTreeSet::new()),
+            (SectionKind::Policies, BTreeSet::new()),
+            (SectionKind::Requirements, BTreeSet::new()),
+            (SectionKind::Features, BTreeSet::new()),
+        ]),
+        ids_by_value: BTreeSet::new(),
+    };
+
+    if !index.enabled {
+        return Ok(index);
+    }
+
+    let workspace_root = resolve_workspace_root(workspace_root)?;
+    let repository_root = match git_repository_root(&workspace_root) {
+        Ok(root) => root,
+        Err(_) => return Ok(index),
+    };
+    let spec_root = resolve_spec_root(&workspace_root, config);
+    let spec_root_relative = match spec_root.strip_prefix(&repository_root) {
+        Ok(relative) if !relative.as_os_str().is_empty() => relative.to_path_buf(),
+        _ => return Ok(index),
+    };
+
+    let commits = if let Some(start_ref) = index.start_ref.clone() {
+        let mut commits = Vec::new();
+        record_commit_snapshot(
+            &repository_root,
+            &spec_root_relative,
+            &start_ref,
+            &mut index,
+        )?;
+        commits.extend(git_rev_list(
+            &repository_root,
+            &format!("{start_ref}..HEAD"),
+        )?);
+        commits
+    } else {
+        git_rev_list(&repository_root, "HEAD")?
+    };
+
+    for commit in commits {
+        record_commit_snapshot(&repository_root, &spec_root_relative, &commit, &mut index)?;
+    }
+
+    index.available = true;
+    Ok(index)
+}
+
+fn git_repository_root(workspace_root: &Path) -> Result<PathBuf> {
+    let output = git_command(workspace_root)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git rev-parse` in `{}`",
+                workspace_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "workspace `{}` is not inside a Git repository, so historical IDs cannot be indexed.",
+            workspace_root.display()
+        );
+    }
+
+    let root =
+        String::from_utf8(output.stdout).context("git repository root should be valid UTF-8")?;
+    let root = root.trim();
+    if root.is_empty() {
+        bail!(
+            "git rev-parse returned an empty repository root for `{}`",
+            workspace_root.display()
+        );
+    }
+
+    Ok(PathBuf::from(root))
+}
+
+fn git_rev_list(repository_root: &Path, rev_range: &str) -> Result<Vec<String>> {
+    let output = git_command(repository_root)
+        .arg("rev-list")
+        .arg("--reverse")
+        .arg(rev_range)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git rev-list {rev_range}` in `{}`",
+                repository_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "failed to enumerate historical commits for `{}`: {}",
+            rev_range,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout =
+        String::from_utf8(output.stdout).context("git rev-list output should be valid UTF-8")?;
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn record_commit_snapshot(
+    repository_root: &Path,
+    spec_root_relative: &Path,
+    commit: &str,
+    index: &mut HistoricalIdIndex,
+) -> Result<()> {
+    let files = git_tree_files(repository_root, commit, spec_root_relative)?;
+    for file in files {
+        if !is_yaml_file(&file) {
+            continue;
+        }
+
+        if is_under_section(&file, spec_root_relative, "philosophy") {
+            if let Some(document) =
+                parse_blob::<PhilosophyDocument>(repository_root, commit, &file)?
+            {
+                for item in document.philosophies {
+                    record_id(index, SectionKind::Philosophy, item.id);
+                }
+            }
+        } else if is_under_section(&file, spec_root_relative, "policies") {
+            if let Some(document) = parse_blob::<PolicyDocument>(repository_root, commit, &file)? {
+                for item in document.policies {
+                    record_id(index, SectionKind::Policies, item.id);
+                }
+            }
+        } else if is_under_section(&file, spec_root_relative, "requirements") {
+            if let Some(document) =
+                parse_blob::<RequirementDocument>(repository_root, commit, &file)?
+            {
+                for item in document.requirements {
+                    record_id(index, SectionKind::Requirements, item.id);
+                }
+            }
+        } else if is_under_section(&file, spec_root_relative, "features") {
+            if file.ends_with("features.yaml") {
+                continue;
+            }
+
+            if let Some(document) = parse_feature_blob(repository_root, commit, &file)? {
+                for item in document.features {
+                    record_id(index, SectionKind::Features, item.id);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_feature_blob(
+    repository_root: &Path,
+    commit: &str,
+    path: &str,
+) -> Result<Option<FeatureDocument>> {
+    let Some(raw) = git_blob(repository_root, commit, path)? else {
+        return Ok(None);
+    };
+    let value: serde_yaml::Value = match serde_yaml::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    let Some(mapping) = value.as_mapping() else {
+        return Ok(None);
+    };
+    if !mapping.contains_key(serde_yaml::Value::String("features".to_string())) {
+        return Ok(None);
+    }
+    Ok(Some(serde_yaml::from_str(&raw).with_context(|| {
+        format!("failed to parse feature document `{path}` at `{commit}`")
+    })?))
+}
+
+fn parse_blob<T>(repository_root: &Path, commit: &str, path: &str) -> Result<Option<T>>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    let Some(raw) = git_blob(repository_root, commit, path)? else {
+        return Ok(None);
+    };
+    Ok(Some(serde_yaml::from_str(&raw).with_context(|| {
+        format!("failed to parse historical blob `{path}` at `{commit}`")
+    })?))
+}
+
+fn git_blob(repository_root: &Path, commit: &str, path: &str) -> Result<Option<String>> {
+    let spec = format!("{commit}:{path}");
+    let output = git_command(repository_root)
+        .arg("show")
+        .arg(&spec)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git show {spec}` in `{}`",
+                repository_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(
+        String::from_utf8(output.stdout).context("git blob output should be valid UTF-8")?,
+    ))
+}
+
+fn git_tree_files(
+    repository_root: &Path,
+    commit: &str,
+    spec_root_relative: &Path,
+) -> Result<Vec<String>> {
+    let spec_root = spec_root_relative.to_string_lossy().to_string();
+    let output = git_command(repository_root)
+        .arg("ls-tree")
+        .arg("-r")
+        .arg("--name-only")
+        .arg(commit)
+        .arg("--")
+        .arg(&spec_root)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git ls-tree {commit}` in `{}`",
+                repository_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "failed to enumerate historical files for `{commit}` in `{}`: {}",
+            repository_root.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout =
+        String::from_utf8(output.stdout).context("git ls-tree output should be valid UTF-8")?;
+    Ok(stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn is_yaml_file(path: &str) -> bool {
+    path.ends_with(".yaml") || path.ends_with(".yml")
+}
+
+fn is_under_section(path: &str, spec_root_relative: &Path, section: &str) -> bool {
+    let prefix = format!(
+        "{}/{}",
+        spec_root_relative.to_string_lossy().replace('\\', "/"),
+        section
+    );
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
+
+fn record_id(index: &mut HistoricalIdIndex, kind: SectionKind, id: String) {
+    index.ids_by_value.insert(id.clone());
+    index.ids_by_section.entry(kind).or_default().insert(id);
+}
+
+fn git_command(workspace_root: &Path) -> Command {
+    let mut command = Command::new("git");
+    command.current_dir(workspace_root);
+    command
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -93,10 +93,9 @@ pub(crate) fn build_historical_id_index(
             &start_ref,
             &mut index,
         )?;
-        commits.extend(git_rev_list(
-            &repository_root,
-            &format!("{start_ref}..HEAD"),
-        )?);
+        let commit_range = format!("{start_ref}..HEAD");
+        let later_commits = git_rev_list(&repository_root, &commit_range)?;
+        commits.extend(later_commits);
         commits
     } else {
         git_rev_list(&repository_root, "HEAD")?
@@ -128,8 +127,11 @@ fn git_repository_root(workspace_root: &Path) -> Result<PathBuf> {
         );
     }
 
-    let root =
-        String::from_utf8(output.stdout).context("git repository root should be valid UTF-8")?;
+    parse_git_repository_root_stdout(output.stdout, workspace_root)
+}
+
+fn parse_git_repository_root_stdout(stdout: Vec<u8>, workspace_root: &Path) -> Result<PathBuf> {
+    let root = String::from_utf8(stdout).context("git repository root should be valid UTF-8")?;
     let root = root.trim();
     if root.is_empty() {
         bail!(
@@ -179,43 +181,64 @@ fn record_commit_snapshot(
 ) -> Result<()> {
     let files = git_tree_files(repository_root, commit, spec_root_relative)?;
     for file in files {
-        if !is_yaml_file(&file) {
-            continue;
-        }
+        record_snapshot_file(repository_root, spec_root_relative, commit, &file, index)?;
+    }
 
-        if is_under_section(&file, spec_root_relative, "philosophy") {
-            if let Some(document) =
-                parse_blob::<PhilosophyDocument>(repository_root, commit, &file)?
-            {
+    Ok(())
+}
+
+fn record_snapshot_file(
+    repository_root: &Path,
+    spec_root_relative: &Path,
+    commit: &str,
+    file: &str,
+    index: &mut HistoricalIdIndex,
+) -> Result<()> {
+    if !is_yaml_file(file) {
+        return Ok(());
+    }
+
+    if is_under_section(file, spec_root_relative, "philosophy") {
+        parse_blob::<PhilosophyDocument>(repository_root, commit, file)?
+            .into_iter()
+            .for_each(|document| {
                 for item in document.philosophies {
                     record_id(index, SectionKind::Philosophy, item.id);
                 }
-            }
-        } else if is_under_section(&file, spec_root_relative, "policies") {
-            if let Some(document) = parse_blob::<PolicyDocument>(repository_root, commit, &file)? {
+            });
+        return Ok(());
+    }
+
+    if is_under_section(file, spec_root_relative, "policies") {
+        parse_blob::<PolicyDocument>(repository_root, commit, file)?
+            .into_iter()
+            .for_each(|document| {
                 for item in document.policies {
                     record_id(index, SectionKind::Policies, item.id);
                 }
-            }
-        } else if is_under_section(&file, spec_root_relative, "requirements") {
-            if let Some(document) =
-                parse_blob::<RequirementDocument>(repository_root, commit, &file)?
-            {
+            });
+        return Ok(());
+    }
+
+    if is_under_section(file, spec_root_relative, "requirements") {
+        parse_blob::<RequirementDocument>(repository_root, commit, file)?
+            .into_iter()
+            .for_each(|document| {
                 for item in document.requirements {
                     record_id(index, SectionKind::Requirements, item.id);
                 }
-            }
-        } else if is_under_section(&file, spec_root_relative, "features") {
-            if file.ends_with("features.yaml") {
-                continue;
-            }
+            });
+        return Ok(());
+    }
 
-            if let Some(document) = parse_feature_blob(repository_root, commit, &file)? {
+    if is_under_section(file, spec_root_relative, "features") && !file.ends_with("features.yaml") {
+        parse_feature_blob(repository_root, commit, file)?
+            .into_iter()
+            .for_each(|document| {
                 for item in document.features {
                     record_id(index, SectionKind::Features, item.id);
                 }
-            }
-        }
+            });
     }
 
     Ok(())
@@ -580,6 +603,94 @@ mod tests {
     }
 
     #[test]
+    fn build_historical_id_index_handles_empty_historical_documents() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+
+        fs::create_dir_all(workspace.join("philosophy")).expect("philosophy dir");
+        fs::create_dir_all(workspace.join("policies")).expect("policies dir");
+        fs::create_dir_all(workspace.join("requirements/core")).expect("requirements dir");
+        fs::create_dir_all(workspace.join("features")).expect("features dir");
+        fs::write(
+            workspace.join("philosophy/empty.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies: []\n",
+        )
+        .expect("philosophy file");
+        fs::write(
+            workspace.join("policies/empty.yaml"),
+            "category: Policy\nversion: 1\nlanguage: en\npolicies: []\n",
+        )
+        .expect("policy file");
+        fs::write(
+            workspace.join("requirements/core/empty.yaml"),
+            "category: Core History\nprefix: REQ-HIST\nrequirements: []\n",
+        )
+        .expect("requirement file");
+        fs::write(
+            workspace.join("features/empty.yaml"),
+            "category: History\nversion: 1\nfeatures: []\n",
+        )
+        .expect("feature file");
+
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add empty historical sections");
+
+        let config = SyuConfig {
+            spec: crate::config::SpecConfig {
+                root: PathBuf::from("."),
+            },
+            ..SyuConfig::default()
+        };
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+
+        assert!(index.available());
+        assert!(!index.contains("REQ-HIST-MISSING-001"));
+    }
+
+    #[test]
+    fn build_historical_id_index_surfaces_start_ref_snapshot_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+        fs::write(workspace.join("placeholder.txt"), "placeholder\n").expect("placeholder file");
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "chore: initialize repository");
+
+        let mut config = SyuConfig::default();
+        config.spec.root = PathBuf::from(".");
+        config.validate.historical_ids.start_ref = Some("definitely-not-a-ref".to_string());
+
+        let error = build_historical_id_index(workspace, &config)
+            .expect_err("invalid start ref should fail while recording the start snapshot");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to enumerate historical files"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn build_historical_id_index_handles_empty_start_ref_ranges() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+        fs::write(workspace.join("placeholder.txt"), "placeholder\n").expect("placeholder file");
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "chore: initialize repository");
+        let start_ref = git_stdout(workspace, &["rev-parse", "HEAD"]);
+
+        let mut config = SyuConfig::default();
+        config.spec.root = PathBuf::from(".");
+        config.validate.historical_ids.start_ref = Some(start_ref);
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(index.available());
+    }
+
+    #[test]
     fn historical_id_helpers_surface_git_and_parse_errors() {
         let tempdir = tempdir().expect("tempdir should exist");
         let workspace = tempdir.path();
@@ -655,6 +766,20 @@ mod tests {
                 .is_none()
         );
         assert!(parse_feature_blob(workspace, &commit, "features/structured.yaml").is_err());
+    }
+
+    #[test]
+    fn git_repository_root_rejects_empty_stdout() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let error = parse_git_repository_root_stdout(Vec::new(), tempdir.path())
+            .expect_err("empty git root should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("git rev-parse returned an empty repository root"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -390,6 +390,23 @@ mod tests {
         );
     }
 
+    fn git_stdout(workspace: &Path, args: &[&str]) -> String {
+        let mut command = Command::new("git");
+        command.arg("-C").arg(workspace).args(args);
+        let output = command.output().expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git output should be utf8")
+            .trim()
+            .to_string()
+    }
+
     fn git_commit(workspace: &Path, summary: &str) {
         let timestamp = COMMIT_TIMESTAMP.fetch_add(1, Ordering::Relaxed);
         let timestamp = format!("{timestamp} +0000");
@@ -413,6 +430,19 @@ mod tests {
         git(workspace, &["init"]);
         git(workspace, &["config", "user.name", "Test User"]);
         git(workspace, &["config", "user.email", "test@example.com"]);
+    }
+
+    #[test]
+    fn build_historical_id_index_returns_disabled_index_when_disabled() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        let mut config = SyuConfig::default();
+        config.validate.historical_ids.enabled = false;
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(!index.enabled());
+        assert!(!index.available());
+        assert!(!index.contains("PHIL-HIST-000"));
     }
 
     #[test]
@@ -450,6 +480,71 @@ mod tests {
         let index = build_historical_id_index(workspace, &config).expect("index should build");
         assert!(index.available());
         assert!(index.contains("PHIL-HIST-ROOT-001"));
+    }
+
+    #[test]
+    fn build_historical_id_index_skips_external_spec_roots() {
+        let workspace_dir = tempdir().expect("tempdir should exist");
+        let workspace = workspace_dir.path();
+        init_git_repository(workspace);
+        fs::write(workspace.join("placeholder.txt"), "placeholder\n").expect("placeholder file");
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "chore: initialize repository");
+
+        let external = tempdir().expect("external tempdir should exist");
+        let mut config = SyuConfig::default();
+        config.spec.root = external.path().join("external-spec");
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(index.enabled());
+        assert!(!index.available());
+    }
+
+    #[test]
+    fn build_historical_id_index_honors_start_refs_and_skips_feature_docs_without_features_lists() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+
+        fs::create_dir_all(workspace.join("philosophy")).expect("philosophy dir");
+        fs::create_dir_all(workspace.join("features")).expect("features dir");
+
+        fs::write(
+            workspace.join("philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-START-001\n    title: Start refs should be indexed.\n    product_design_principle: History should include the start ref snapshot.\n    coding_guideline: Keep invalid feature documents out of the index.\n    linked_policies: []\n",
+        )
+        .expect("philosophy file");
+        fs::write(
+            workspace.join("features/features.yaml"),
+            "version: \"1\"\nfiles: []\n",
+        )
+        .expect("feature registry");
+        fs::write(
+            workspace.join("features/valid.yaml"),
+            "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-START-001\n    title: Start refs should be indexed.\n    summary: Start refs should include valid feature documents.\n    status: implemented\n    linked_requirements: []\n    implementations: {}\n",
+        )
+        .expect("feature file");
+
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add historical id start ref fixture");
+        let start_ref = git_stdout(workspace, &["rev-parse", "HEAD"]);
+
+        fs::write(
+            workspace.join("features/broken.yaml"),
+            "category: History\nversion: 1\nstories: []\n",
+        )
+        .expect("broken feature file");
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add ignored historical feature fixture");
+
+        let mut config = SyuConfig::default();
+        config.spec.root = PathBuf::from(".");
+        config.validate.historical_ids.start_ref = Some(start_ref);
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(index.available());
+        assert!(index.contains("PHIL-HIST-START-001"));
+        assert!(index.contains("FEAT-HIST-START-001"));
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -381,12 +381,14 @@ mod tests {
         let mut command = Command::new("git");
         command.arg("-C").arg(workspace).args(args);
         let output = command.output().expect("git should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             output.status.success(),
             "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
             args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            stdout,
+            stderr
         );
     }
 
@@ -394,12 +396,14 @@ mod tests {
         let mut command = Command::new("git");
         command.arg("-C").arg(workspace).args(args);
         let output = command.output().expect("git should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             output.status.success(),
             "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
             args,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            stdout,
+            stderr
         );
         String::from_utf8(output.stdout)
             .expect("git output should be utf8")
@@ -418,11 +422,13 @@ mod tests {
             .env("GIT_AUTHOR_DATE", &timestamp)
             .env("GIT_COMMITTER_DATE", &timestamp);
         let output = command.output().expect("git commit should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             output.status.success(),
             "git commit failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            stdout,
+            stderr
         );
     }
 
@@ -501,12 +507,25 @@ mod tests {
     }
 
     #[test]
+    fn build_historical_id_index_returns_unavailable_when_workspace_is_not_a_git_repository() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        let config = SyuConfig::default();
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(index.enabled());
+        assert!(!index.available());
+    }
+
+    #[test]
     fn build_historical_id_index_honors_start_refs_and_skips_feature_docs_without_features_lists() {
         let tempdir = tempdir().expect("tempdir should exist");
         let workspace = tempdir.path();
         init_git_repository(workspace);
 
         fs::create_dir_all(workspace.join("philosophy")).expect("philosophy dir");
+        fs::create_dir_all(workspace.join("policies")).expect("policies dir");
+        fs::create_dir_all(workspace.join("requirements/core")).expect("requirements dir");
         fs::create_dir_all(workspace.join("features")).expect("features dir");
 
         fs::write(
@@ -514,6 +533,16 @@ mod tests {
             "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-START-001\n    title: Start refs should be indexed.\n    product_design_principle: History should include the start ref snapshot.\n    coding_guideline: Keep invalid feature documents out of the index.\n    linked_policies: []\n",
         )
         .expect("philosophy file");
+        fs::write(
+            workspace.join("policies/policies.yaml"),
+            "category: Policy\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-HIST-START-001\n    title: Policy history should be indexed.\n    summary: Start refs should include policy documents.\n    description: Cover the policy branch in the historical index.\n    linked_philosophies: []\n    linked_requirements: []\n",
+        )
+        .expect("policy file");
+        fs::write(
+            workspace.join("requirements/core/req.yaml"),
+            "category: Core History\nprefix: REQ-HIST\nrequirements:\n  - id: REQ-HIST-START-001\n    title: Requirement history should be indexed.\n    description: Start refs should include requirement documents.\n    priority: medium\n    status: implemented\n    linked_policies: []\n    linked_features: []\n    tests: {}\n",
+        )
+        .expect("requirement file");
         fs::write(
             workspace.join("features/features.yaml"),
             "version: \"1\"\nfiles: []\n",
@@ -524,6 +553,7 @@ mod tests {
             "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-START-001\n    title: Start refs should be indexed.\n    summary: Start refs should include valid feature documents.\n    status: implemented\n    linked_requirements: []\n    implementations: {}\n",
         )
         .expect("feature file");
+        fs::write(workspace.join("notes.txt"), "ignore me\n").expect("non-yaml file");
 
         git(workspace, &["add", "."]);
         git_commit(workspace, "docs: add historical id start ref fixture");
@@ -544,7 +574,98 @@ mod tests {
         let index = build_historical_id_index(workspace, &config).expect("index should build");
         assert!(index.available());
         assert!(index.contains("PHIL-HIST-START-001"));
+        assert!(index.contains("POL-HIST-START-001"));
+        assert!(index.contains("REQ-HIST-START-001"));
         assert!(index.contains("FEAT-HIST-START-001"));
+    }
+
+    #[test]
+    fn historical_id_helpers_surface_git_and_parse_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+
+        fs::write(
+            workspace.join("philosophy.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-BROKEN-001\n    title: Broken documents should fail to parse.\n    product_design_principle: Historical parsing errors should remain visible.\n    coding_guideline: Keep YAML failures explicit.\n    linked_policies: []\n    - invalid\n",
+        )
+        .expect("malformed philosophy file");
+        fs::create_dir_all(workspace.join("features")).expect("features dir");
+        fs::write(
+            workspace.join("features/broken.yaml"),
+            "category: History\nversion: 1\nstories: []\n",
+        )
+        .expect("broken feature file");
+        fs::write(
+            workspace.join("features/invalid.yaml"),
+            "category: History\nversion: 1\nfeatures: [\n",
+        )
+        .expect("invalid feature file");
+        fs::write(
+            workspace.join("features/not-a-mapping.yaml"),
+            "- 1\n",
+        )
+        .expect("non-mapping feature file");
+        fs::write(
+            workspace.join("features/structured.yaml"),
+            "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-STRUCT-001\n    title: Structured feature docs should parse.\n    summary: Structured feature docs should hit the parse-error path.\n    status: implemented\n    linked_requirements: []\n    implementations: []\n",
+        )
+        .expect("structured feature file");
+
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add malformed historical fixtures");
+        let commit = git_stdout(workspace, &["rev-parse", "HEAD"]);
+        let missing_repo = workspace.join("missing-repo");
+
+        assert!(git_repository_root(&missing_repo).is_err());
+        assert!(git_rev_list(workspace, "definitely-not-a-revision").is_err());
+        assert!(git_rev_list(&missing_repo, "HEAD").is_err());
+        assert!(
+            git_tree_files(
+                workspace,
+                "definitely-not-a-commit",
+                std::path::Path::new("")
+            )
+            .is_err()
+        );
+        assert!(git_tree_files(&missing_repo, "HEAD", std::path::Path::new("")).is_err());
+        assert!(git_blob(&missing_repo, "HEAD", "philosophy.yaml").is_err());
+
+        assert!(parse_blob::<PhilosophyDocument>(
+            workspace,
+            &commit,
+            "philosophy.yaml"
+        )
+        .is_err());
+        assert!(
+            parse_blob::<PhilosophyDocument>(workspace, &commit, "missing.yaml")
+                .expect("missing historical blob lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            parse_feature_blob(workspace, &commit, "features/broken.yaml")
+                .expect("feature blob lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            parse_feature_blob(workspace, &commit, "features/missing.yaml")
+                .expect("missing feature blob lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            parse_feature_blob(workspace, &commit, "features/invalid.yaml")
+                .expect("invalid feature blob lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            parse_feature_blob(workspace, &commit, "features/not-a-mapping.yaml")
+                .expect("non-mapping feature blob lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            parse_feature_blob(workspace, &commit, "features/structured.yaml")
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -601,11 +601,8 @@ mod tests {
             "category: History\nversion: 1\nfeatures: [\n",
         )
         .expect("invalid feature file");
-        fs::write(
-            workspace.join("features/not-a-mapping.yaml"),
-            "- 1\n",
-        )
-        .expect("non-mapping feature file");
+        fs::write(workspace.join("features/not-a-mapping.yaml"), "- 1\n")
+            .expect("non-mapping feature file");
         fs::write(
             workspace.join("features/structured.yaml"),
             "category: History\nversion: 1\nfeatures:\n  - id: FEAT-HIST-STRUCT-001\n    title: Structured feature docs should parse.\n    summary: Structured feature docs should hit the parse-error path.\n    status: implemented\n    linked_requirements: []\n    implementations: []\n",
@@ -631,12 +628,7 @@ mod tests {
         assert!(git_tree_files(&missing_repo, "HEAD", std::path::Path::new("")).is_err());
         assert!(git_blob(&missing_repo, "HEAD", "philosophy.yaml").is_err());
 
-        assert!(parse_blob::<PhilosophyDocument>(
-            workspace,
-            &commit,
-            "philosophy.yaml"
-        )
-        .is_err());
+        assert!(parse_blob::<PhilosophyDocument>(workspace, &commit, "philosophy.yaml").is_err());
         assert!(
             parse_blob::<PhilosophyDocument>(workspace, &commit, "missing.yaml")
                 .expect("missing historical blob lookup should succeed")
@@ -662,10 +654,7 @@ mod tests {
                 .expect("non-mapping feature blob lookup should succeed")
                 .is_none()
         );
-        assert!(
-            parse_feature_blob(workspace, &commit, "features/structured.yaml")
-                .is_err()
-        );
+        assert!(parse_feature_blob(workspace, &commit, "features/structured.yaml").is_err());
     }
 
     #[test]

--- a/src/history.rs
+++ b/src/history.rs
@@ -81,8 +81,8 @@ pub(crate) fn build_historical_id_index(
     };
     let spec_root = resolve_spec_root(&workspace_root, config);
     let spec_root_relative = match spec_root.strip_prefix(&repository_root) {
-        Ok(relative) if !relative.as_os_str().is_empty() => relative.to_path_buf(),
-        _ => return Ok(index),
+        Ok(relative) => relative.to_path_buf(),
+        Err(_) => return Ok(index),
     };
 
     let commits = if let Some(start_ref) = index.start_ref.clone() {
@@ -269,11 +269,24 @@ fn git_blob(repository_root: &Path, commit: &str, path: &str) -> Result<Option<S
             )
         })?;
     if !output.status.success() {
-        return Ok(None);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if git_blob_missing(&stderr, commit, path) {
+            return Ok(None);
+        }
+
+        bail!(
+            "failed to read historical blob `{path}` at `{commit}` in `{}`: {}",
+            repository_root.display(),
+            stderr.trim()
+        );
     }
     Ok(Some(
         String::from_utf8(output.stdout).context("git blob output should be valid UTF-8")?,
     ))
+}
+
+fn git_blob_missing(stderr: &str, commit: &str, path: &str) -> bool {
+    stderr.contains(&format!("path '{path}' does not exist in '{commit}'"))
 }
 
 fn git_tree_files(
@@ -281,14 +294,13 @@ fn git_tree_files(
     commit: &str,
     spec_root_relative: &Path,
 ) -> Result<Vec<String>> {
-    let spec_root = spec_root_relative.to_string_lossy().to_string();
     let output = git_command(repository_root)
         .arg("ls-tree")
         .arg("-r")
         .arg("--name-only")
         .arg(commit)
         .arg("--")
-        .arg(&spec_root)
+        .args(spec_root_arg(spec_root_relative))
         .output()
         .with_context(|| {
             format!(
@@ -314,16 +326,28 @@ fn git_tree_files(
         .collect())
 }
 
+fn spec_root_arg(spec_root_relative: &Path) -> Vec<&Path> {
+    if spec_root_relative.as_os_str().is_empty() {
+        Vec::new()
+    } else {
+        vec![spec_root_relative]
+    }
+}
+
 fn is_yaml_file(path: &str) -> bool {
     path.ends_with(".yaml") || path.ends_with(".yml")
 }
 
 fn is_under_section(path: &str, spec_root_relative: &Path, section: &str) -> bool {
-    let prefix = format!(
-        "{}/{}",
-        spec_root_relative.to_string_lossy().replace('\\', "/"),
-        section
-    );
+    let prefix = if spec_root_relative.as_os_str().is_empty() {
+        section.to_string()
+    } else {
+        format!(
+            "{}/{}",
+            spec_root_relative.to_string_lossy().replace('\\', "/"),
+            section
+        )
+    };
     path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
@@ -336,4 +360,153 @@ fn git_command(workspace_root: &Path) -> Command {
     let mut command = Command::new("git");
     command.current_dir(workspace_root);
     command
+}
+
+#[cfg(test)]
+mod tests {
+    // REQ-CORE-024
+    use super::*;
+
+    use std::{
+        fs,
+        process::Command,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use tempfile::tempdir;
+
+    static COMMIT_TIMESTAMP: AtomicU64 = AtomicU64::new(1_776_355_200);
+
+    fn git(workspace: &Path, args: &[&str]) {
+        let mut command = Command::new("git");
+        command.arg("-C").arg(workspace).args(args);
+        let output = command.output().expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_commit(workspace: &Path, summary: &str) {
+        let timestamp = COMMIT_TIMESTAMP.fetch_add(1, Ordering::Relaxed);
+        let timestamp = format!("{timestamp} +0000");
+        let mut command = Command::new("git");
+        command
+            .arg("-C")
+            .arg(workspace)
+            .args(["commit", "-m", summary])
+            .env("GIT_AUTHOR_DATE", &timestamp)
+            .env("GIT_COMMITTER_DATE", &timestamp);
+        let output = command.output().expect("git commit should run");
+        assert!(
+            output.status.success(),
+            "git commit failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_git_repository(workspace: &Path) {
+        git(workspace, &["init"]);
+        git(workspace, &["config", "user.name", "Test User"]);
+        git(workspace, &["config", "user.email", "test@example.com"]);
+    }
+
+    #[test]
+    fn build_historical_id_index_supports_repository_root_spec_roots() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+
+        fs::create_dir_all(workspace.join("philosophy")).expect("philosophy dir");
+        fs::create_dir_all(workspace.join("policies")).expect("policies dir");
+        fs::create_dir_all(workspace.join("requirements")).expect("requirements dir");
+        fs::create_dir_all(workspace.join("features")).expect("features dir");
+
+        fs::write(
+            workspace.join("philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-ROOT-001\n    title: Root history should be indexed.\n    product_design_principle: Keep the root spec root indexed.\n    coding_guideline: Support repository-root configurations.\n    linked_policies: []\n",
+        )
+        .expect("philosophy file");
+        fs::write(
+            workspace.join("features/features.yaml"),
+            "version: \"1\"\nfiles: []\n",
+        )
+        .expect("feature registry");
+
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add root historical ids");
+
+        let config = SyuConfig {
+            spec: crate::config::SpecConfig {
+                root: PathBuf::from("."),
+            },
+            ..SyuConfig::default()
+        };
+
+        let index = build_historical_id_index(workspace, &config).expect("index should build");
+        assert!(index.available());
+        assert!(index.contains("PHIL-HIST-ROOT-001"));
+    }
+
+    #[test]
+    fn git_blob_distinguishes_missing_paths_from_unexpected_errors() {
+        let tempdir = tempdir().expect("tempdir should exist");
+        let workspace = tempdir.path();
+        init_git_repository(workspace);
+
+        fs::write(
+            workspace.join("philosophy.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-HIST-002\n    title: Blob lookup should work.\n    product_design_principle: Missing paths are normal; invalid commits are not.\n    coding_guideline: Keep Git failures visible.\n    linked_policies: []\n",
+        )
+        .expect("philosophy file");
+        git(workspace, &["add", "."]);
+        git_commit(workspace, "docs: add blob lookup fixture");
+
+        let commit = {
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(workspace)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .expect("git rev-parse should run");
+            assert!(output.status.success(), "git rev-parse failed");
+            String::from_utf8(output.stdout)
+                .expect("commit should be utf8")
+                .trim()
+                .to_string()
+        };
+
+        assert_eq!(
+            git_blob(workspace, &commit, "missing.yaml").expect("missing path lookup"),
+            None
+        );
+
+        let error = git_blob(workspace, "definitely-not-a-commit", "philosophy.yaml")
+            .expect_err("invalid commit should surface as an error");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to read historical blob `philosophy.yaml`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn git_blob_missing_matches_git_show_missing_path_errors() {
+        let stderr = "fatal: path 'docs/syu/philosophy/foundation.yaml' does not exist in 'HEAD'";
+        assert!(git_blob_missing(
+            stderr,
+            "HEAD",
+            "docs/syu/philosophy/foundation.yaml"
+        ));
+        assert!(!git_blob_missing(
+            "fatal: invalid object name 'HEAD'",
+            "HEAD",
+            "docs/syu/philosophy/foundation.yaml"
+        ));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cli;
 pub mod command;
 pub mod config;
 pub mod coverage;
+pub mod history;
 pub mod inspect;
 pub mod language;
 mod lsp;

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -72,7 +72,8 @@ fn clean_shutdown(status: &std::process::ExitStatus) -> bool {
 }
 
 fn wait_for_server(port: u16) {
-    for _ in 0..80 {
+    // Coverage builds are slower, so give the app more time to finish its startup work.
+    for _ in 0..200 {
         if let Ok(response) = http_get(port, "/health")
             && response.contains("200 OK")
             && response.contains("\"status\":\"ok\"")
@@ -149,7 +150,7 @@ fn spawn_fake_vite_server() -> std::thread::JoinHandle<()> {
 }
 
 fn wait_for_output_fragment(path: &Path, fragment: &str) {
-    for _ in 0..80 {
+    for _ in 0..200 {
         if fs::read_to_string(path)
             .map(|contents| contents.contains(fragment))
             .unwrap_or(false)


### PR DESCRIPTION
Summary:
- Add a git-backed historical ID index for philosophy, policy, requirement, and feature documents.
- Thread the index through app payloads and use it to block `syu add` from reusing historical IDs.
- Add config support for enabling/disabling history scanning and limiting the scan start ref.

Validation:
- `cargo test build_historical_id_index_collects_ids_across_layers_and_history --lib`
- `cargo test load_config_parses_workspace_override --lib`
- `cargo test build_app_payload_surfaces_validation_snapshot_details --lib`
- `cargo test run_add_command_rejects_historical_ids_that_no_longer_exist_currently --lib`
- `cargo fmt --all --check`

Closes #636
