### PR TITLE
Clarify safe autofix scope for validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,8 +716,8 @@ syu validate . --fix --dry-run
 syu validate . --format json --fix --dry-run
 ```
 
-Today autofix only repairs documentation-style trace gaps that can be updated
-mechanically:
+Today autofix repairs documentation-style trace gaps plus a few deterministic
+graph and registry issues:
 
 - missing requirement / feature IDs in symbol documentation
 - missing `doc_contains` snippets for Rust, Python, Go, and TypeScript symbols

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -199,15 +199,11 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       writing files, with both machine-readable and reviewer-friendly output.
       `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
       MUST disable it. Autofix MUST stay conservative and avoid speculative
-      structural edits.
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
-      It MAY also remove exact duplicate graph links, restore already-declared
-      reciprocal links, and resynchronize the feature registry with checked-in
-      feature documents when one safe correction is obvious. If a later write
-      fails, it MUST roll back earlier writes so the workspace is not left
-      half-updated.
+      structural edits. It MAY also remove exact duplicate graph links,
+      restore already-declared reciprocal links, and resynchronize the feature
+      registry with checked-in feature documents when one safe correction is
+      obvious. If a later write fails, it MUST roll back earlier writes so the
+      workspace is not left half-updated.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -444,15 +440,11 @@ requirements:
       writing files, with both machine-readable and reviewer-friendly output.
       `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
       MUST disable it. Autofix MUST stay conservative and avoid speculative
-      structural edits.
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
-      It MAY also remove exact duplicate graph links, restore already-declared
-      reciprocal links, and resynchronize the feature registry with checked-in
-      feature documents when one safe correction is obvious. If a later write
-      fails, it MUST roll back earlier writes so the workspace is not left
-      half-updated.
+      structural edits. It MAY also remove exact duplicate graph links,
+      restore already-declared reciprocal links, and resynchronize the feature
+      registry with checked-in feature documents when one safe correction is
+      obvious. If a later write fails, it MUST roll back earlier writes so the
+      workspace is not left half-updated.
     priority: high
     status: implemented
     linked_policies:

--- a/docs/guide/existing-repository.md
+++ b/docs/guide/existing-repository.md
@@ -172,8 +172,11 @@ ready to claim traces yet, leave it `planned`.
 
 Use `syu validate . --fix --dry-run` when you want to preview the autofix plan
 before changing files. Once you have decided the owning IDs, `syu validate .
---fix` is good at inserting required doc-comment snippets; it does not choose
-the right graph links for you.
+--fix` is good at inserting required doc-comment snippets, removing exact
+duplicate graph links, restoring already-declared reciprocal links, and
+resynchronizing the feature registry when the checked-in feature documents and
+registry disagree in a deterministic way. It still does not choose ambiguous
+graph links for you.
 
 If one small file is intentionally owned by one requirement or feature, you can
 use `symbols: ['*']` instead of enumerating every public symbol by hand.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -538,10 +538,12 @@ If a traced symbol is missing required documentation snippets, run:
 syu validate . --fix
 ```
 
-Autofix is conservative. It currently repairs documentation-style trace gaps
-for Rust, Python, Go, and TypeScript without guessing at larger structural changes.
-If you want to preview the same fix set without writing files, use
-`syu validate . --fix --dry-run` and review the printed plan instead.
+Autofix is conservative. It repairs documentation-style trace gaps, exact
+duplicate graph links, already-declared reciprocal links, and feature
+registry drift when one safe correction is obvious. It still avoids guessing
+at new links or larger structural changes. If you want to preview the same fix
+set without writing files, use `syu validate . --fix --dry-run` and review the
+printed plan instead.
 
 ## 6. Generate a report
 

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -180,15 +180,11 @@ requirements:
       writing files, with both machine-readable and reviewer-friendly output.
       `syu.yaml` MUST be able to configure default fix behavior, and `--no-fix`
       MUST disable it. Autofix MUST stay conservative and avoid speculative
-      structural edits.
-      mechanical repairs for documentation-style trace gaps. `syu.yaml` MUST be
-      able to configure default fix behavior, and `--no-fix` MUST disable it.
-      Autofix MUST stay conservative and avoid speculative structural edits.
-      It MAY also remove exact duplicate graph links, restore already-declared
-      reciprocal links, and resynchronize the feature registry with checked-in
-      feature documents when one safe correction is obvious. If a later write
-      fails, it MUST roll back earlier writes so the workspace is not left
-      half-updated.
+      structural edits. It MAY also remove exact duplicate graph links,
+      restore already-declared reciprocal links, and resynchronize the feature
+      registry with checked-in feature documents when one safe correction is
+      obvious. If a later write fails, it MUST roll back earlier writes so the
+      workspace is not left half-updated.
     priority: high
     status: implemented
     linked_policies:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -577,7 +577,9 @@ pub struct ValidateArgs {
     #[arg(long, action = ArgAction::SetTrue)]
     pub spec_only: bool,
 
-    #[arg(help = "Apply conservative documentation autofixes")]
+    #[arg(
+        help = "Apply conservative autofixes for trace docs, graph links, and feature registry drift"
+    )]
     #[arg(long, action = ArgAction::SetTrue)]
     pub fix: bool,
 


### PR DESCRIPTION
Summary:
- Clarify `syu validate --fix` help and docs so they match the actual conservative autofix behavior.
- Document the deterministic graph repairs and feature-registry resync that `--fix` already supports.

Validation:
- `cargo fmt --check`
- `cargo test --test validate_fix_command`

Closes #658
