### PR TITLE
Add trace adapter capability conformance harness

### DIFF
--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -173,6 +173,9 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
           - python_only_example_validates
           - ruby_only_example_validates
           - polyglot_example_validates
+      - **file**: tests/trace_adapter_conformance.rs
+        - **symbols**:
+          - built_in_trace_adapters_share_one_capability_matrix
     - **python**:
       - **file**: tests/fixtures/workspaces/passing/python/test_traceability.py
         - **symbols**:
@@ -419,6 +422,9 @@ requirements:
             - python_only_example_validates
             - ruby_only_example_validates
             - polyglot_example_validates
+        - file: tests/trace_adapter_conformance.rs
+          symbols:
+            - built_in_trace_adapters_share_one_capability_matrix
       python:
         - file: tests/fixtures/workspaces/passing/python/test_traceability.py
           symbols:

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,7 +14,7 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 120/120
+- Requirement-to-test traceability: 121/121
 - Feature-to-implementation traceability: 136/136
 
 ## Issues

--- a/docs/guide/trace-adapter-support.md
+++ b/docs/guide/trace-adapter-support.md
@@ -14,27 +14,30 @@ This page summarizes the built-in trace adapters that ship with this checked-in
 version of `syu`. Use it before you turn on `doc_contains` checks widely or
 enable strict coverage in a mixed-language repository.
 
+The checked-in conformance harness uses the same capability matrix, so update
+both together when adapter support changes.
+
 OpenAPI-backed feature traces are separate from these adapters. Use the OpenAPI
 selector shape when the feature is proved by an API contract document instead
 of a source symbol.
 
 ## Built-in adapter matrix
 
-| Built-in adapter | Accepted `lang:` aliases / files | Symbol existence validation | `doc_contains` validation | Strict `require_symbol_trace_coverage` inventory |
-| --- | --- | --- | --- | --- |
-| Rust | `rust`, `rs` / `.rs` | ✅ Rich symbol inspection plus declaration matching | ✅ | ✅ |
-| Python | `python`, `py`, `pytest`, `unittest` / `.py` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
-| Ruby | `ruby`, `rb`, `minitest`, `rspec` / `.rb` | ✅ Pattern-based symbol matching plus declaration-adjacent line-comment inspection | ✅ | ✅ |
-| Go | `go`, `golang`, `gotest` / `.go` | ✅ Rich doc-comment inspection plus pattern fallback | ✅ | ✅ |
-| Java | `java`, `junit` / `.java` | ✅ Pattern-based symbol matching plus declaration-adjacent Javadoc inspection | ✅ | ✅ |
-| C# | `csharp`, `cs`, `dotnet`, `xunit`, `nunit`, `mstest` / `.cs` | ✅ Pattern-based symbol matching plus declaration-adjacent XML doc inspection | ✅ | ✅ |
-| Kotlin | `kotlin`, `kt` / `.kt` | ✅ Pattern-based symbol matching plus declaration-adjacent KDoc inspection | ✅ | ✅ |
-| TypeScript / JavaScript | `typescript`, `ts`, `tsx`, `javascript`, `js`, `jsx`, `vitest`, `bun`, `bun-test` / `.ts`, `.tsx`, `.js`, `.jsx` | ✅ Rich symbol inspection plus pattern fallback | ✅ | ✅ |
-| Shell | `shell`, `sh`, `bash`, `zsh` / `.sh`, `.bash`, `.zsh` | ✅ Pattern-based symbol matching | ❌ | ❌ |
-| YAML | `yaml`, `yml` / `.yaml`, `.yml` | ✅ Pattern-based symbol matching | ❌ | ❌ |
-| JSON | `json` / `.json` | ✅ Pattern-based symbol matching | ❌ | ❌ |
-| Markdown | `markdown`, `md` / `.md` | ✅ Pattern-based symbol matching | ❌ | ❌ |
-| Gitignore | `gitignore`, `ignore` / `.gitignore` | ✅ Filename-aware, pattern-based matching | ❌ | ❌ |
+| Built-in adapter | Accepted `lang:` aliases / files | Symbol existence validation | `doc_contains` validation | Strict `require_symbol_trace_coverage` inventory | Autofix |
+| --- | --- | --- | --- | --- | --- |
+| Rust | `rust`, `rs` / `.rs` | ✅ | ✅ | ✅ | ✅ |
+| Python | `python`, `py`, `pytest`, `unittest` / `.py` | ✅ | ✅ | ✅ | ✅ |
+| Ruby | `ruby`, `rb`, `minitest`, `rspec` / `.rb` | ✅ | ✅ | ✅ | ✅ |
+| Go | `go`, `golang`, `gotest` / `.go` | ✅ | ✅ | ✅ | ✅ |
+| Java | `java`, `junit` / `.java` | ✅ | ✅ | ✅ | ✅ |
+| C# | `csharp`, `cs`, `dotnet`, `xunit`, `nunit`, `mstest` / `.cs` | ✅ | ✅ | ✅ | ✅ |
+| Kotlin | `kotlin`, `kt` / `.kt` | ✅ | ✅ | ✅ | ✅ |
+| TypeScript / JavaScript | `typescript`, `ts`, `tsx`, `javascript`, `js`, `jsx`, `vitest`, `bun`, `bun-test` / `.ts`, `.tsx`, `.js`, `.jsx` | ✅ | ✅ | ✅ | ✅ |
+| Shell | `shell`, `sh`, `bash`, `zsh` / `.sh`, `.bash`, `.zsh` | ✅ | ❌ | ❌ | ❌ |
+| YAML | `yaml`, `yml` / `.yaml`, `.yml` | ✅ | ❌ | ❌ | ❌ |
+| JSON | `json` / `.json` | ✅ | ❌ | ❌ | ❌ |
+| Markdown | `markdown`, `md` / `.md` | ✅ | ❌ | ❌ | ❌ |
+| Gitignore | `gitignore`, `ignore` / `.gitignore` | ✅ | ❌ | ❌ | ❌ |
 
 ## What the strict inventory scans
 
@@ -64,10 +67,10 @@ they do **not** participate in the repository-wide strict ownership scan.
 
 ## How to choose the right promises
 
-- Need `doc_contains`? Rust, Python, Ruby, Go, Java, C#, Kotlin, and TypeScript /
-  JavaScript traces all
-  support it today. For a staged rollout, starter examples, and "when should I
-  add this?" guidance, use the [dedicated `doc_contains` adoption guide](./doc-contains.md).
+- Need `doc_contains` or autofix? Rust, Python, Ruby, Go, Java, C#, Kotlin, and
+  TypeScript / JavaScript traces support both today. For a staged rollout,
+  starter examples, and "when should I add this?" guidance, use the [dedicated
+  `doc_contains` adoption guide](./doc-contains.md).
 - Need strict ownership coverage? Rust, Python, Ruby, Go, Java, C#, Kotlin, and
   TypeScript / JavaScript all participate today.
 - Using Shell, YAML, JSON, Markdown, or Gitignore traces? Keep the mapping to

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -155,6 +155,9 @@ requirements:
             - python_only_example_validates
             - ruby_only_example_validates
             - polyglot_example_validates
+        - file: tests/trace_adapter_conformance.rs
+          symbols:
+            - built_in_trace_adapters_share_one_capability_matrix
       python:
         - file: tests/fixtures/workspaces/passing/python/test_traceability.py
           symbols:

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -13,6 +13,7 @@ use syn::{Attribute, ImplItem, Item, Visibility};
 use crate::{
     config::SyuConfig,
     inspect::{inspect_python_file, inspect_typescript_file},
+    language::{LanguageAdapter, adapter_for_language},
     model::{Feature, Issue, Requirement, TraceReference},
     workspace::Workspace,
 };
@@ -29,6 +30,17 @@ struct CoverageTarget {
     symbol: String,
     kind: CoverageTargetKind,
 }
+
+pub const STRICT_INVENTORY_LANGUAGES: &[&str] = &[
+    "rust",
+    "python",
+    "ruby",
+    "go",
+    "java",
+    "csharp",
+    "kotlin",
+    "typescript",
+];
 
 #[derive(Debug, Default, Clone)]
 struct CoverageMap {
@@ -54,6 +66,12 @@ struct CoverageDiscoverers {
     csharp: DiscoveryWithIssuesFn,
     kotlin: DiscoveryWithIssuesFn,
     typescript: DiscoveryWithIssuesFn,
+}
+
+pub fn supports_strict_inventory(language: &str) -> bool {
+    adapter_for_language(language)
+        .map(LanguageAdapter::canonical_name)
+        .is_some_and(|canonical| STRICT_INVENTORY_LANGUAGES.contains(&canonical))
 }
 
 pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Issue>) {

--- a/tests/trace_adapter_conformance.rs
+++ b/tests/trace_adapter_conformance.rs
@@ -12,7 +12,9 @@ use tempfile::tempdir;
 
 struct TraceAdapterCase {
     label: &'static str,
+    row_label: &'static str,
     language: &'static str,
+    canonical_name: &'static str,
     path: &'static str,
     source: &'static str,
     symbol: &'static str,
@@ -25,7 +27,9 @@ const CAPABILITY_SNIPPET: &str = "capability harness";
 const CASES: &[TraceAdapterCase] = &[
     TraceAdapterCase {
         label: "Rust",
+        row_label: "Rust",
         language: "rust",
+        canonical_name: "rust",
         path: "src/trace.rs",
         source: "/// existing docs\npub fn trace_harness_rust() {}\n",
         symbol: "trace_harness_rust",
@@ -34,7 +38,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Python",
+        row_label: "Python",
         language: "python",
+        canonical_name: "python",
         path: "src/trace.py",
         source: "def trace_harness_python():\n    \"\"\"existing docs\"\"\"\n    pass\n",
         symbol: "trace_harness_python",
@@ -43,7 +49,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Ruby",
+        row_label: "Ruby",
         language: "ruby",
+        canonical_name: "ruby",
         path: "src/trace.rb",
         source: "# existing docs\ndef trace_harness_ruby\n  true\nend\n",
         symbol: "trace_harness_ruby",
@@ -52,7 +60,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Go",
+        row_label: "Go",
         language: "go",
+        canonical_name: "go",
         path: "src/trace.go",
         source: "// existing docs\nfunc TraceHarnessGo() {}\n",
         symbol: "TraceHarnessGo",
@@ -61,7 +71,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Java",
+        row_label: "Java",
         language: "java",
+        canonical_name: "java",
         path: "src/TraceHarnessJava.java",
         source: "/** existing docs */\npublic class TraceHarnessJava {}\n",
         symbol: "TraceHarnessJava",
@@ -70,7 +82,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "C#",
+        row_label: "C#",
         language: "csharp",
+        canonical_name: "csharp",
         path: "src/TraceHarnessCSharp.cs",
         source: "/// existing docs\npublic class TraceHarnessCSharp {}\n",
         symbol: "TraceHarnessCSharp",
@@ -79,7 +93,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Kotlin",
+        row_label: "Kotlin",
         language: "kotlin",
+        canonical_name: "kotlin",
         path: "src/TraceHarnessKotlin.kt",
         source: "/** existing docs */\nfun traceHarnessKotlin() {}\n",
         symbol: "traceHarnessKotlin",
@@ -87,8 +103,10 @@ const CASES: &[TraceAdapterCase] = &[
         strict_inventory: true,
     },
     TraceAdapterCase {
-        label: "TypeScript / JavaScript",
+        label: "TypeScript",
+        row_label: "TypeScript / JavaScript",
         language: "typescript",
+        canonical_name: "typescript",
         path: "src/trace-harness.ts",
         source: "/** existing docs */\nexport function traceHarnessTs() {}\n",
         symbol: "traceHarnessTs",
@@ -96,8 +114,21 @@ const CASES: &[TraceAdapterCase] = &[
         strict_inventory: true,
     },
     TraceAdapterCase {
+        label: "JavaScript",
+        row_label: "TypeScript / JavaScript",
+        language: "javascript",
+        canonical_name: "typescript",
+        path: "src/trace-harness.js",
+        source: "/** existing docs */\nexport function traceHarnessJs() {}\n",
+        symbol: "traceHarnessJs",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
         label: "Shell",
+        row_label: "Shell",
         language: "shell",
+        canonical_name: "shell",
         path: "scripts/trace.sh",
         source: "trace_harness_shell() { :; }\n",
         symbol: "trace_harness_shell",
@@ -106,7 +137,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "YAML",
+        row_label: "YAML",
         language: "yaml",
+        canonical_name: "yaml",
         path: "config/trace.yaml",
         source: "trace_harness_yaml: true\n",
         symbol: "trace_harness_yaml",
@@ -115,7 +148,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "JSON",
+        row_label: "JSON",
         language: "json",
+        canonical_name: "json",
         path: "config/trace.json",
         source: "{\"trace_harness_json\": true}\n",
         symbol: "trace_harness_json",
@@ -124,7 +159,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Markdown",
+        row_label: "Markdown",
         language: "markdown",
+        canonical_name: "markdown",
         path: "README.md",
         source: "# trace_harness_markdown\n",
         symbol: "trace_harness_markdown",
@@ -133,7 +170,9 @@ const CASES: &[TraceAdapterCase] = &[
     },
     TraceAdapterCase {
         label: "Gitignore",
+        row_label: "Gitignore",
         language: "gitignore",
+        canonical_name: "gitignore",
         path: ".gitignore",
         source: "trace_harness_gitignore\n",
         symbol: "trace_harness_gitignore",
@@ -166,7 +205,7 @@ fn display_extensions(adapter: &dyn LanguageAdapter) -> String {
 fn expected_row(case: &TraceAdapterCase, adapter: &dyn LanguageAdapter) -> String {
     format!(
         "| {} | {} / {} | {} | {} | {} | {} |",
-        case.label,
+        case.row_label,
         backticked_list(adapter.aliases()),
         display_extensions(adapter),
         checkmark(true),
@@ -185,7 +224,7 @@ fn built_in_trace_adapters_share_one_capability_matrix() {
         let adapter = adapter_for_language(case.language).expect("adapter should exist");
         assert_eq!(
             adapter.canonical_name(),
-            case.language,
+            case.canonical_name,
             "unexpected canonical adapter for {}",
             case.label
         );

--- a/tests/trace_adapter_conformance.rs
+++ b/tests/trace_adapter_conformance.rs
@@ -1,0 +1,274 @@
+// REQ-CORE-002
+// REQ-CORE-003
+
+use std::fs;
+use syu::{
+    config::SyuConfig,
+    coverage::supports_strict_inventory,
+    inspect::{apply_symbol_doc_fix, inspect_symbol, supports_rich_inspection},
+    language::{LanguageAdapter, adapter_for_language},
+};
+use tempfile::tempdir;
+
+struct TraceAdapterCase {
+    label: &'static str,
+    language: &'static str,
+    path: &'static str,
+    source: &'static str,
+    symbol: &'static str,
+    doc_contains: bool,
+    strict_inventory: bool,
+}
+
+const CAPABILITY_SNIPPET: &str = "capability harness";
+
+const CASES: &[TraceAdapterCase] = &[
+    TraceAdapterCase {
+        label: "Rust",
+        language: "rust",
+        path: "src/trace.rs",
+        source: "/// existing docs\npub fn trace_harness_rust() {}\n",
+        symbol: "trace_harness_rust",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Python",
+        language: "python",
+        path: "src/trace.py",
+        source: "def trace_harness_python():\n    \"\"\"existing docs\"\"\"\n    pass\n",
+        symbol: "trace_harness_python",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Ruby",
+        language: "ruby",
+        path: "src/trace.rb",
+        source: "# existing docs\ndef trace_harness_ruby\n  true\nend\n",
+        symbol: "trace_harness_ruby",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Go",
+        language: "go",
+        path: "src/trace.go",
+        source: "// existing docs\nfunc TraceHarnessGo() {}\n",
+        symbol: "TraceHarnessGo",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Java",
+        language: "java",
+        path: "src/TraceHarnessJava.java",
+        source: "/** existing docs */\npublic class TraceHarnessJava {}\n",
+        symbol: "TraceHarnessJava",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "C#",
+        language: "csharp",
+        path: "src/TraceHarnessCSharp.cs",
+        source: "/// existing docs\npublic class TraceHarnessCSharp {}\n",
+        symbol: "TraceHarnessCSharp",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Kotlin",
+        language: "kotlin",
+        path: "src/TraceHarnessKotlin.kt",
+        source: "/** existing docs */\nfun traceHarnessKotlin() {}\n",
+        symbol: "traceHarnessKotlin",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "TypeScript / JavaScript",
+        language: "typescript",
+        path: "src/trace-harness.ts",
+        source: "/** existing docs */\nexport function traceHarnessTs() {}\n",
+        symbol: "traceHarnessTs",
+        doc_contains: true,
+        strict_inventory: true,
+    },
+    TraceAdapterCase {
+        label: "Shell",
+        language: "shell",
+        path: "scripts/trace.sh",
+        source: "trace_harness_shell() { :; }\n",
+        symbol: "trace_harness_shell",
+        doc_contains: false,
+        strict_inventory: false,
+    },
+    TraceAdapterCase {
+        label: "YAML",
+        language: "yaml",
+        path: "config/trace.yaml",
+        source: "trace_harness_yaml: true\n",
+        symbol: "trace_harness_yaml",
+        doc_contains: false,
+        strict_inventory: false,
+    },
+    TraceAdapterCase {
+        label: "JSON",
+        language: "json",
+        path: "config/trace.json",
+        source: "{\"trace_harness_json\": true}\n",
+        symbol: "trace_harness_json",
+        doc_contains: false,
+        strict_inventory: false,
+    },
+    TraceAdapterCase {
+        label: "Markdown",
+        language: "markdown",
+        path: "README.md",
+        source: "# trace_harness_markdown\n",
+        symbol: "trace_harness_markdown",
+        doc_contains: false,
+        strict_inventory: false,
+    },
+    TraceAdapterCase {
+        label: "Gitignore",
+        language: "gitignore",
+        path: ".gitignore",
+        source: "trace_harness_gitignore\n",
+        symbol: "trace_harness_gitignore",
+        doc_contains: false,
+        strict_inventory: false,
+    },
+];
+
+fn checkmark(value: bool) -> &'static str {
+    if value { "✅" } else { "❌" }
+}
+
+fn backticked_list(values: &[&str]) -> String {
+    values
+        .iter()
+        .map(|value| format!("`{value}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn display_extensions(adapter: &dyn LanguageAdapter) -> String {
+    adapter
+        .extensions()
+        .iter()
+        .map(|extension| format!("`.{extension}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn expected_row(case: &TraceAdapterCase, adapter: &dyn LanguageAdapter) -> String {
+    format!(
+        "| {} | {} / {} | {} | {} | {} | {} |",
+        case.label,
+        backticked_list(adapter.aliases()),
+        display_extensions(adapter),
+        checkmark(true),
+        checkmark(case.doc_contains),
+        checkmark(case.strict_inventory),
+        checkmark(case.doc_contains),
+    )
+}
+
+#[test]
+fn built_in_trace_adapters_share_one_capability_matrix() {
+    let documentation = std::fs::read_to_string("docs/guide/trace-adapter-support.md")
+        .expect("trace adapter support guide should exist");
+
+    for case in CASES {
+        let adapter = adapter_for_language(case.language).expect("adapter should exist");
+        assert_eq!(
+            adapter.canonical_name(),
+            case.language,
+            "unexpected canonical adapter for {}",
+            case.label
+        );
+        assert!(adapter.symbol_exists(case.source, case.symbol));
+        assert_eq!(
+            supports_rich_inspection(case.language),
+            case.doc_contains,
+            "doc_contains capability drift for {}",
+            case.label
+        );
+        assert_eq!(
+            supports_strict_inventory(case.language),
+            case.strict_inventory,
+            "strict inventory capability drift for {}",
+            case.label
+        );
+
+        if case.doc_contains {
+            let tempdir = tempdir().expect("tempdir should exist");
+            let path = tempdir.path().join(case.path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("parent directory should exist");
+            }
+            fs::write(&path, case.source).expect("sample file should be writable");
+
+            let inspected = inspect_symbol(
+                case.language,
+                &SyuConfig::default(),
+                &path,
+                case.source,
+                case.symbol,
+            )
+            .expect("inspection should succeed")
+            .expect("rich inspection should find the symbol");
+
+            assert!(
+                inspected.docs.contains("existing docs"),
+                "expected doc inspection for {}",
+                case.label
+            );
+
+            let updated = apply_symbol_doc_fix(
+                case.language,
+                &SyuConfig::default(),
+                &path,
+                case.source,
+                case.symbol,
+                &[CAPABILITY_SNIPPET.to_string()],
+            )
+            .expect("doc autofix should succeed")
+            .expect("rich inspection languages should support autofix");
+
+            assert!(
+                updated.contains(CAPABILITY_SNIPPET),
+                "expected autofix for {} to insert the requested snippet",
+                case.label
+            );
+        } else {
+            let tempdir = tempdir().expect("tempdir should exist");
+            let path = tempdir.path().join(case.path);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("parent directory should exist");
+            }
+            fs::write(&path, case.source).expect("sample file should be writable");
+
+            assert_eq!(
+                inspect_symbol(
+                    case.language,
+                    &SyuConfig::default(),
+                    &path,
+                    case.source,
+                    case.symbol,
+                )
+                .expect("inspection should not fail"),
+                None
+            );
+        }
+
+        let expected_row = expected_row(case, adapter);
+        assert!(
+            documentation.contains(&expected_row),
+            "missing matrix row for {}: {expected_row}",
+            case.label
+        );
+    }
+}


### PR DESCRIPTION
Summary:
- Add a table-driven trace-adapter conformance harness that checks symbol validation, `doc_contains`, strict ownership inventory, and autofix behavior against the built-in adapters.
- Mirror the same capability matrix in the trace-adapter support guide and keep the validation requirement trace aligned.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test built_in_trace_adapters_share_one_capability_matrix --test trace_adapter_conformance -- --exact`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test repository_declares_documentation_guides --test repository_quality -- --exact`
- `cargo fmt --all --check`
- `syu validate .` via the commit hook

Closes #651
