### PR TITLE
Align Ruby trace support docs with current capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Key behaviors:
 - `validate.allow_planned` controls whether `planned` requirements and features are allowed at all
 - `validate.require_non_orphaned_items` turns isolated layered definitions into validation errors
 - `validate.require_reciprocal_links` keeps adjacent-layer backlinks mandatory by default while still allowing phased migration when disabled
-- `validate.require_symbol_trace_coverage` opt-in checks that public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols belong to features and tests belong to requirements, while still skipping configured repository-relative generated paths
+- `validate.require_symbol_trace_coverage` opt-in checks that public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols belong to features and tests belong to requirements, with Ruby covered by the same inventory rules, while still skipping configured repository-relative generated paths
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence
 - `app.bind` and `app.port` define the default local browser-app address and port unless `--bind` / `--port` override them
 - `report.output` sets the default `syu report` destination while `--output` still takes precedence
@@ -720,7 +720,7 @@ Today autofix repairs documentation-style trace gaps plus a few deterministic
 graph and registry issues:
 
 - missing requirement / feature IDs in symbol documentation
-- missing `doc_contains` snippets for Rust, Python, Go, and TypeScript symbols
+- missing `doc_contains` snippets for Rust, Python, Ruby, Go, and TypeScript symbols
 - exact duplicate graph links in philosophy / policy / requirement / feature files
 - missing reciprocal graph links when the opposite side is already declared
 - drift between checked-in feature documents and `features/features.yaml`

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -211,8 +211,9 @@ items:
       When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
       Kotlin, and TypeScript/JavaScript symbol to belong to some feature and
       every test in those inventoried languages to belong to some requirement,
-      in addition to verifying declared traces. The validate command can enable
-      or disable this for one run with `--require-symbol-trace-coverage` or
+      in addition to verifying declared traces. Ruby uses the same strict
+      ownership inventory path. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.
   - key: validate.trace_ownership_mode
     type: enum(mapping|inline|sidecar)

--- a/docs/generated/site-spec/config/validate.md
+++ b/docs/generated/site-spec/config/validate.md
@@ -85,14 +85,15 @@ description: "Generated reference for docs/syu/config/validate.yaml"
 - **key**: validate.require_symbol_trace_coverage
   - **type**: boolean
   - **default**: False
-  - **summary**: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests.
+  - **summary**: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests, with Ruby covered by the same inventory rules.
   - **description**:
     - |
       When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
       Kotlin, and TypeScript/JavaScript symbol to belong to some feature and
       every test in those inventoried languages to belong to some requirement,
-      in addition to verifying declared traces. The validate command can enable
-      or disable this for one run with `--require-symbol-trace-coverage` or
+      in addition to verifying declared traces. Ruby uses the same strict
+      ownership inventory path. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.
 - **key**: validate.trace_ownership_mode
   - **type**: enum(mapping|inline|sidecar)
@@ -205,7 +206,7 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests.
+    summary: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests, with Ruby covered by the same inventory rules.
     description: |
       When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
       Kotlin, and TypeScript/JavaScript symbol to belong to some feature and

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -858,7 +858,7 @@ rules:
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, C#, Kotlin, and TypeScript/JavaScript source and test files.
+      Java, C#, Kotlin, TypeScript/JavaScript, and Ruby source and test files.
       Generated-path ignores keep common build output such as `build/`,
       `coverage/`, `dist/`, and `target/` out of the inventory without hiding
       authored nested paths like `src/build/`. If directory discovery fails, the

--- a/docs/generated/site-spec/features/validation/validation.md
+++ b/docs/generated/site-spec/features/validation/validation.md
@@ -400,12 +400,12 @@ description: "Generated reference for docs/syu/features/validation/validation.ya
   - **genre**: coverage
   - **severity**: error
   - **title**: Coverage inventory paths must be walkable
-  - **summary**: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+  - **summary**: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, with Ruby included in the same inventory pass, while skipping configured repository-relative generated paths.
   - **description**:
     - |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, C#, Kotlin, and TypeScript/JavaScript source and test files.
+      Java, C#, Kotlin, TypeScript/JavaScript, and Ruby source and test files.
       Generated-path ignores keep common build output such as `build/`,
       `coverage/`, `dist/`, and `target/` out of the inventory without hiding
       authored nested paths like `src/build/`. If directory discovery fails, the
@@ -854,7 +854,7 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, with Ruby included in the same inventory pass, while skipping configured repository-relative generated paths.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -142,7 +142,7 @@ of editing `syu.yaml`.
 
 ### `validate.require_symbol_trace_coverage`
 
-When `true`, `syu` scans Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files to confirm that every public symbol belongs to some feature and every test belongs to some requirement.
+When `true`, `syu` scans Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files, plus Ruby source and test files, to confirm that every public symbol belongs to some feature and every test belongs to some requirement.
 
 - `false`: only declared traces are verified
 - `true`: undeclared public APIs and tests become validation errors
@@ -159,8 +159,8 @@ That example keeps the higher-layer spec and surrounding automation explicit
 without requiring every checked-in C# file to be traced immediately. Use
 [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 or `syu init . --template go-only` as a reminder that Go now supports symbol
-checks, coverage ownership, and `doc_contains`, and that Java, C#, and Kotlin do
-too.
+checks, coverage ownership, and `doc_contains`, and that Ruby, Java, C#, and
+Kotlin do too.
 
 ### `validate.trace_ownership_mode`
 

--- a/docs/guide/doc-contains.md
+++ b/docs/guide/doc-contains.md
@@ -40,6 +40,7 @@ the few symbols where comment-level evidence genuinely helps.
 
 - **Rust**
 - **Python**
+- **Ruby**
 - **Go**
 - **Java**
 - **C#**
@@ -49,9 +50,9 @@ the few symbols where comment-level evidence genuinely helps.
 For the full matrix, including strict ownership coverage and symbol-only
 adapters, use the [trace adapter capability matrix](./trace-adapter-support.md).
 
-Languages such as Ruby, Shell, YAML, JSON, Markdown, and Gitignore can still use
-explicit `file` + `symbols` traces, but they do not validate `doc_contains`
-yet.
+Ruby can use `doc_contains` now. Shell, YAML, JSON, Markdown, and Gitignore can
+still use explicit `file` + `symbols` traces, but they do not validate
+`doc_contains` yet.
 
 ## Starter-level examples to copy from
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -249,11 +249,11 @@ until you are ready to declare real tests and implementation traces.
 
 ### Unsupported implementation languages can still adopt the spec layers first
 
-`syu` can validate code-level traces today in Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript, plus lighter file/symbol ownership in `shell`, `yaml`, `json`, `markdown`, and `gitignore`. Repositories that still contain other
+`syu` can validate code-level traces today in Rust, Python, Ruby, Go, Java, C#, Kotlin, and TypeScript/JavaScript, plus lighter file/symbol ownership in `shell`, `yaml`, `json`, `markdown`, and `gitignore`. Repositories that still contain other
 unsupported implementation languages can still adopt `syu` today, but they
 should treat code-level mappings for those files as future work.
 
-Go, Java, C#, and Kotlin already participate in strict `validate.require_symbol_trace_coverage` inventory. Go, Java, C#, and Kotlin now support `doc_contains` checks as well. The [trace adapter capability matrix](./trace-adapter-support.md)
+Go, Ruby, Java, C#, and Kotlin already participate in strict `validate.require_symbol_trace_coverage` inventory. Go, Ruby, Java, C#, and Kotlin now support `doc_contains` checks as well. The [trace adapter capability matrix](./trace-adapter-support.md)
 summarizes that language-by-language support.
 
 Today you can still:
@@ -290,11 +290,13 @@ implementations:
 What you should avoid for unsupported-language files today is adding
 language-specific `tests:` or `implementations:` entries before the adapter
 exists at all. If you need code-level tracing with `doc_contains`, stay with
-Rust, Python, Go, Java, C#, Kotlin, or TypeScript/JavaScript for now. For
-Ruby-first repositories, use
+Rust, Python, Ruby, Go, Java, C#, Kotlin, or TypeScript/JavaScript for now.
+For Ruby-first repositories, use
 [`examples/ruby-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/ruby-only)
-or `syu init . --template ruby-only`: both use real Ruby files plus symbol-level
-trace mappings that validate today.
+or `syu init . --template ruby-only`: both use real Ruby files plus
+symbol-level trace mappings that validate today, and the Ruby adapter can also
+inspect adjacent comments and enforce strict ownership inventory when the
+symbol shape is stable.
 For Go-first repositories,
 use [`examples/go-only` workspace on GitHub](https://github.com/ugoite/syu/tree/main/examples/go-only)
 or `syu init . --template go-only`: both use real Go files plus symbol-level

--- a/docs/syu/config/validate.yaml
+++ b/docs/syu/config/validate.yaml
@@ -60,13 +60,14 @@ items:
   - key: validate.require_symbol_trace_coverage
     type: boolean
     default: false
-    summary: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests.
+    summary: Enforces ownership for public Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript symbols and tests, with Ruby covered by the same inventory rules.
     description: |
       When enabled, `syu` requires every public Rust, Python, Go, Java, C#,
       Kotlin, and TypeScript/JavaScript symbol to belong to some feature and
       every test in those inventoried languages to belong to some requirement,
-      in addition to verifying declared traces. The validate command can enable
-      or disable this for one run with `--require-symbol-trace-coverage` or
+      in addition to verifying declared traces. Ruby uses the same strict
+      ownership inventory path. The validate command can enable or disable this
+      for one run with `--require-symbol-trace-coverage` or
       `--require-symbol-trace-coverage=false`.
   - key: validate.trace_ownership_mode
     type: enum(mapping|inline|sidecar)

--- a/docs/syu/features/validation/validation.yaml
+++ b/docs/syu/features/validation/validation.yaml
@@ -389,11 +389,11 @@ rules:
     genre: coverage
     severity: error
     title: Coverage inventory paths must be walkable
-    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, while skipping configured repository-relative generated paths.
+    summary: Strict trace coverage starts by discovering supported Rust, Python, Go, Java, C#, Kotlin, and TypeScript/JavaScript source and test files under `src/` and `tests/`, with Ruby included in the same inventory pass, while skipping configured repository-relative generated paths.
     description: |
       The strict trace coverage rule only means something when `syu` can walk the
       repository paths that are supposed to contain owned Rust, Python, Go,
-      Java, C#, Kotlin, and TypeScript/JavaScript source and test files.
+      Java, C#, Kotlin, TypeScript/JavaScript, and Ruby source and test files.
       Generated-path ignores keep common build output such as `build/`,
       `coverage/`, `dist/`, and `target/` out of the inventory without hiding
       authored nested paths like `src/build/`. If directory discovery fails, the


### PR DESCRIPTION
Summary:
- Updated the Ruby trace-adapter docs to reflect that Ruby now supports `doc_contains`, strict inventory, and autofix parity.
- Aligned the top-level README and getting-started/configuration guides with the current Ruby capability matrix.
- Synced the checked-in config/spec docs that describe trace coverage and inventory support.

Validation:
- `cargo test --test trace_adapter_conformance --test example_workspaces ruby_only_example_validates` (blocked by the repo build script's pinned npm check: expected npm 11.8.0, found 11.12.1)
- `git diff --check`

Closes #655
