### PR TITLE
Add syu task classify for request artifacts

### DIFF
--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -1,0 +1,74 @@
+---
+title: "Task Planning CLI / Task"
+description: "Generated reference for docs/syu/features/cli/task.yaml"
+---
+
+> Generated from `docs/syu/features/cli/task.yaml`.
+
+## Parsed content
+
+### Category
+
+- Task Planning CLI
+
+### Version
+
+- 1
+
+### Features
+
+- **id**: FEAT-TASK-001
+  - **title**: Request artifact classification
+  - **summary**: Classify captured request artifacts into requirement create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-028
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - run_task_command
+          - run_task_classify_command
+      - **file**: src/cli.rs
+        - **symbols**:
+          - TaskArgs
+          - TaskClassifyArgs
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatches_task_subcommands_without_rewriting_them
+    - **markdown**:
+      - **file**: docs/guide/request-artifact-format.md
+        - **symbols**:
+          - syu task classify
+
+## Source YAML
+
+```yaml
+category: Task Planning CLI
+version: 1
+
+features:
+  - id: FEAT-TASK-001
+    title: Request artifact classification
+    summary: Classify captured request artifacts into requirement create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-028
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_classify_command
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskClassifyArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatches_task_subcommands_without_rewriting_them
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task classify
+```

--- a/docs/generated/site-spec/features/features.md
+++ b/docs/generated/site-spec/features/features.md
@@ -41,6 +41,8 @@ description: "Generated reference for docs/syu/features/features.yaml"
   - **file**: cli/init.yaml
 - **kind**: add
   - **file**: cli/add.yaml
+- **kind**: task
+  - **file**: cli/task.yaml
 - **kind**: doctor
   - **file**: cli/doctor.yaml
 - **kind**: report
@@ -93,6 +95,8 @@ files:
     file: cli/init.yaml
   - kind: add
     file: cli/add.yaml
+  - kind: task
+    file: cli/task.yaml
   - kind: doctor
     file: cli/doctor.yaml
   - kind: report

--- a/docs/generated/site-spec/index.md
+++ b/docs/generated/site-spec/index.md
@@ -26,6 +26,7 @@ This section is generated from the YAML source under `docs/syu/`.
 - [Report Command / Report](features/cli/report)
 - [Lookup Search CLI / Search](features/cli/search)
 - [Lookup CLI / Show List](features/cli/show-list)
+- [Task Planning CLI / Task](features/cli/task)
 - [Trace Lookup CLI / Trace](features/cli/trace)
 - [Documentation / Docs](features/documentation/docs)
 - [Agent Skills / Skills](features/documentation/skills)

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -43,6 +43,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-021
     - REQ-CORE-023
     - REQ-CORE-025
+    - REQ-CORE-028
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -70,6 +71,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-024
     - REQ-CORE-025
     - REQ-CORE-026
+    - REQ-CORE-028
 - **id**: POL-003
   - **title**: Traceability should prove ownership from specification to code and tests
   - **summary**: Declared traces should map to real files, real symbols, optional full-file ownership, and derivable repository history.
@@ -122,6 +124,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-025
     - REQ-CORE-026
     - REQ-CORE-027
+    - REQ-CORE-028
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -225,6 +228,7 @@ policies:
       - REQ-CORE-021
       - REQ-CORE-023
       - REQ-CORE-025
+      - REQ-CORE-028
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -252,6 +256,7 @@ policies:
       - REQ-CORE-024
       - REQ-CORE-025
       - REQ-CORE-026
+      - REQ-CORE-028
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -304,6 +309,7 @@ policies:
       - REQ-CORE-025
       - REQ-CORE-026
       - REQ-CORE-027
+      - REQ-CORE-028
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -557,6 +557,45 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - explain_text_handles_gaps_and_empty_sections
           - explain_text_renders_file_only_traces_and_definition_matches
           - explain_text_renders_direct_trace_symbols
+- **id**: REQ-CORE-028
+  - **title**: Provide request-first task classification for requirement planning
+  - **description**:
+    - |
+      The CLI MUST provide a `task classify` command that reads a captured
+      request artifact and the current spec graph, then classifies the request
+      into a requirement create, change, or delete decision with a short
+      explanation. The command MUST emit both text and JSON output, SHOULD make
+      the request artifact and the closest existing spec items visible in the
+      result, and MUST stay focused on the request plus the current spec graph
+      without needing source-code inspection for the first version.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-002
+    - POL-004
+  - **linked_features**:
+    - FEAT-TASK-001
+  - **tests**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - *
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatches_lookup_subcommands_without_rewriting_them
+          - dispatches_task_subcommands_without_rewriting_them
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - task_help_mentions_request_artifacts_and_json_output
+      - **file**: tests/task_command.rs
+        - **symbols**:
+          - task_classify_prints_text_output
+          - task_classify_prints_json_output
+    - **markdown**:
+      - **file**: docs/guide/request-artifact-format.md
+        - **symbols**:
+          - syu task classify
 
 ## Source YAML
 
@@ -1091,4 +1130,42 @@ requirements:
             - explain_text_handles_gaps_and_empty_sections
             - explain_text_renders_file_only_traces_and_definition_matches
             - explain_text_renders_direct_trace_symbols
+  - id: REQ-CORE-028
+    title: Provide request-first task classification for requirement planning
+    description: |
+      The CLI MUST provide a `task classify` command that reads a captured
+      request artifact and the current spec graph, then classifies the request
+      into a requirement create, change, or delete decision with a short
+      explanation. The command MUST emit both text and JSON output, SHOULD make
+      the request artifact and the closest existing spec items visible in the
+      result, and MUST stay focused on the request plus the current spec graph
+      without needing source-code inspection for the first version.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-TASK-001
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - '*'
+        - file: src/lib.rs
+          symbols:
+            - dispatches_lookup_subcommands_without_rewriting_them
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: tests/help_command.rs
+          symbols:
+            - task_help_mentions_request_artifacts_and_json_output
+        - file: tests/task_command.rs
+          symbols:
+            - task_classify_prints_text_output
+            - task_classify_prints_json_output
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task classify
 ```

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -592,6 +592,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
         - **symbols**:
           - task_classify_prints_text_output
           - task_classify_prints_json_output
+          - task_classify_handles_requests_without_matches
     - **markdown**:
       - **file**: docs/guide/request-artifact-format.md
         - **symbols**:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -1165,6 +1165,7 @@ requirements:
           symbols:
             - task_classify_prints_text_output
             - task_classify_prints_json_output
+            - task_classify_handles_requests_without_matches
       markdown:
         - file: docs/guide/request-artifact-format.md
           symbols:

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -592,6 +592,8 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
         - **symbols**:
           - task_classify_prints_text_output
           - task_classify_prints_json_output
+          - task_classify_reports_related_items_without_explicit_ids
+          - task_classify_reports_explicit_items_from_all_spec_layers
           - task_classify_handles_requests_without_matches
     - **markdown**:
       - **file**: docs/guide/request-artifact-format.md
@@ -1165,6 +1167,8 @@ requirements:
           symbols:
             - task_classify_prints_text_output
             - task_classify_prints_json_output
+            - task_classify_reports_related_items_without_explicit_ids
+            - task_classify_reports_explicit_items_from_all_spec_layers
             - task_classify_handles_requests_without_matches
       markdown:
         - file: docs/guide/request-artifact-format.md

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,6 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 126/126
+- Feature-to-implementation traceability: 140/140
 
 ## Issues
 

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 8
-- Requirements: 27
-- Features: 35
+- Requirements: 28
+- Features: 36
 
 ## Traceability
 
-- Requirement-to-test traceability: 120/120
-- Feature-to-implementation traceability: 136/136
+- Requirement-to-test traceability: 125/125
+- Feature-to-implementation traceability: 140/140
 
 ## Issues
 

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,8 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 125/125
-- Feature-to-implementation traceability: 140/140
+- Requirement-to-test traceability: 126/126
 
 ## Issues
 

--- a/docs/guide/request-artifact-format.md
+++ b/docs/guide/request-artifact-format.md
@@ -50,3 +50,7 @@ context:
 The artifact is intentionally smaller than the spec itself. Once the request is
 understood, move the real work into planned requirements and features with the
 normal spec workflow.
+
+For a quick planning pass, `syu task classify request.yaml` can read the
+artifact and the current spec graph, then return a requirement create, change,
+or delete decision with an explanation in text or JSON.

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -1,0 +1,27 @@
+category: Task Planning CLI
+version: 1
+
+features:
+  - id: FEAT-TASK-001
+    title: Request artifact classification
+    summary: Classify captured request artifacts into requirement create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-028
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_classify_command
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskClassifyArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatches_task_subcommands_without_rewriting_them
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task classify

--- a/docs/syu/features/features.yaml
+++ b/docs/syu/features/features.yaml
@@ -28,6 +28,8 @@ files:
     file: cli/init.yaml
   - kind: add
     file: cli/add.yaml
+  - kind: task
+    file: cli/task.yaml
   - kind: doctor
     file: cli/doctor.yaml
   - kind: report

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -24,6 +24,7 @@ policies:
       - REQ-CORE-021
       - REQ-CORE-023
       - REQ-CORE-025
+      - REQ-CORE-028
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -51,6 +52,7 @@ policies:
       - REQ-CORE-024
       - REQ-CORE-025
       - REQ-CORE-026
+      - REQ-CORE-028
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -103,6 +105,7 @@ policies:
       - REQ-CORE-025
       - REQ-CORE-026
       - REQ-CORE-027
+      - REQ-CORE-028
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -562,6 +562,8 @@ requirements:
           symbols:
             - task_classify_prints_text_output
             - task_classify_prints_json_output
+            - task_classify_reports_related_items_without_explicit_ids
+            - task_classify_reports_explicit_items_from_all_spec_layers
             - task_classify_handles_requests_without_matches
       markdown:
         - file: docs/guide/request-artifact-format.md

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -562,6 +562,7 @@ requirements:
           symbols:
             - task_classify_prints_text_output
             - task_classify_prints_json_output
+            - task_classify_handles_requests_without_matches
       markdown:
         - file: docs/guide/request-artifact-format.md
           symbols:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -528,3 +528,41 @@ requirements:
             - explain_text_handles_gaps_and_empty_sections
             - explain_text_renders_file_only_traces_and_definition_matches
             - explain_text_renders_direct_trace_symbols
+  - id: REQ-CORE-028
+    title: Provide request-first task classification for requirement planning
+    description: |
+      The CLI MUST provide a `task classify` command that reads a captured
+      request artifact and the current spec graph, then classifies the request
+      into a requirement create, change, or delete decision with a short
+      explanation. The command MUST emit both text and JSON output, SHOULD make
+      the request artifact and the closest existing spec items visible in the
+      result, and MUST stay focused on the request plus the current spec graph
+      without needing source-code inspection for the first version.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-TASK-001
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - '*'
+        - file: src/lib.rs
+          symbols:
+            - dispatches_lookup_subcommands_without_rewriting_them
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: tests/help_command.rs
+          symbols:
+            - task_help_mentions_request_artifacts_and_json_output
+        - file: tests/task_command.rs
+          symbols:
+            - task_classify_prints_text_output
+            - task_classify_prints_json_output
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task classify

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,9 @@
 // FEAT-REPORT-001
 // FEAT-INIT-002
 // FEAT-DOCTOR-001
+// FEAT-TASK-001
 // REQ-CORE-001
+// REQ-CORE-028
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
 use clap_complete::Shell;
@@ -33,7 +35,8 @@ New here?
   3. syu init .      scaffold a workspace in the current directory
   4. syu validate .  check the layered spec and traceability
   5. syu browse .    explore the spec in your terminal
-  6. syu app .       start the local browser UI server";
+  6. syu app .       start the local browser UI server
+  7. syu task classify request.yaml  classify a request artifact against the current spec graph";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -76,6 +79,13 @@ Examples:
   syu add feature FEAT-AUTH-LOGIN-001 --kind auth
   syu add feature path/to/workspace --interactive
   syu add feature FEAT-AUTH-001 --kind auth --file docs/syu/features/auth/login.yaml";
+
+const TASK_CLASSIFY_AFTER_HELP: &str = "\
+Examples:
+  syu task classify request.yaml
+  syu task classify request.yaml --format json
+
+Use this when a request has already been captured as a request artifact and you want the current spec graph to decide whether the next requirement-level move is to create, change, or delete.";
 
 const WORKSPACE_HELP: &str = "Workspace root or any child directory; syu walks upward to find syu.yaml and the configured spec tree";
 
@@ -276,6 +286,11 @@ pub enum Commands {
         after_help = ADD_AFTER_HELP
     )]
     Add(AddArgs),
+    #[command(
+        about = "Classify request artifacts against the current spec graph",
+        after_help = TASK_CLASSIFY_AFTER_HELP
+    )]
+    Task(TaskArgs),
     #[command(about = "Start LSP server for editor integrations (JSON-RPC 2.0 over stdio)")]
     Lsp,
 }
@@ -764,6 +779,36 @@ pub struct AddArgs {
     pub kind: Option<String>,
 }
 
+#[derive(Debug, Clone, Args)]
+#[command(subcommand_required = true, arg_required_else_help = true)]
+pub struct TaskArgs {
+    #[command(subcommand)]
+    pub command: TaskCommands,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum TaskCommands {
+    #[command(
+        about = "Classify a request artifact as requirement create, change, or delete",
+        after_help = TASK_CLASSIFY_AFTER_HELP
+    )]
+    Classify(TaskClassifyArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskClassifyArgs {
+    #[arg(help = "YAML request artifact to classify")]
+    pub request: PathBuf,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Output format for the classification result")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum StarterTemplate {
     #[default]
@@ -840,8 +885,8 @@ impl ValidationGenreFilter {
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, CompletionArgs, LookupKind, StarterTemplate, ValidationGenreFilter,
-        ValidationSeverityFilter,
+        Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskClassifyArgs, TaskCommands,
+        ValidationGenreFilter, ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;
@@ -953,6 +998,33 @@ mod tests {
         let rendered = format!("{cli:?}");
         assert!(rendered.contains("command: Some(Templates("));
         assert!(rendered.contains("format: Text"));
+    }
+
+    #[test]
+    fn task_classify_args_parse_request_paths_and_json_format() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "task",
+            "classify",
+            "request.yaml",
+            ".",
+            "--format",
+            "json",
+        ])
+        .expect("task classify args should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(super::Commands::Task(TaskArgs {
+                command: TaskCommands::Classify(TaskClassifyArgs {
+                    request,
+                    workspace,
+                    format,
+                }),
+            })) if request == std::path::Path::new("request.yaml")
+                && workspace == std::path::Path::new(".")
+                && format == super::OutputFormat::Json
+        ));
     }
 
     #[test]

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -20,6 +20,7 @@ pub mod relate;
 pub mod report;
 pub mod search;
 pub mod show;
+pub mod task;
 pub mod templates;
 pub mod trace;
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -324,12 +324,8 @@ fn print_text_output(request_path: &Path, outcome: &ClassificationOutcome) {
     print_items("explicit items", &outcome.explicit_items);
     print_items("related items", &outcome.related_items);
     println!("reasons:");
-    if outcome.reasons.is_empty() {
-        println!("- none");
-    } else {
-        for reason in &outcome.reasons {
-            println!("- {reason}");
-        }
+    for reason in &outcome.reasons {
+        println!("- {reason}");
     }
 }
 
@@ -525,6 +521,34 @@ mod tests {
                 .reasons
                 .iter()
                 .any(|reason| reason.contains("create-oriented language"))
+        );
+    }
+
+    #[test]
+    fn classify_request_merges_related_items_from_analysis_text() {
+        let tempdir = tempdir().expect("tempdir");
+        write_workspace(tempdir.path());
+        let request = tempdir.path().join("request.yaml");
+        fs::write(
+            &request,
+            "version: 1\nrequest: >\n  Classify request artifacts into requirement actions\ncontext: {}\n",
+        )
+        .expect("request artifact should write");
+
+        let workspace = crate::workspace::load_workspace(tempdir.path()).expect("workspace");
+        let artifact = load_request_artifact(&request).expect("request");
+        let outcome = classify_request(&workspace, artifact).expect("classification");
+        assert!(
+            outcome
+                .related_items
+                .iter()
+                .any(|item| item.id == "REQ-CORE-028")
+        );
+        assert!(
+            outcome
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("closest spec graph matches"))
         );
     }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1,0 +1,552 @@
+// FEAT-TASK-001
+// REQ-CORE-028
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    cli::{OutputFormat, TaskArgs, TaskClassifyArgs, TaskCommands},
+    workspace::load_workspace,
+};
+
+use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
+
+const REQUEST_ARTIFACT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RequirementAction {
+    Create,
+    Change,
+    Delete,
+}
+
+impl RequirementAction {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Create => "requirement_create",
+            Self::Change => "requirement_change",
+            Self::Delete => "requirement_delete",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RequestArtifact {
+    version: u32,
+    request: String,
+    #[serde(default)]
+    context: RequestArtifactContext,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RequestArtifactContext {
+    #[serde(default)]
+    affected_area: Option<String>,
+    #[serde(default)]
+    repository_constraints: Vec<String>,
+    #[serde(default)]
+    linked_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskClassifyOutput {
+    request_path: String,
+    request: String,
+    classification: String,
+    reasons: Vec<String>,
+    explicit_items: Vec<SearchResult>,
+    related_items: Vec<SearchResult>,
+    context: JsonRequestArtifactContext,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRequestArtifactContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    affected_area: Option<String>,
+    repository_constraints: Vec<String>,
+    linked_ids: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ClassificationOutcome {
+    classification: RequirementAction,
+    reasons: Vec<String>,
+    explicit_items: Vec<SearchResult>,
+    related_items: Vec<SearchResult>,
+    request: String,
+    context: RequestArtifactContext,
+}
+
+pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
+    match &args.command {
+        TaskCommands::Classify(classify) => run_task_classify_command(classify),
+    }
+}
+
+pub fn run_task_classify_command(args: &TaskClassifyArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let request_artifact = load_request_artifact(&args.request)?;
+    let outcome = classify_request(&workspace, request_artifact)?;
+
+    match args.format {
+        OutputFormat::Text => print_text_output(&args.request, &outcome),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&JsonTaskClassifyOutput {
+                request_path: args.request.display().to_string(),
+                request: outcome.request,
+                classification: outcome.classification.label().to_string(),
+                reasons: outcome.reasons,
+                explicit_items: outcome.explicit_items,
+                related_items: outcome.related_items,
+                context: JsonRequestArtifactContext {
+                    affected_area: outcome.context.affected_area,
+                    repository_constraints: outcome.context.repository_constraints,
+                    linked_ids: outcome.context.linked_ids,
+                },
+            })
+            .expect("serializing task classification output to JSON should succeed")
+        ),
+    }
+
+    Ok(0)
+}
+
+fn load_request_artifact(path: &PathBuf) -> Result<RequestArtifact> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read request artifact `{}`", path.display()))?;
+    let artifact: RequestArtifact = serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse request artifact `{}`", path.display()))?;
+    if artifact.version != REQUEST_ARTIFACT_VERSION {
+        bail!(
+            "unsupported request artifact version `{}` in `{}`",
+            artifact.version,
+            path.display()
+        );
+    }
+    Ok(artifact)
+}
+
+fn classify_request(
+    workspace: &crate::workspace::Workspace,
+    artifact: RequestArtifact,
+) -> Result<ClassificationOutcome> {
+    let lookup = WorkspaceLookup::new(workspace);
+    let analysis_text = artifact.analysis_text();
+    let lower = analysis_text.to_lowercase();
+    let delete_hits = count_keyword_hits(&lower, DELETE_KEYWORDS);
+    let change_hits = count_keyword_hits(&lower, CHANGE_KEYWORDS);
+    let create_hits = count_keyword_hits(&lower, CREATE_KEYWORDS);
+
+    let explicit_ids = artifact.explicit_ids();
+    let explicit_items = collect_explicit_items(&lookup, &explicit_ids);
+    let mut related_items = collect_related_items(&lookup, &artifact.request);
+    merge_related_items(&mut related_items, lookup.search(&analysis_text, None));
+    related_items.truncate(5);
+
+    let mut reasons = Vec::new();
+    if delete_hits > 0 {
+        reasons.push(format!(
+            "request uses delete-oriented language: {}",
+            describe_keyword_hits(&lower, DELETE_KEYWORDS)
+        ));
+    }
+    if change_hits > 0 {
+        reasons.push(format!(
+            "request uses change-oriented language: {}",
+            describe_keyword_hits(&lower, CHANGE_KEYWORDS)
+        ));
+    }
+    if create_hits > 0 {
+        reasons.push(format!(
+            "request uses create-oriented language: {}",
+            describe_keyword_hits(&lower, CREATE_KEYWORDS)
+        ));
+    }
+    if !explicit_items.is_empty() {
+        reasons.push(format!(
+            "request names existing spec items: {}",
+            explicit_items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if explicit_items.is_empty() && !related_items.is_empty() {
+        reasons.push(format!(
+            "closest spec graph matches are {}",
+            related_items
+                .iter()
+                .map(|item| format!("{} {}", item.kind, item.id))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if delete_hits == 0 && change_hits == 0 && create_hits == 0 {
+        reasons.push(
+            "request does not use a strong create/change/delete verb, so the graph match and linked IDs carry the decision"
+                .to_string(),
+        );
+    }
+
+    let classification = if delete_hits > 0 {
+        RequirementAction::Delete
+    } else if change_hits > 0 || !explicit_items.is_empty() {
+        RequirementAction::Change
+    } else {
+        RequirementAction::Create
+    };
+
+    if matches!(classification, RequirementAction::Create) {
+        if create_hits > 0 {
+            reasons.push(
+                "request uses create-oriented language and does not name an existing spec item"
+                    .to_string(),
+            );
+        } else {
+            reasons.push(
+                "no existing spec item was named and the request reads like new work".to_string(),
+            );
+        }
+    }
+
+    Ok(ClassificationOutcome {
+        classification,
+        reasons,
+        explicit_items,
+        related_items,
+        request: artifact.request,
+        context: artifact.context,
+    })
+}
+
+impl RequestArtifact {
+    fn analysis_text(&self) -> String {
+        let mut text = String::new();
+        text.push_str(&self.request);
+        if let Some(affected_area) = &self.context.affected_area {
+            text.push('\n');
+            text.push_str(affected_area);
+        }
+        for constraint in &self.context.repository_constraints {
+            text.push('\n');
+            text.push_str(constraint);
+        }
+        for id in &self.context.linked_ids {
+            text.push('\n');
+            text.push_str(id);
+        }
+        text
+    }
+
+    fn explicit_ids(&self) -> Vec<String> {
+        let mut ids = self.context.linked_ids.clone();
+        ids.extend(extract_spec_ids(&self.request));
+        if let Some(affected_area) = &self.context.affected_area {
+            ids.extend(extract_spec_ids(affected_area));
+        }
+        ids.sort();
+        ids.dedup();
+        ids
+    }
+}
+
+fn collect_explicit_items(lookup: &WorkspaceLookup<'_>, ids: &[String]) -> Vec<SearchResult> {
+    let mut items = BTreeMap::<String, SearchResult>::new();
+    for id in ids {
+        if let Some(item) = lookup.find(id) {
+            items.insert(id.clone(), item_to_search_result(item));
+        }
+    }
+    items.into_values().collect()
+}
+
+fn collect_related_items(lookup: &WorkspaceLookup<'_>, request: &str) -> Vec<SearchResult> {
+    let mut items = BTreeMap::<String, SearchResult>::new();
+    for result in lookup.search(request, None) {
+        items.insert(result.id.clone(), result);
+    }
+    items.into_values().collect()
+}
+
+fn merge_related_items(related_items: &mut Vec<SearchResult>, additional_items: Vec<SearchResult>) {
+    let mut merged = BTreeMap::<String, SearchResult>::new();
+    for item in related_items.drain(..) {
+        merged.insert(item.id.clone(), item);
+    }
+    for item in additional_items {
+        merged.insert(item.id.clone(), item);
+    }
+    *related_items = merged.into_values().collect();
+}
+
+fn item_to_search_result(item: WorkspaceEntity<'_>) -> SearchResult {
+    match item {
+        WorkspaceEntity::Philosophy(item) => SearchResult {
+            id: item.id.clone(),
+            kind: "philosophy",
+            title: item.title.clone(),
+        },
+        WorkspaceEntity::Policy(item) => SearchResult {
+            id: item.id.clone(),
+            kind: "policy",
+            title: item.title.clone(),
+        },
+        WorkspaceEntity::Requirement(item) => SearchResult {
+            id: item.id.clone(),
+            kind: "requirement",
+            title: item.title.clone(),
+        },
+        WorkspaceEntity::Feature(item) => SearchResult {
+            id: item.id.clone(),
+            kind: "feature",
+            title: item.title.clone(),
+        },
+    }
+}
+
+fn print_text_output(request_path: &Path, outcome: &ClassificationOutcome) {
+    println!("request: {}", request_path.display());
+    println!("classification: {}", outcome.classification.label());
+    println!();
+    println!("request text:");
+    println!("{}", outcome.request.trim());
+    println!();
+    print_items("explicit items", &outcome.explicit_items);
+    print_items("related items", &outcome.related_items);
+    println!("reasons:");
+    if outcome.reasons.is_empty() {
+        println!("- none");
+    } else {
+        for reason in &outcome.reasons {
+            println!("- {reason}");
+        }
+    }
+}
+
+fn print_items(heading: &str, items: &[SearchResult]) {
+    println!("{heading}:");
+    if items.is_empty() {
+        println!("- none");
+        return;
+    }
+
+    for item in items {
+        println!("- {}\t{}\t{}", item.id, item.kind, item.title);
+    }
+}
+
+const DELETE_KEYWORDS: &[&str] = &[
+    "delete",
+    "remove",
+    "drop",
+    "retire",
+    "deprecate",
+    "obsolete",
+    "eliminate",
+    "no longer valid",
+];
+
+const CHANGE_KEYWORDS: &[&str] = &[
+    "change", "update", "modify", "refine", "expand", "extend", "revise", "adjust", "replace",
+    "rework", "clarify",
+];
+
+const CREATE_KEYWORDS: &[&str] = &[
+    "create",
+    "add",
+    "introduce",
+    "new",
+    "implement",
+    "support",
+    "build",
+];
+
+fn count_keyword_hits(text: &str, keywords: &[&str]) -> usize {
+    keywords
+        .iter()
+        .filter(|keyword| text.contains(**keyword))
+        .count()
+}
+
+fn describe_keyword_hits(text: &str, keywords: &[&str]) -> String {
+    keywords
+        .iter()
+        .copied()
+        .filter(|keyword| text.contains(keyword))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn extract_spec_ids(text: &str) -> Vec<String> {
+    static SPEC_ID_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = SPEC_ID_RE.get_or_init(|| {
+        Regex::new(r"\b(?:PHIL|POL|REQ|FEAT)-[A-Z0-9][A-Z0-9-]*\b")
+            .expect("spec id regex should compile")
+    });
+
+    re.find_iter(text).map(|m| m.as_str().to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use crate::cli::{OutputFormat, TaskClassifyArgs, TaskCommands};
+
+    use super::{RequirementAction, classify_request, load_request_artifact, run_task_command};
+
+    fn write_request_artifact(path: &Path, request: &str, linked_ids: &[&str]) {
+        let linked_ids_block = if linked_ids.is_empty() {
+            "  linked_ids: []\n".to_string()
+        } else {
+            let list = linked_ids
+                .iter()
+                .map(|id| format!("    - {id}\n"))
+                .collect::<String>();
+            format!("  linked_ids:\n{list}")
+        };
+        fs::write(
+            path,
+            format!(
+                "version: 1\nrequest: >\n  {request}\ncontext:\n  affected_area: core\n  repository_constraints:\n    - keep text and JSON output\n{linked_ids_block}",
+            ),
+        )
+        .expect("request artifact should write");
+    }
+
+    fn write_workspace(root: &Path) {
+        fs::write(
+            root.join("syu.yaml"),
+            "version: 1\nspec:\n  root: docs/syu\n",
+        )
+        .expect("workspace config");
+        fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+        fs::create_dir_all(root.join("docs/syu/policies")).expect("policy dir");
+        fs::create_dir_all(root.join("docs/syu/requirements/core")).expect("requirements dir");
+        fs::create_dir_all(root.join("docs/syu/features/core")).expect("features dir");
+
+        fs::write(
+            root.join("docs/syu/philosophy/foundation.yaml"),
+            "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-001\n    title: Keep planning explicit\n    product_design_principle: Request artifacts should stay reviewable.\n    coding_guideline: Prefer explicit request classification.\n    linked_policies:\n      - POL-001\n",
+        )
+        .expect("philosophy doc");
+        fs::write(
+            root.join("docs/syu/policies/policies.yaml"),
+            "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-001\n    title: Keep request workflows visible\n    summary: Keep intake and planning separate.\n    description: Request artifacts should be classified against the current graph.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-CORE-028\n",
+        )
+        .expect("policy doc");
+        fs::write(
+            root.join("docs/syu/requirements/core/classify.yaml"),
+            "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-028\n    title: Classify request artifacts into requirement actions\n    description: The task classifier should decide whether a request creates, changes, or deletes a requirement.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-001\n    tests:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - '*'\n",
+        )
+        .expect("requirement doc");
+        fs::write(
+            root.join("docs/syu/features/features.yaml"),
+            "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n",
+        )
+        .expect("feature registry");
+        fs::write(
+            root.join("docs/syu/features/core/task.yaml"),
+            "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify planned request artifacts into create, change, or delete decisions using the current spec graph and a brief explanation.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskClassifyArgs\n",
+        )
+        .expect("feature doc");
+    }
+
+    #[test]
+    fn load_request_artifact_rejects_version_mismatch() {
+        let tempdir = tempdir().expect("tempdir");
+        let request = tempdir.path().join("request.yaml");
+        fs::write(
+            &request,
+            "version: 2\nrequest: Update the requirement\ncontext: {}\n",
+        )
+        .expect("request");
+
+        let error = load_request_artifact(&request).expect_err("version mismatch should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported request artifact version")
+        );
+    }
+
+    #[test]
+    fn classify_request_prefers_change_for_existing_requirement_ids() {
+        let tempdir = tempdir().expect("tempdir");
+        write_workspace(tempdir.path());
+        let request = tempdir.path().join("request.yaml");
+        write_request_artifact(
+            &request,
+            "Update REQ-CORE-028 so the request classifier stays explainable.",
+            &["REQ-CORE-028"],
+        );
+
+        let workspace = crate::workspace::load_workspace(tempdir.path()).expect("workspace");
+        let artifact = load_request_artifact(&request).expect("request");
+        let outcome = classify_request(&workspace, artifact).expect("classification");
+        assert_eq!(outcome.classification, RequirementAction::Change);
+        assert!(
+            outcome
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("REQ-CORE-028"))
+        );
+    }
+
+    #[test]
+    fn classify_request_prefers_create_for_new_requests_without_existing_ids() {
+        let tempdir = tempdir().expect("tempdir");
+        write_workspace(tempdir.path());
+        let request = tempdir.path().join("request.yaml");
+        write_request_artifact(
+            &request,
+            "Create a new request summary for the upcoming planning flow.",
+            &[],
+        );
+
+        let workspace = crate::workspace::load_workspace(tempdir.path()).expect("workspace");
+        let artifact = load_request_artifact(&request).expect("request");
+        let outcome = classify_request(&workspace, artifact).expect("classification");
+        assert_eq!(outcome.classification, RequirementAction::Create);
+        assert!(
+            outcome
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("create-oriented language"))
+        );
+    }
+
+    #[test]
+    fn run_task_command_executes_nested_classify_commands() {
+        let tempdir = tempdir().expect("tempdir");
+        write_workspace(tempdir.path());
+        let request = tempdir.path().join("request.yaml");
+        write_request_artifact(
+            &request,
+            "Delete REQ-CORE-028 because the requirement no longer matches the workflow.",
+            &["REQ-CORE-028"],
+        );
+
+        let code = run_task_command(&crate::cli::TaskArgs {
+            command: TaskCommands::Classify(TaskClassifyArgs {
+                request: request.clone(),
+                workspace: tempdir.path().to_path_buf(),
+                format: OutputFormat::Text,
+            }),
+        })
+        .expect("task command should succeed");
+        assert_eq!(code, 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,11 @@
 // FEAT-TRACE-001
 // FEAT-BROWSE-001
 // FEAT-LSP-001
+// FEAT-TASK-001
 // REQ-CORE-021
 // REQ-CORE-023
 // REQ-CORE-024
+// REQ-CORE-028
 
 pub mod cli;
 pub mod command;
@@ -67,6 +69,7 @@ enum Dispatch {
     List(cli::ListArgs),
     Show(cli::ShowArgs),
     Search(cli::SearchArgs),
+    Task(cli::TaskArgs),
     Audit(cli::AuditArgs),
     Log(cli::LogArgs),
     Explain(cli::ExplainArgs),
@@ -90,6 +93,7 @@ fn dispatch(cli: cli::Cli, stdin_is_terminal: bool, stdout_is_terminal: bool) ->
         Some(cli::Commands::List(args)) => Dispatch::List(args),
         Some(cli::Commands::Show(args)) => Dispatch::Show(args),
         Some(cli::Commands::Search(args)) => Dispatch::Search(args),
+        Some(cli::Commands::Task(args)) => Dispatch::Task(args),
         Some(cli::Commands::Audit(args)) => Dispatch::Audit(args),
         Some(cli::Commands::Log(args)) => Dispatch::Log(args),
         Some(cli::Commands::Explain(args)) => Dispatch::Explain(args),
@@ -117,6 +121,7 @@ fn run_dispatch(dispatch: Dispatch) -> Result<i32> {
         Dispatch::List(args) => command::list::run_list_command(&args),
         Dispatch::Show(args) => command::show::run_show_command(&args),
         Dispatch::Search(args) => command::search::run_search_command(&args),
+        Dispatch::Task(args) => command::task::run_task_command(&args),
         Dispatch::Audit(args) => command::audit::run_audit_command(&args),
         Dispatch::Log(args) => command::log::run_log_command(&args),
         Dispatch::Explain(args) => command::explain::run_explain_command(&args),
@@ -158,8 +163,8 @@ mod tests {
 
     use crate::cli::{
         AddArgs, AppArgs, AuditArgs, Cli, Commands, CompletionArgs, ExplainArgs, HistoryKind,
-        ListArgs, LogArgs, LookupKind, OutputFormat, RelateArgs, SearchArgs, ShowArgs,
-        TemplatesArgs, TraceArgs,
+        ListArgs, LogArgs, LookupKind, OutputFormat, RelateArgs, SearchArgs, ShowArgs, TaskArgs,
+        TaskClassifyArgs, TaskCommands, TemplatesArgs, TraceArgs,
     };
     use clap_complete::Shell;
 
@@ -350,6 +355,37 @@ mod tests {
                     && workspace == Path::new("workspace")
                     && kind == Some(LookupKind::Feature)
                     && format == OutputFormat::Json
+        ));
+    }
+
+    #[test]
+    // REQ-CORE-028
+    fn dispatches_task_subcommands_without_rewriting_them() {
+        let task = super::dispatch(
+            Cli {
+                command: Some(Commands::Task(TaskArgs {
+                    command: TaskCommands::Classify(TaskClassifyArgs {
+                        request: PathBuf::from("request.yaml"),
+                        workspace: PathBuf::from("workspace"),
+                        format: OutputFormat::Json,
+                    }),
+                })),
+            },
+            true,
+            true,
+        );
+
+        assert!(matches!(
+            task,
+            super::Dispatch::Task(crate::cli::TaskArgs {
+                command: TaskCommands::Classify(TaskClassifyArgs {
+                    request,
+                    workspace,
+                    format,
+                })
+            }) if request == Path::new("request.yaml")
+                && workspace == Path::new("workspace")
+                && format == OutputFormat::Json
         ));
     }
 

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -56,31 +56,46 @@ fn app_help_mentions_remote_bind_opt_in() {
 #[test]
 fn workspace_help_uses_current_directory_default_consistently() {
     for command in [
-        "browse", "show", "search", "trace", "review", "app", "doctor", "validate", "check",
-        "report", "add", "task", "relate", "log", "audit", "explain",
+        &["browse"][..],
+        &["show"][..],
+        &["search"][..],
+        &["trace"][..],
+        &["review"][..],
+        &["app"][..],
+        &["doctor"][..],
+        &["validate"][..],
+        &["check"][..],
+        &["report"][..],
+        &["add"][..],
+        &["task", "classify"][..],
+        &["relate"][..],
+        &["log"][..],
+        &["audit"][..],
+        &["explain"][..],
     ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
-            .args([command, "--help"])
+            .args(command)
+            .arg("--help")
             .output()
             .expect("help should render");
 
-        assert!(output.status.success(), "{command} help should succeed");
+        assert!(output.status.success(), "{command:?} help should succeed");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains(
                 "Workspace root or any child directory; syu walks upward to find syu.yaml and the configured spec tree"
             ),
-            "{command} help should describe the workspace root consistently",
+            "{command:?} help should describe the workspace root consistently",
         );
         assert!(
             stdout.contains("[default: .]"),
-            "{command} help should keep the current-directory default",
+            "{command:?} help should keep the current-directory default",
         );
         assert!(
             !stdout.contains("default: docs/syu"),
-            "{command} help should not claim docs/syu is the workspace default",
+            "{command:?} help should not claim docs/syu is the workspace default",
         );
     }
 }

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -7,6 +7,7 @@
 // REQ-CORE-025
 // REQ-CORE-026
 // REQ-CORE-027
+// REQ-CORE-028
 
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
@@ -30,6 +31,7 @@ fn root_help_includes_start_here_guidance() {
     assert!(stdout.contains("syu validate ."));
     assert!(stdout.contains("syu browse ."));
     assert!(stdout.contains("syu app ."));
+    assert!(stdout.contains("syu task classify request.yaml"));
     assert!(stdout.contains(
         "Browse the specification in your terminal (interactive prompts or text output)"
     ));
@@ -55,7 +57,7 @@ fn app_help_mentions_remote_bind_opt_in() {
 fn workspace_help_uses_current_directory_default_consistently() {
     for command in [
         "browse", "show", "search", "trace", "review", "app", "doctor", "validate", "check",
-        "report", "add", "relate", "log", "audit", "explain",
+        "report", "add", "task", "relate", "log", "audit", "explain",
     ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
@@ -259,6 +261,23 @@ fn add_help_mentions_explicit_file_and_feature_kind() {
     );
     assert!(stdout.contains("syu add requirement --interactive"));
     assert!(stdout.contains("FEAT-AUTH-LOGIN-001 --kind auth"));
+}
+
+#[test]
+fn task_help_mentions_request_artifacts_and_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "classify", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("request artifact"));
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("syu task classify request.yaml"));
+    assert!(stdout.contains("syu task classify request.yaml --format json"));
 }
 
 #[test]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -1,0 +1,109 @@
+// REQ-CORE-028
+
+use std::fs;
+
+use assert_cmd::cargo::CommandCargoExt;
+use tempfile::tempdir;
+
+fn write_workspace(root: &std::path::Path) {
+    fs::write(
+        root.join("syu.yaml"),
+        "version: 1\nspec:\n  root: docs/syu\n",
+    )
+    .expect("workspace config");
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policy dir");
+    fs::create_dir_all(root.join("docs/syu/requirements/core")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features/core")).expect("features dir");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-001\n    title: Keep planning explicit\n    product_design_principle: Request artifacts should stay reviewable.\n    coding_guideline: Prefer explicit request classification.\n    linked_policies:\n      - POL-001\n",
+    )
+    .expect("philosophy doc");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-001\n    title: Keep request workflows visible\n    summary: Keep intake and planning separate.\n    description: Request artifacts should be classified against the current graph.\n    linked_philosophies:\n      - PHIL-001\n    linked_requirements:\n      - REQ-CORE-028\n",
+    )
+    .expect("policy doc");
+    fs::write(
+        root.join("docs/syu/requirements/core/classify.yaml"),
+        "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-028\n    title: Classify request artifacts into requirement actions\n    description: The task classifier should decide whether a request creates, changes, or deletes a requirement.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-001\n    tests:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - '*'\n",
+    )
+    .expect("requirement doc");
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n",
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core/task.yaml"),
+        "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify captured request artifacts into create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskClassifyArgs\n        - file: src/lib.rs\n          symbols:\n            - dispatches_task_subcommands_without_rewriting_them\n",
+    )
+    .expect("feature doc");
+}
+
+fn write_request(root: &std::path::Path, request: &str, linked_ids: &[&str]) {
+    let linked_ids_block = if linked_ids.is_empty() {
+        "  linked_ids: []\n".to_string()
+    } else {
+        let list = linked_ids
+            .iter()
+            .map(|id| format!("    - {id}\n"))
+            .collect::<String>();
+        format!("  linked_ids:\n{list}")
+    };
+    fs::write(
+        root.join("request.yaml"),
+        format!(
+            "version: 1\nrequest: >\n  {request}\ncontext:\n  affected_area: core\n  repository_constraints:\n    - keep text and JSON output\n{linked_ids_block}",
+        ),
+    )
+    .expect("request");
+}
+
+#[test]
+fn task_classify_prints_text_output() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Update REQ-CORE-028 so the request classifier stays explainable.",
+        &["REQ-CORE-028"],
+    );
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "classify", "request.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task classify should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("classification: requirement_change"));
+    assert!(stdout.contains("REQ-CORE-028"));
+}
+
+#[test]
+fn task_classify_prints_json_output() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Create a new request summary for planning.",
+        &[],
+    );
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "classify", "request.yaml", "--format", "json"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task classify should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"classification\": \"requirement_create\""));
+    assert!(stdout.contains("\"request_path\": \"request.yaml\""));
+}

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -109,6 +109,53 @@ fn task_classify_prints_json_output() {
 }
 
 #[test]
+fn task_classify_reports_related_items_without_explicit_ids() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(tempdir.path(), "Request artifact classification", &[]);
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "classify", "request.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task classify should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("classification: requirement_create"));
+    assert!(stdout.contains("closest spec graph matches are"));
+    assert!(stdout.contains("related items:"));
+    assert!(stdout.contains("FEAT-TASK-001"));
+}
+
+#[test]
+fn task_classify_reports_explicit_items_from_all_spec_layers() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Update PHIL-001, POL-001, REQ-CORE-028, and FEAT-TASK-001 together.",
+        &["PHIL-001", "POL-001", "REQ-CORE-028", "FEAT-TASK-001"],
+    );
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "classify", "request.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task classify should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("classification: requirement_change"));
+    assert!(stdout.contains("PHIL-001\tphilosophy\tKeep planning explicit"));
+    assert!(stdout.contains("POL-001\tpolicy\tKeep request workflows visible"));
+    assert!(stdout.contains("REQ-CORE-028\trequirement\tClassify request artifacts"));
+    assert!(stdout.contains("FEAT-TASK-001\tfeature\tRequest artifact classification"));
+}
+
+#[test]
 // REQ-CORE-028
 fn task_classify_handles_requests_without_matches() {
     let tempdir = tempdir().expect("tempdir");

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -107,3 +107,29 @@ fn task_classify_prints_json_output() {
     assert!(stdout.contains("\"classification\": \"requirement_create\""));
     assert!(stdout.contains("\"request_path\": \"request.yaml\""));
 }
+
+#[test]
+// REQ-CORE-028
+fn task_classify_handles_requests_without_matches() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("request.yaml"),
+        "version: 1\nrequest: >\n  Blorf zqxw 123.\ncontext: {}\n",
+    )
+    .expect("request");
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "classify", "request.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task classify should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("classification: requirement_create"));
+    assert!(stdout.contains("- none"));
+    assert!(stdout.contains("request does not use a strong create/change/delete verb"));
+    assert!(stdout.contains("no existing spec item was named and the request reads like new work"));
+}


### PR DESCRIPTION
Summary:
- Added `syu task classify` with request-artifact parsing and requirement create/change/delete classification.
- Wired the new nested CLI subcommand through dispatch, docs, and generated site output.
- Added targeted command, parser, and help tests plus reciprocal spec links.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test task --locked`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test site_docs_generator --locked`
- `python scripts/generate-site-docs.py`
- `cargo fmt --all`

Closes #647
