### PR TITLE
Summarize range review by affected IDs

### DIFF
--- a/app/tests/browser-app.spec.ts
+++ b/app/tests/browser-app.spec.ts
@@ -196,7 +196,7 @@ test("shows openapi operation details in the item panel", async ({ page }) => {
             ? {
                 ...document,
                 content: document.content.replace(
-                  '  - id: FEAT-TRACE-001\n    title: Source-first trace lookup\n    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-021\n    implementations:\n      rust:\n        - file: src/cli.rs\n          symbols:\n            - TraceArgs\n        - file: src/command/trace.rs\n          symbols:\n            - "*"\n',
+                  /  - id: FEAT-TRACE-001\n    title: Source-first trace lookup\n[\s\S]*?        - file: src\/command\/trace\.rs\n          symbols:\n            - "\*"\n/,
                   "  - id: FEAT-TRACE-001\n    title: OpenAPI implementation trace\n    summary: Feature links to an OpenAPI contract file.\n    status: implemented\n    linked_requirements:\n      - REQ-TRACE-001\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n      rust:\n        - file: src/rust_feature.rs\n          symbols:\n            - feature_trace_rust\n",
                 ),
               }

--- a/docs/generated/site-spec/features/cli/trace.md
+++ b/docs/generated/site-spec/features/cli/trace.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/trace.yaml"
 
 - **id**: FEAT-TRACE-001
   - **title**: Source-first trace lookup
-  - **summary**: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership.
+  - **summary**: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-021
@@ -41,7 +41,7 @@ version: 1
 features:
   - id: FEAT-TRACE-001
     title: Source-first trace lookup
-    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership.
+    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
     status: implemented
     linked_requirements:
       - REQ-CORE-021

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -25,7 +25,7 @@ If a pull request already exists, pair this page with the
 | Generate the Markdown report | `syu report .` | save the current validation result as a shareable report |
 | Inspect one spec item | `syu show FEAT-CHECK-001` | read the title, links, traces, and status for one philosophy, policy, requirement, or feature |
 | Expand the nearby graph | `syu relate FEAT-CHECK-001` | see linked policies, requirements, features, files, and symbols around one selector |
-| Review a PR range | `syu review --range origin/main...HEAD` | summarize the changed files in one reviewer-friendly pass before you drill into `show`, `relate`, or `log` |
+| Review a PR range | `syu review --range origin/main...HEAD` | start with the affected philosophy, policy, requirement, and feature IDs, then drill into changed files with `show`, `relate`, or `log` |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |
 | Search by keyword or ID | `syu search validation --kind feature` | find the right spec item before `show`, `relate`, or `log` |
@@ -44,9 +44,10 @@ If a pull request already exists, pair this page with the
 Use `syu audit .` before `syu report .` when you want the review handoff to read as one short loop instead of a loose list of checks.
 
 If a reviewed diff includes an OpenAPI contract file, the range summary still
-shows the owning requirements and features and now prints the traced
-method/path selector so the change stays connected to the spec items that own
-the contract operation.
+shows the owning requirements and features, separates direct matches from
+indirect upstream/downstream context, and prints the traced method/path
+selector so the change stays connected to the spec items that own the contract
+operation.
 
 ## Common command bundles
 

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -88,9 +88,10 @@ syu review --range origin/main...HEAD
 ```
 
 `syu review` is a friendly entry point for the same range tracing logic. It
-summarizes changed files, surfaces unowned or skipped paths inline, and keeps
-the follow-up `show`, `relate`, `log`, and `validate --id` commands close at
-hand.
+starts with the affected philosophy, policy, requirement, and feature IDs,
+separates directly matched items from indirect upstream/downstream context,
+surfaces unowned or skipped paths inline, and keeps the follow-up `show`,
+`relate`, `log`, and `validate --id` commands close at hand.
 
 When a changed file is a contract file with traced operations, the range
 summary keeps the owning requirements and features visible and also prints the

--- a/docs/syu/features/cli/trace.yaml
+++ b/docs/syu/features/cli/trace.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-TRACE-001
     title: Source-first trace lookup
-    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership.
+    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
     status: implemented
     linked_requirements:
       - REQ-CORE-021

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -114,6 +114,20 @@ struct TraceRangeOutput {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct TraceRangeEntityGroup {
+    requirements: Vec<EntitySummary>,
+    features: Vec<EntitySummary>,
+    policies: Vec<EntitySummary>,
+    philosophies: Vec<EntitySummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceRangeIdSummary {
+    direct: TraceRangeEntityGroup,
+    indirect: TraceRangeEntityGroup,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct TraceRangeSummary {
     changed_files_total: usize,
     inspected_files: usize,
@@ -125,6 +139,7 @@ struct TraceRangeSummary {
     total_features: usize,
     total_policies: usize,
     total_philosophies: usize,
+    ids: TraceRangeIdSummary,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -205,6 +220,20 @@ fn run_trace_range(workspace: &Workspace, range: &str, format: OutputFormat) -> 
                             total_features: 0,
                             total_policies: 0,
                             total_philosophies: 0,
+                            ids: TraceRangeIdSummary {
+                                direct: TraceRangeEntityGroup {
+                                    requirements: Vec::new(),
+                                    features: Vec::new(),
+                                    policies: Vec::new(),
+                                    philosophies: Vec::new(),
+                                },
+                                indirect: TraceRangeEntityGroup {
+                                    requirements: Vec::new(),
+                                    features: Vec::new(),
+                                    policies: Vec::new(),
+                                    philosophies: Vec::new(),
+                                },
+                            },
                         },
                     })
                     .expect("serializing empty trace range output to JSON should succeed")
@@ -240,10 +269,7 @@ fn compute_range_summary(
     results: &[TraceLookupOutput],
     skipped: &[TraceSkippedFile],
 ) -> TraceRangeSummary {
-    let mut requirements = std::collections::BTreeSet::new();
-    let mut features = std::collections::BTreeSet::new();
-    let mut policies = std::collections::BTreeSet::new();
-    let mut philosophies = std::collections::BTreeSet::new();
+    let ids = collect_range_id_summary(results);
 
     let mut owned = 0;
     let mut partial = 0;
@@ -255,19 +281,6 @@ fn compute_range_summary(
             TraceLookupStatus::Partial => partial += 1,
             TraceLookupStatus::Unowned => unowned += 1,
         }
-
-        for req in &result.requirements {
-            requirements.insert(&req.id);
-        }
-        for feat in &result.features {
-            features.insert(&feat.id);
-        }
-        for pol in &result.policies {
-            policies.insert(&pol.id);
-        }
-        for phil in &result.philosophies {
-            philosophies.insert(&phil.id);
-        }
     }
 
     TraceRangeSummary {
@@ -277,10 +290,83 @@ fn compute_range_summary(
         owned_files: owned,
         partial_files: partial,
         unowned_files: unowned,
-        total_requirements: requirements.len(),
-        total_features: features.len(),
-        total_policies: policies.len(),
-        total_philosophies: philosophies.len(),
+        total_requirements: ids.indirect.requirements.len() + ids.direct.requirements.len(),
+        total_features: ids.indirect.features.len() + ids.direct.features.len(),
+        total_policies: ids.indirect.policies.len() + ids.direct.policies.len(),
+        total_philosophies: ids.indirect.philosophies.len() + ids.direct.philosophies.len(),
+        ids,
+    }
+}
+
+fn collect_range_id_summary(results: &[TraceLookupOutput]) -> TraceRangeIdSummary {
+    let mut direct_requirements = BTreeMap::<String, EntitySummary>::new();
+    let mut direct_features = BTreeMap::<String, EntitySummary>::new();
+    let mut indirect_requirements = BTreeMap::<String, EntitySummary>::new();
+    let mut indirect_features = BTreeMap::<String, EntitySummary>::new();
+    let mut indirect_policies = BTreeMap::<String, EntitySummary>::new();
+    let mut indirect_philosophies = BTreeMap::<String, EntitySummary>::new();
+
+    for result in results {
+        for owner in result
+            .matched_owners
+            .iter()
+            .chain(result.file_only_owners.iter())
+        {
+            match owner.kind {
+                "requirement" => {
+                    direct_requirements
+                        .entry(owner.id.clone())
+                        .or_insert_with(|| EntitySummary {
+                            id: owner.id.clone(),
+                            title: owner.title.clone(),
+                            document_path: None,
+                        });
+                }
+                "feature" => {
+                    direct_features
+                        .entry(owner.id.clone())
+                        .or_insert_with(|| EntitySummary {
+                            id: owner.id.clone(),
+                            title: owner.title.clone(),
+                            document_path: None,
+                        });
+                }
+                _ => {}
+            }
+        }
+
+        collect_entities_into_map(&result.requirements, &mut indirect_requirements);
+        collect_entities_into_map(&result.features, &mut indirect_features);
+        collect_entities_into_map(&result.policies, &mut indirect_policies);
+        collect_entities_into_map(&result.philosophies, &mut indirect_philosophies);
+    }
+
+    for id in direct_requirements.keys() {
+        indirect_requirements.remove(id);
+    }
+    for id in direct_features.keys() {
+        indirect_features.remove(id);
+    }
+
+    TraceRangeIdSummary {
+        direct: TraceRangeEntityGroup {
+            requirements: direct_requirements.into_values().collect(),
+            features: direct_features.into_values().collect(),
+            policies: Vec::new(),
+            philosophies: Vec::new(),
+        },
+        indirect: TraceRangeEntityGroup {
+            requirements: indirect_requirements.into_values().collect(),
+            features: indirect_features.into_values().collect(),
+            policies: indirect_policies.into_values().collect(),
+            philosophies: indirect_philosophies.into_values().collect(),
+        },
+    }
+}
+
+fn collect_entities_into_map(items: &[EntitySummary], map: &mut BTreeMap<String, EntitySummary>) {
+    for item in items {
+        map.entry(item.id.clone()).or_insert_with(|| item.clone());
     }
 }
 
@@ -324,6 +410,15 @@ fn render_range_text(
         summary.owned_files, summary.partial_files, summary.unowned_files
     )
     .unwrap();
+
+    writeln!(output, "Affected IDs:").unwrap();
+    render_range_id_group(&mut output, "Direct matches", &summary.ids.direct);
+    render_range_id_group(
+        &mut output,
+        "Indirect upstream/downstream context",
+        &summary.ids.indirect,
+    );
+    writeln!(output).unwrap();
 
     let mut by_owner = BTreeMap::<(String, String), Vec<&TraceLookupOutput>>::new();
     for result in results {
@@ -390,6 +485,31 @@ fn render_range_text(
     }
 
     output
+}
+
+fn render_range_id_group(rendered: &mut String, heading: &str, group: &TraceRangeEntityGroup) {
+    writeln!(rendered, "  {heading}:").expect("writing to String must succeed");
+    let mut wrote_any = false;
+    wrote_any |= render_range_id_items(rendered, "requirements", &group.requirements);
+    wrote_any |= render_range_id_items(rendered, "features", &group.features);
+    wrote_any |= render_range_id_items(rendered, "policies", &group.policies);
+    wrote_any |= render_range_id_items(rendered, "philosophies", &group.philosophies);
+    if !wrote_any {
+        writeln!(rendered, "    - none").expect("writing to String must succeed");
+    }
+}
+
+fn render_range_id_items(rendered: &mut String, label: &str, items: &[EntitySummary]) -> bool {
+    if items.is_empty() {
+        return false;
+    }
+
+    writeln!(rendered, "    {label}:").expect("writing to String must succeed");
+    for item in items {
+        writeln!(rendered, "      - {}\t{}", item.id, item.title)
+            .expect("writing to String must succeed");
+    }
+    true
 }
 
 fn normalize_lookup_file(workspace: &Workspace, file: &Path) -> Result<PathBuf> {
@@ -872,8 +992,9 @@ mod tests {
 
     use super::{
         MatchMode, TraceLookupOutput, TraceLookupStatus, TraceOwnerMatch, TraceOwnerMetadata,
-        collect_related_entities, collect_requirement_context, insert_summary, match_mode,
-        normalize_lookup_file, query_label, render_text_output, trace_owner_match,
+        collect_range_id_summary, collect_related_entities, collect_requirement_context,
+        insert_summary, match_mode, normalize_lookup_file, query_label, render_text_output,
+        trace_owner_match,
     };
 
     #[test]
@@ -1364,6 +1485,103 @@ mod tests {
         assert_eq!(summary.total_features, 1);
         assert_eq!(summary.total_policies, 1);
         assert_eq!(summary.total_philosophies, 1);
+        assert_eq!(summary.ids.direct.requirements.len(), 1);
+        assert_eq!(summary.ids.direct.features.len(), 1);
+        assert_eq!(summary.ids.indirect.policies.len(), 1);
+        assert_eq!(summary.ids.indirect.philosophies.len(), 1);
+    }
+
+    #[test]
+    fn collect_range_id_summary_separates_direct_and_indirect_ids() {
+        let summary = collect_range_id_summary(&[
+            TraceLookupOutput {
+                file: "feature.rs".to_string(),
+                symbol: None,
+                status: TraceLookupStatus::Owned,
+                matched_owners: vec![TraceOwnerMatch {
+                    kind: "feature",
+                    id: "FEAT-1".to_string(),
+                    title: "Feature".to_string(),
+                    trace_role: "implementation".to_string(),
+                    language: "rust".to_string(),
+                    file: "feature.rs".to_string(),
+                    declared_symbols: Vec::new(),
+                    method: None,
+                    path: None,
+                    matched_symbol: None,
+                    match_mode: "file",
+                }],
+                file_only_owners: Vec::new(),
+                requirements: vec![EntitySummary {
+                    id: "REQ-1".to_string(),
+                    title: "Requirement".to_string(),
+                    document_path: None,
+                }],
+                features: vec![EntitySummary {
+                    id: "FEAT-1".to_string(),
+                    title: "Feature".to_string(),
+                    document_path: None,
+                }],
+                policies: vec![EntitySummary {
+                    id: "POL-1".to_string(),
+                    title: "Policy".to_string(),
+                    document_path: None,
+                }],
+                philosophies: vec![EntitySummary {
+                    id: "PHIL-1".to_string(),
+                    title: "Philosophy".to_string(),
+                    document_path: None,
+                }],
+            },
+            TraceLookupOutput {
+                file: "requirement.rs".to_string(),
+                symbol: None,
+                status: TraceLookupStatus::Owned,
+                matched_owners: vec![TraceOwnerMatch {
+                    kind: "requirement",
+                    id: "REQ-2".to_string(),
+                    title: "Requirement 2".to_string(),
+                    trace_role: "test".to_string(),
+                    language: "rust".to_string(),
+                    file: "requirement.rs".to_string(),
+                    declared_symbols: Vec::new(),
+                    method: None,
+                    path: None,
+                    matched_symbol: None,
+                    match_mode: "file",
+                }],
+                file_only_owners: Vec::new(),
+                requirements: vec![EntitySummary {
+                    id: "REQ-2".to_string(),
+                    title: "Requirement 2".to_string(),
+                    document_path: None,
+                }],
+                features: vec![EntitySummary {
+                    id: "FEAT-2".to_string(),
+                    title: "Feature 2".to_string(),
+                    document_path: None,
+                }],
+                policies: vec![EntitySummary {
+                    id: "POL-2".to_string(),
+                    title: "Policy 2".to_string(),
+                    document_path: None,
+                }],
+                philosophies: vec![EntitySummary {
+                    id: "PHIL-2".to_string(),
+                    title: "Philosophy 2".to_string(),
+                    document_path: None,
+                }],
+            },
+        ]);
+
+        assert_eq!(summary.direct.features.len(), 1);
+        assert_eq!(summary.direct.requirements.len(), 1);
+        assert_eq!(summary.indirect.features.len(), 1);
+        assert_eq!(summary.indirect.requirements.len(), 1);
+        assert_eq!(summary.indirect.policies.len(), 2);
+        assert_eq!(summary.indirect.philosophies.len(), 2);
+        assert_eq!(summary.indirect.features[0].id, "FEAT-2");
+        assert_eq!(summary.indirect.requirements[0].id, "REQ-1");
     }
 
     #[test]
@@ -1418,9 +1636,30 @@ mod tests {
                 total_features: 1,
                 total_policies: 0,
                 total_philosophies: 0,
+                ids: super::TraceRangeIdSummary {
+                    direct: super::TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: vec![EntitySummary {
+                            id: "FEAT-1".to_string(),
+                            title: "Feature".to_string(),
+                            document_path: None,
+                        }],
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                    indirect: super::TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                },
             },
         );
 
+        assert!(rendered.contains("Affected IDs:"));
+        assert!(rendered.contains("Direct matches:"));
+        assert!(rendered.contains("features:"));
         assert!(rendered.contains("feature FEAT-1:"));
         assert!(rendered.contains("UNOWNED:"));
         assert!(rendered.contains("Inspected files: 2"));
@@ -1475,6 +1714,28 @@ mod tests {
                 total_features: 1,
                 total_policies: 0,
                 total_philosophies: 0,
+                ids: super::TraceRangeIdSummary {
+                    direct: super::TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: vec![EntitySummary {
+                            id: "FEAT-TRACE-001".to_string(),
+                            title: "OpenAPI trace".to_string(),
+                            document_path: None,
+                        }],
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                    indirect: super::TraceRangeEntityGroup {
+                        requirements: vec![EntitySummary {
+                            id: "REQ-TRACE-001".to_string(),
+                            title: "Trace".to_string(),
+                            document_path: None,
+                        }],
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                },
             },
         );
 
@@ -1503,6 +1764,20 @@ mod tests {
                 total_features: 0,
                 total_policies: 0,
                 total_philosophies: 0,
+                ids: super::TraceRangeIdSummary {
+                    direct: super::TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                    indirect: super::TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                },
             },
         );
 

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -1485,8 +1485,8 @@ mod tests {
         assert_eq!(summary.total_features, 1);
         assert_eq!(summary.total_policies, 1);
         assert_eq!(summary.total_philosophies, 1);
-        assert_eq!(summary.ids.direct.requirements.len(), 1);
-        assert_eq!(summary.ids.direct.features.len(), 1);
+        assert_eq!(summary.ids.direct.requirements.len(), 0);
+        assert_eq!(summary.ids.direct.features.len(), 0);
         assert_eq!(summary.ids.indirect.policies.len(), 1);
         assert_eq!(summary.ids.indirect.philosophies.len(), 1);
     }

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -1585,6 +1585,29 @@ mod tests {
                     document_path: None,
                 }],
             },
+            TraceLookupOutput {
+                file: "policy.rs".to_string(),
+                symbol: None,
+                status: TraceLookupStatus::Owned,
+                matched_owners: vec![TraceOwnerMatch {
+                    kind: "policy",
+                    id: "POL-IGNORED".to_string(),
+                    title: "Ignored policy".to_string(),
+                    trace_role: "documentation".to_string(),
+                    language: "rust".to_string(),
+                    file: "policy.rs".to_string(),
+                    declared_symbols: Vec::new(),
+                    method: None,
+                    path: None,
+                    matched_symbol: None,
+                    match_mode: "file",
+                }],
+                file_only_owners: Vec::new(),
+                requirements: Vec::new(),
+                features: Vec::new(),
+                policies: Vec::new(),
+                philosophies: Vec::new(),
+            },
         ]);
 
         assert_eq!(summary.direct.features.len(), 1);

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -1423,7 +1423,19 @@ mod tests {
                     file: "owned.rs".to_string(),
                     symbol: None,
                     status: TraceLookupStatus::Owned,
-                    matched_owners: Vec::new(),
+                    matched_owners: vec![TraceOwnerMatch {
+                        kind: "feature",
+                        id: "FEAT-1".to_string(),
+                        title: "Feat".to_string(),
+                        trace_role: "implementation".to_string(),
+                        language: "rust".to_string(),
+                        file: "owned.rs".to_string(),
+                        declared_symbols: Vec::new(),
+                        method: None,
+                        path: None,
+                        matched_symbol: None,
+                        match_mode: "symbol",
+                    }],
                     file_only_owners: Vec::new(),
                     requirements: vec![EntitySummary {
                         id: "REQ-1".to_string(),
@@ -1486,7 +1498,8 @@ mod tests {
         assert_eq!(summary.total_policies, 1);
         assert_eq!(summary.total_philosophies, 1);
         assert_eq!(summary.ids.direct.requirements.len(), 0);
-        assert_eq!(summary.ids.direct.features.len(), 0);
+        assert_eq!(summary.ids.direct.features.len(), 1);
+        assert_eq!(summary.ids.indirect.features.len(), 0);
         assert_eq!(summary.ids.indirect.policies.len(), 1);
         assert_eq!(summary.ids.indirect.philosophies.len(), 1);
     }


### PR DESCRIPTION
Summary:
- Add an ID-first range summary to `syu review` / `trace --range` output.
- Separate directly matched spec IDs from indirect upstream/downstream context in both text and JSON.
- Update the reviewer workflow docs and trace feature docs to describe the new review flow.

Validation:
- `cargo test --lib trace::tests` (blocked by missing browser-app dependencies in `build.rs`)
- `cargo fmt --all --check`
- `git diff --check`

Closes #642
