### PR TITLE
ci: expose uncovered coverage lines

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -35,3 +35,5 @@ runs:
 
     - name: Restore Rust cache
       uses: Swatinem/rust-cache@v2
+      with:
+        cache-bin: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         run: scripts/ci/coverage.sh lcov
 
       - name: Upload coverage artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: lcov

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -62,19 +62,44 @@ lcov_path = sys.argv[1]
 threshold = float(sys.argv[2])
 covered = 0
 total = 0
+current_file = None
+misses = []
 
 with open(lcov_path, encoding="utf-8") as handle:
     for line in handle:
+        if line.startswith("SF:"):
+            current_file = line[3:].strip()
+            continue
         if not line.startswith("DA:"):
             continue
         _, payload = line.split(":", 1)
-        _, count = payload.strip().split(",", 1)
+        line_number_text, count = payload.strip().split(",", 1)
+        line_number = int(line_number_text)
         total += 1
-        covered += int(int(count) > 0)
+        if int(count) > 0:
+            covered += 1
+        else:
+            misses.append((current_file, line_number))
 
 coverage = 100.0 if total == 0 else covered * 100.0 / total
 print(f"line coverage: {coverage:.2f}% ({covered}/{total})")
 if coverage + 1e-9 < threshold:
+    print("\nuncovered executable lines:")
+    by_file = {}
+    for filename, line_number in misses:
+        by_file.setdefault(filename or "<unknown>", []).append(line_number)
+    for filename, line_numbers in by_file.items():
+        print(f"\n{filename} ({len(line_numbers)} missed)")
+        try:
+            with open(filename, encoding="utf-8") as source:
+                source_lines = source.read().splitlines()
+        except OSError:
+            source_lines = []
+        for line_number in line_numbers:
+            snippet = ""
+            if 1 <= line_number <= len(source_lines):
+                snippet = source_lines[line_number - 1].strip()
+            print(f"  {line_number}: {snippet}")
     raise SystemExit(1)
 PY
 }
@@ -98,18 +123,18 @@ run_coverage() {
   case "$mode" in
     summary)
       generate_lcov target/coverage/lcov.info
-      enforce_lcov_threshold target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
+      enforce_lcov_threshold target/coverage/lcov.info
       ;;
     lcov)
       generate_lcov target/coverage/lcov.info
-      enforce_lcov_threshold target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
+      enforce_lcov_threshold target/coverage/lcov.info
       ;;
     html)
       generate_lcov target/coverage/lcov.info
-      enforce_lcov_threshold target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
+      enforce_lcov_threshold target/coverage/lcov.info
       cargo llvm-cov --no-run --html
       ;;
     *)


### PR DESCRIPTION
## Summary
- keep the 100% line coverage gate intact
- print uncovered LCOV file/line/source snippets before failing
- generate/upload coverage artifacts even when the threshold fails

## Test
- bash -n scripts/ci/coverage.sh
- pre-commit run check-yaml --files .github/workflows/ci.yml
- scripts/ci/coverage.sh lcov