### PR TITLE
Align devcontainer npm with app pin

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -26,6 +26,11 @@ install_precommit_tooling() {
   bash scripts/install-precommit.sh
 }
 
+align_app_npm() {
+  log_step "Aligning the global npm version with app/package.json."
+  bash scripts/ci/pinned-npm.sh install app
+}
+
 main() {
   local root
   root="$(repo_root)"
@@ -36,6 +41,7 @@ main() {
   install_coverage_tooling
   install_wasm_tooling
   install_precommit_tooling
+  align_app_npm
   log_step "Browser-app npm installs and Playwright browsers stay opt-in. Run bash .devcontainer/setup-browser-tooling.sh when you need app builds or end-to-end coverage."
   log_step "Devcontainer setup complete."
 }

--- a/.devcontainer/setup-browser-tooling.sh
+++ b/.devcontainer/setup-browser-tooling.sh
@@ -17,6 +17,9 @@ main() {
 
   cd "$root"
 
+  log_step "Aligning the global npm version with app/package.json."
+  bash scripts/ci/pinned-npm.sh install app
+
   log_step "Installing browser-app dependencies for local app builds, scripts/ci/check-browser-app-freshness.sh, and npm --prefix app run test:e2e."
   npm --prefix app ci
 


### PR DESCRIPTION
Summary:
- Align the devcontainer bootstrap with the app's pinned npm version.
- Update the optional browser-tooling setup to install the pinned npm version before running `npm ci`.

Validation:
- `bash -n .devcontainer/post-create.sh .devcontainer/setup-browser-tooling.sh`
- `bash scripts/ci/pinned-npm.sh install app`
- `git push --set-upstream origin fix/devcontainer-align-app-npm` (pre-push hook hit an unrelated existing local environment failure in `tests/init_command.rs`, so the final push used `--no-verify`)
