### PR TITLE
Add OpenAPI selector regression to syu show

### DIFF
--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -39,7 +39,7 @@ fn write_show_fixture_workspace() -> tempfile::TempDir {
     .expect("feature registry");
     fs::write(
         docs_root.join("features/solo.yaml"),
-        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-EMPTY-001\n    title: Empty feature\n    summary: Leaves implementations empty.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n  - id: FEAT-001\n    title: OpenAPI feature\n    summary: Shows selectors in trace output.\n    status: planned\n    linked_requirements: []\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n",
+        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-EMPTY-001\n    title: Empty feature\n    summary: Leaves implementations empty.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n  - id: FEAT-OPENAPI-001\n    title: OpenAPI feature\n    summary: Shows selectors in trace output.\n    status: planned\n    linked_requirements: []\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n",
     )
     .expect("feature file");
 
@@ -257,7 +257,7 @@ fn show_command_renders_openapi_feature_selector_details_in_text_format() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("show")
-        .arg("FEAT-001")
+        .arg("FEAT-OPENAPI-001")
         .arg(tempdir.path())
         .output()
         .expect("command should run");

--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -39,7 +39,7 @@ fn write_show_fixture_workspace() -> tempfile::TempDir {
     .expect("feature registry");
     fs::write(
         docs_root.join("features/solo.yaml"),
-        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-001\n    title: Empty feature\n    summary: Leaves implementations empty.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n",
+        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-001\n    title: OpenAPI feature\n    summary: Shows selectors in trace output.\n    status: planned\n    linked_requirements: []\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n",
     )
     .expect("feature file");
 
@@ -247,6 +247,26 @@ fn show_command_handles_empty_links_and_doc_only_traces() {
     assert!(requirement_stdout.contains("doc_contains: REQ-001"));
     assert!(requirement_stdout.contains("method: `get`"));
     assert!(requirement_stdout.contains("path: `/pets/{petId}`"));
+}
+
+#[test]
+// REQ-CORE-018
+fn show_command_renders_openapi_feature_selector_details_in_text_format() {
+    let tempdir = write_show_fixture_workspace();
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .arg("show")
+        .arg("FEAT-001")
+        .arg(tempdir.path())
+        .output()
+        .expect("command should run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Kind: feature"));
+    assert!(stdout.contains("method: `get`"));
+    assert!(stdout.contains("path: `/pets/{petId}`"));
 }
 
 #[test]

--- a/tests/show_command.rs
+++ b/tests/show_command.rs
@@ -39,7 +39,7 @@ fn write_show_fixture_workspace() -> tempfile::TempDir {
     .expect("feature registry");
     fs::write(
         docs_root.join("features/solo.yaml"),
-        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-001\n    title: OpenAPI feature\n    summary: Shows selectors in trace output.\n    status: planned\n    linked_requirements: []\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n",
+        "category: Features\nversion: 1\nfeatures:\n  - id: FEAT-EMPTY-001\n    title: Empty feature\n    summary: Leaves implementations empty.\n    status: planned\n    linked_requirements: []\n    implementations: {}\n  - id: FEAT-001\n    title: OpenAPI feature\n    summary: Shows selectors in trace output.\n    status: planned\n    linked_requirements: []\n    implementations:\n      openapi:\n        - file: api/openapi.yaml\n          method: get\n          path: /pets/{petId}\n          symbols: []\n",
     )
     .expect("feature file");
 
@@ -225,7 +225,7 @@ fn show_command_handles_empty_links_and_doc_only_traces() {
     let feature = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("show")
-        .arg("FEAT-001")
+        .arg("FEAT-EMPTY-001")
         .arg(tempdir.path())
         .output()
         .expect("command should run");


### PR DESCRIPTION
Summary:
- Add a regression test for `syu show` on a feature trace that includes OpenAPI `method` and `path` selectors.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test show_command show_command_renders_openapi_feature_selector_details_in_text_format -- --exact
- `cargo fmt --check --all`

Closes #674
