### PR TITLE
Add syu task plan for temporary Goal Plan generation

### DIFF
--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -78,6 +78,7 @@ edit YAML by hand, use the task workflow first:
 ```bash
 syu task classify request.yaml
 syu task scaffold request.yaml
+syu task plan request.yaml --output .syu/tasks/current.yaml
 ```
 
 Keep the planned items small. If one request is trying to introduce multiple

--- a/docs/guide/request-artifact-format.md
+++ b/docs/guide/request-artifact-format.md
@@ -50,6 +50,7 @@ context:
 The artifact is intentionally smaller than the spec itself. Once the request is
 understood, move the real work into planned requirements and features with the
 normal spec workflow. `syu task classify request.yaml` can read the artifact
-and the current graph first, and `syu task scaffold request.yaml` can then
-preview the planned requirement and feature updates that follow from that
-decision.
+and the current graph first, `syu task scaffold request.yaml` can then preview
+the planned requirement and feature updates that follow from that decision, and
+`syu task plan request.yaml` can turn the scoped request into a temporary Goal
+Plan artifact for implementation work outside the persistent spec tree.

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -54,3 +54,31 @@ features:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scaffold
+  - id: FEAT-TASK-003
+    title: Temporary Goal Plan generation
+    summary: Generate a temporary Goal Plan artifact from request artifacts while mapping the request to the current spec graph and keeping the plan outside the persistent spec tree.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-030
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_plan_command
+            - build_goal_plan
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskPlanArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task plan
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - syu task plan

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -26,6 +26,7 @@ policies:
       - REQ-CORE-025
       - REQ-CORE-028
       - REQ-CORE-029
+      - REQ-CORE-030
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -55,6 +56,7 @@ policies:
       - REQ-CORE-026
       - REQ-CORE-028
       - REQ-CORE-029
+      - REQ-CORE-030
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -109,6 +111,7 @@ policies:
       - REQ-CORE-027
       - REQ-CORE-028
       - REQ-CORE-029
+      - REQ-CORE-030
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -620,3 +620,51 @@ requirements:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scaffold
+  - id: REQ-CORE-030
+    title: Generate temporary Goal Plans from request artifacts
+    description: |
+      The CLI MUST provide a `task plan` command that reads a captured request
+      artifact, classifies and scopes it against the current spec graph, and
+      emits a temporary Goal Plan artifact that stays outside the persistent
+      spec tree. The command MUST surface goal, non-goal, spec-mapping,
+      implementation-scope, test-scope, coverage, and completion sections, MUST
+      support text, YAML, and JSON output, SHOULD warn when the output path
+      appears to live under `spec.root`, and SHOULD keep the plan useful even
+      when only a low-confidence implementation scope can be inferred.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-TASK-003
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - "*"
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskPlanArgs
+        - file: tests/task_command.rs
+          symbols:
+            - task_plan_prints_yaml_output_and_writes_plan_file
+            - task_plan_prints_json_output_for_explicit_ids
+            - task_plan_warns_when_output_is_inside_spec_root
+        - file: tests/help_command.rs
+          symbols:
+            - task_plan_help_mentions_goal_plans_and_output_path
+      markdown:
+        - file: docs/guide/request-artifact-format.md
+          symbols:
+            - syu task plan
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - syu task plan

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,9 @@
 // FEAT-REPORT-001
 // FEAT-INIT-002
 // FEAT-DOCTOR-001
+// FEAT-TASK-003
 // REQ-CORE-001
+// REQ-CORE-030
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
 use clap_complete::Shell;
@@ -35,7 +37,8 @@ New here?
   5. syu browse .    explore the spec in your terminal
   6. syu app .       start the local browser UI server
   7. syu task classify request.yaml  classify a request artifact against the current spec graph
-  8. syu task scaffold request.yaml   preview planned requirement and feature updates from a request artifact";
+  8. syu task scaffold request.yaml   preview planned requirement and feature updates from a request artifact
+  9. syu task plan request.yaml       generate a temporary Goal Plan from a request artifact";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -86,12 +89,26 @@ Examples:
 
 Use this when a request has already been captured as a request artifact and you want the current spec graph to decide whether the next requirement-level move is to create, change, or delete.";
 
+const TASK_AFTER_HELP: &str = "\
+Examples:
+  syu task classify request.yaml
+  syu task scaffold request.yaml
+  syu task plan request.yaml --output .syu/tasks/current.yaml";
+
 const TASK_SCAFFOLD_AFTER_HELP: &str = "\
 Examples:
   syu task scaffold request.yaml
   syu task scaffold request.yaml --format json
 
 Use this after `syu task classify` when you want reviewable planned requirement and feature updates that stay aligned with the existing `syu add` document and registry conventions.";
+
+const TASK_PLAN_AFTER_HELP: &str = "\
+Examples:
+  syu task plan request.yaml
+  syu task plan request.yaml --output .syu/tasks/current.yaml
+  syu task plan request.yaml --format json
+
+Use this when a scoped request is ready to become a temporary Goal Plan that stays outside the persistent spec tree while still mapping the request to existing philosophy, policy, requirement, and feature items.";
 
 const WORKSPACE_HELP: &str = "Workspace root or any child directory; syu walks upward to find syu.yaml and the configured spec tree";
 
@@ -290,8 +307,8 @@ pub enum Commands {
     )]
     Completion(CompletionArgs),
     #[command(
-        about = "Classify or scaffold request-driven task planning work",
-        after_help = TASK_CLASSIFY_AFTER_HELP
+        about = "Classify, scaffold, or plan request-driven task planning work",
+        after_help = TASK_AFTER_HELP
     )]
     Task(TaskArgs),
     #[command(
@@ -779,6 +796,11 @@ pub enum TaskCommands {
         after_help = TASK_SCAFFOLD_AFTER_HELP
     )]
     Scaffold(TaskScaffoldArgs),
+    #[command(
+        about = "Generate a temporary Goal Plan from a request artifact",
+        after_help = TASK_PLAN_AFTER_HELP
+    )]
+    Plan(TaskPlanArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -807,6 +829,24 @@ pub struct TaskScaffoldArgs {
     #[arg(help = "Output format for the scaffold preview")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskPlanArgs {
+    #[arg(help = "YAML request artifact to turn into a Goal Plan")]
+    pub request: PathBuf,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Write the Goal Plan artifact to a file instead of stdout")]
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    #[arg(help = "Output format for the Goal Plan artifact or summary")]
+    #[arg(long, value_enum, default_value_t = TaskPlanFormat::Text)]
+    pub format: TaskPlanFormat,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -881,6 +921,13 @@ pub enum OutputFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TaskPlanFormat {
+    Text,
+    Yaml,
+    Json,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum ValidationSeverityFilter {
     Error,
@@ -921,7 +968,7 @@ impl ValidationGenreFilter {
 mod tests {
     use super::{
         Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskClassifyArgs, TaskCommands,
-        TaskScaffoldArgs, ValidationGenreFilter, ValidationSeverityFilter,
+        TaskPlanArgs, TaskScaffoldArgs, ValidationGenreFilter, ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;
@@ -1044,6 +1091,37 @@ mod tests {
             })) if request == std::path::Path::new("request.yaml")
                 && workspace == std::path::Path::new(".")
                 && format == super::OutputFormat::Json
+        ));
+    }
+
+    #[test]
+    fn task_plan_args_parse_request_paths_output_and_yaml_format() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "task",
+            "plan",
+            "request.yaml",
+            ".",
+            "--output",
+            ".syu/tasks/current.yaml",
+            "--format",
+            "yaml",
+        ])
+        .expect("task plan args should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(super::Commands::Task(TaskArgs {
+                command: TaskCommands::Plan(TaskPlanArgs {
+                    request,
+                    workspace,
+                    output,
+                    format,
+                }),
+            })) if request == std::path::Path::new("request.yaml")
+                && workspace == std::path::Path::new(".")
+                && output.as_deref() == Some(std::path::Path::new(".syu/tasks/current.yaml"))
+                && format == super::TaskPlanFormat::Yaml
         ));
     }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1,9 +1,12 @@
 // FEAT-TASK-001
+// FEAT-TASK-002
+// FEAT-TASK-003
 // REQ-CORE-028
 // REQ-CORE-029
+// REQ-CORE-030
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -13,7 +16,11 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cli::{LookupKind, OutputFormat, TaskArgs, TaskClassifyArgs, TaskCommands, TaskScaffoldArgs},
+    cli::{
+        LookupKind, OutputFormat, TaskArgs, TaskClassifyArgs, TaskCommands, TaskPlanArgs,
+        TaskPlanFormat, TaskScaffoldArgs,
+    },
+    coverage::normalize_relative_path,
     workspace::load_workspace,
 };
 
@@ -79,6 +86,23 @@ struct JsonTaskScaffoldOutput {
 }
 
 #[derive(Debug, Serialize)]
+struct JsonTaskPlanOutput {
+    version: u32,
+    kind: String,
+    request_path: String,
+    request: String,
+    classification: String,
+    source: JsonTaskPlanSource,
+    goal: JsonTaskPlanGoal,
+    spec_mapping: JsonTaskPlanSpecMapping,
+    implementation_plan: JsonTaskPlanImplementationPlan,
+    test_plan: JsonTaskPlanTestPlan,
+    coverage: JsonTaskPlanCoverage,
+    completion: JsonTaskPlanCompletion,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
 struct JsonScaffoldUpdate {
     kind: String,
     action: String,
@@ -86,6 +110,81 @@ struct JsonScaffoldUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
     contents: String,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanSource {
+    mode: String,
+    request_artifact: String,
+    classification: String,
+    confidence: String,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanGoal {
+    id: String,
+    title: String,
+    statement: String,
+    non_goals: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanSpecMapping {
+    persistent_items: JsonTaskPlanPersistentItems,
+    spec_updates_required: bool,
+    spec_update_reasons: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Default)]
+struct JsonTaskPlanPersistentItems {
+    philosophies: Vec<JsonTaskPlanItem>,
+    policies: Vec<JsonTaskPlanItem>,
+    requirements: Vec<JsonTaskPlanItem>,
+    features: Vec<JsonTaskPlanItem>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanItem {
+    id: String,
+    title: String,
+    document_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanImplementationPlan {
+    confidence: String,
+    scope: JsonTaskPlanScope,
+}
+
+#[derive(Debug, Serialize, Default)]
+struct JsonTaskPlanScope {
+    include: Vec<JsonTaskPlanScopeEntry>,
+    exclude: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanScopeEntry {
+    file: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    symbols: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanTestPlan {
+    selection_mode: String,
+    confidence: String,
+    required_tests: BTreeMap<String, Vec<JsonTaskPlanScopeEntry>>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanCoverage {
+    mode: String,
+    threshold: u8,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskPlanCompletion {
+    must_pass: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -158,6 +257,7 @@ pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
     match &args.command {
         TaskCommands::Classify(classify) => run_task_classify_command(classify),
         TaskCommands::Scaffold(scaffold) => run_task_scaffold_command(scaffold),
+        TaskCommands::Plan(plan) => run_task_plan_command(plan),
     }
 }
 
@@ -225,6 +325,45 @@ pub fn run_task_scaffold_command(args: &TaskScaffoldArgs) -> Result<i32> {
             })
             .expect("serializing task scaffold output to JSON should succeed")
         ),
+    }
+
+    Ok(0)
+}
+
+pub fn run_task_plan_command(args: &TaskPlanArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let request_artifact = load_request_artifact(&args.request)?;
+    let explicit_ids = request_artifact.explicit_ids();
+    let outcome = classify_request(&workspace, request_artifact)?;
+    let plan = build_goal_plan(&workspace, &outcome, &explicit_ids, &args.request)?;
+    let output_format = match (&args.output, args.format) {
+        (Some(_), TaskPlanFormat::Text) => TaskPlanFormat::Yaml,
+        (_, format) => format,
+    };
+    let rendered = render_goal_plan_output(&args.request, &outcome, &plan, output_format)?;
+
+    if let Some(output) = &args.output {
+        let resolved_output = resolve_task_plan_output_path(&workspace.root, output);
+        if resolved_output.starts_with(&workspace.spec_root) {
+            eprintln!(
+                "warning: task plan output `{}` is inside spec.root `{}`; the plan is intended to stay outside the persistent spec tree",
+                resolved_output.display(),
+                workspace.spec_root.display()
+            );
+        }
+
+        if let Some(parent) = resolved_output.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&resolved_output, rendered)?;
+        println!("wrote goal plan to {}", resolved_output.display());
+    } else {
+        print!("{rendered}");
+        if !rendered.ends_with('\n') {
+            println!();
+        }
     }
 
     Ok(0)
@@ -430,6 +569,530 @@ fn build_scaffold_plan(
     }
 
     Ok(ScaffoldPlan { updates })
+}
+
+fn build_goal_plan(
+    workspace: &crate::workspace::Workspace,
+    outcome: &ClassificationOutcome,
+    explicit_ids: &[String],
+    request_path: &Path,
+) -> Result<JsonTaskPlanOutput> {
+    let lookup = WorkspaceLookup::new(workspace);
+    let persistent_items = collect_task_plan_persistent_items(&lookup, outcome)?;
+    let spec_update_reasons = determine_spec_update_reasons(outcome, &persistent_items);
+    let spec_updates_required = !spec_update_reasons.is_empty();
+    let scope_include =
+        collect_task_plan_scope_entries(workspace, &persistent_items, explicit_ids)?;
+    let test_plan = collect_task_plan_tests(workspace, &persistent_items, outcome)?;
+    let implementation_confidence = task_plan_confidence(scope_include.len(), outcome);
+    let source_confidence = if outcome.explicit_items.is_empty() && outcome.related_items.is_empty()
+    {
+        "low"
+    } else if outcome.explicit_items.is_empty() {
+        "medium"
+    } else {
+        "high"
+    };
+
+    Ok(JsonTaskPlanOutput {
+        version: 1,
+        kind: "syu.goal_plan".to_string(),
+        request_path: request_path.display().to_string(),
+        request: outcome.request.clone(),
+        classification: outcome.classification.label().to_string(),
+        source: JsonTaskPlanSource {
+            mode: "request_driven".to_string(),
+            request_artifact: request_path.display().to_string(),
+            classification: outcome.classification.label().to_string(),
+            confidence: source_confidence.to_string(),
+        },
+        goal: JsonTaskPlanGoal {
+            id: "GOAL-TASK-PLAN-001".to_string(),
+            title: "Generate request-driven Goal Plans".to_string(),
+            statement: format!(
+                "Turn the scoped request into a temporary implementation plan linked to the current spec graph: {}",
+                summarize_request(&outcome.request)
+            ),
+            non_goals: vec![
+                "Do not modify persistent spec files.".to_string(),
+                "Do not add a fifth persistent spec layer.".to_string(),
+                "Do not skip validation or coverage checks.".to_string(),
+            ],
+        },
+        spec_mapping: JsonTaskPlanSpecMapping {
+            persistent_items,
+            spec_updates_required,
+            spec_update_reasons,
+        },
+        implementation_plan: JsonTaskPlanImplementationPlan {
+            confidence: implementation_confidence.to_string(),
+            scope: JsonTaskPlanScope {
+                include: scope_include,
+                exclude: vec!["docs/generated/**".to_string(), "target/**".to_string()],
+            },
+        },
+        test_plan,
+        coverage: JsonTaskPlanCoverage {
+            mode: "changed_lines".to_string(),
+            threshold: 100,
+        },
+        completion: JsonTaskPlanCompletion {
+            must_pass: vec![
+                "syu task check .syu/tasks/current.yaml --range origin/main...HEAD".to_string(),
+                "syu validate .".to_string(),
+            ],
+        },
+        warnings: collect_task_plan_warnings(outcome),
+    })
+}
+
+fn render_goal_plan_output(
+    request_path: &Path,
+    outcome: &ClassificationOutcome,
+    plan: &JsonTaskPlanOutput,
+    format: TaskPlanFormat,
+) -> Result<String> {
+    match format {
+        TaskPlanFormat::Text => Ok(render_goal_plan_text_output(request_path, outcome, plan)),
+        TaskPlanFormat::Yaml => Ok(serde_yaml::to_string(plan)
+            .expect("serializing task plan output to YAML should succeed")),
+        TaskPlanFormat::Json => Ok(serde_json::to_string_pretty(plan)
+            .expect("serializing task plan output to JSON should succeed")),
+    }
+}
+
+fn render_goal_plan_text_output(
+    request_path: &Path,
+    outcome: &ClassificationOutcome,
+    plan: &JsonTaskPlanOutput,
+) -> String {
+    let mut output = String::new();
+    use std::fmt::Write as _;
+
+    writeln!(&mut output, "request: {}", request_path.display()).expect("write to string");
+    writeln!(&mut output, "version: {}", plan.version).expect("write to string");
+    writeln!(&mut output, "kind: {}", plan.kind).expect("write to string");
+    writeln!(
+        &mut output,
+        "classification: {}",
+        outcome.classification.label()
+    )
+    .expect("write to string");
+    writeln!(&mut output, "source confidence: {}", plan.source.confidence)
+        .expect("write to string");
+    writeln!(&mut output).expect("write to string");
+    writeln!(&mut output, "goal:").expect("write to string");
+    writeln!(&mut output, "  id: {}", plan.goal.id).expect("write to string");
+    writeln!(&mut output, "  title: {}", plan.goal.title).expect("write to string");
+    writeln!(&mut output, "  statement: {}", plan.goal.statement).expect("write to string");
+    writeln!(&mut output, "  non-goals:").expect("write to string");
+    for item in &plan.goal.non_goals {
+        writeln!(&mut output, "    - {item}").expect("write to string");
+    }
+    writeln!(&mut output).expect("write to string");
+    writeln!(&mut output, "persistent spec mapping:").expect("write to string");
+    print_plan_item_section(
+        &mut output,
+        "philosophies",
+        &plan.spec_mapping.persistent_items.philosophies,
+    );
+    print_plan_item_section(
+        &mut output,
+        "policies",
+        &plan.spec_mapping.persistent_items.policies,
+    );
+    print_plan_item_section(
+        &mut output,
+        "requirements",
+        &plan.spec_mapping.persistent_items.requirements,
+    );
+    print_plan_item_section(
+        &mut output,
+        "features",
+        &plan.spec_mapping.persistent_items.features,
+    );
+    writeln!(
+        &mut output,
+        "  spec updates required: {}",
+        if plan.spec_mapping.spec_updates_required {
+            "yes"
+        } else {
+            "no"
+        }
+    )
+    .expect("write to string");
+    if !plan.spec_mapping.spec_update_reasons.is_empty() {
+        writeln!(&mut output, "  spec update reasons:").expect("write to string");
+        for reason in &plan.spec_mapping.spec_update_reasons {
+            writeln!(&mut output, "    - {reason}").expect("write to string");
+        }
+    }
+    writeln!(&mut output).expect("write to string");
+    writeln!(&mut output, "implementation plan:").expect("write to string");
+    writeln!(
+        &mut output,
+        "  confidence: {}",
+        plan.implementation_plan.confidence
+    )
+    .expect("write to string");
+    writeln!(&mut output, "  include:").expect("write to string");
+    if plan.implementation_plan.scope.include.is_empty() {
+        writeln!(&mut output, "    - none").expect("write to string");
+    } else {
+        for entry in &plan.implementation_plan.scope.include {
+            writeln!(&mut output, "    - {}", render_scope_entry(entry)).expect("write to string");
+        }
+    }
+    writeln!(&mut output, "  exclude:").expect("write to string");
+    for item in &plan.implementation_plan.scope.exclude {
+        writeln!(&mut output, "    - {item}").expect("write to string");
+    }
+    writeln!(&mut output).expect("write to string");
+    writeln!(&mut output, "test plan:").expect("write to string");
+    writeln!(
+        &mut output,
+        "  selection mode: {}",
+        plan.test_plan.selection_mode
+    )
+    .expect("write to string");
+    writeln!(&mut output, "  confidence: {}", plan.test_plan.confidence).expect("write to string");
+    if plan.test_plan.required_tests.is_empty() {
+        writeln!(&mut output, "  required tests:").expect("write to string");
+        writeln!(&mut output, "    - none").expect("write to string");
+    } else {
+        writeln!(&mut output, "  required tests:").expect("write to string");
+        for (language, entries) in &plan.test_plan.required_tests {
+            writeln!(&mut output, "    {language}:").expect("write to string");
+            for entry in entries {
+                writeln!(&mut output, "      - {}", render_scope_entry(entry))
+                    .expect("write to string");
+            }
+        }
+    }
+    writeln!(&mut output).expect("write to string");
+    writeln!(
+        &mut output,
+        "coverage: {} (threshold {})",
+        plan.coverage.mode, plan.coverage.threshold
+    )
+    .expect("write to string");
+    writeln!(&mut output).expect("write to string");
+    writeln!(&mut output, "completion checks:").expect("write to string");
+    for item in &plan.completion.must_pass {
+        writeln!(&mut output, "- {item}").expect("write to string");
+    }
+    if !plan.warnings.is_empty() {
+        writeln!(&mut output).expect("write to string");
+        writeln!(&mut output, "warnings:").expect("write to string");
+        for warning in &plan.warnings {
+            writeln!(&mut output, "- {warning}").expect("write to string");
+        }
+    }
+
+    output
+}
+
+fn print_plan_item_section(output: &mut String, heading: &str, items: &[JsonTaskPlanItem]) {
+    use std::fmt::Write as _;
+
+    writeln!(output, "  {heading}:").expect("write to string");
+    if items.is_empty() {
+        writeln!(output, "    - none").expect("write to string");
+        return;
+    }
+    for item in items {
+        let document_path = item
+            .document_path
+            .as_deref()
+            .map(|path| format!(" ({path})"))
+            .unwrap_or_default();
+        writeln!(output, "    - {} {}{}", item.id, item.title, document_path)
+            .expect("write to string");
+    }
+}
+
+fn render_scope_entry(entry: &JsonTaskPlanScopeEntry) -> String {
+    if entry.symbols.is_empty() {
+        entry.file.clone()
+    } else {
+        format!("{} [{}]", entry.file, entry.symbols.join(", "))
+    }
+}
+
+fn resolve_task_plan_output_path(workspace_root: &Path, output: &Path) -> PathBuf {
+    if output.is_absolute() {
+        return output.to_path_buf();
+    }
+
+    workspace_root.join(normalize_relative_path(output))
+}
+
+fn collect_task_plan_persistent_items(
+    lookup: &WorkspaceLookup<'_>,
+    outcome: &ClassificationOutcome,
+) -> Result<JsonTaskPlanPersistentItems> {
+    let mut items = JsonTaskPlanPersistentItems::default();
+    let mut seen = BTreeSet::new();
+
+    for result in outcome
+        .explicit_items
+        .iter()
+        .chain(outcome.related_items.iter())
+    {
+        if !seen.insert(result.id.clone()) {
+            continue;
+        }
+
+        let item = JsonTaskPlanItem {
+            id: result.id.clone(),
+            title: result.title.clone(),
+            document_path: lookup.document_path_for_id(&result.id)?,
+        };
+        match result.kind {
+            "philosophy" => items.philosophies.push(item),
+            "policy" => items.policies.push(item),
+            "requirement" => items.requirements.push(item),
+            "feature" => items.features.push(item),
+            _ => {}
+        }
+    }
+
+    items.philosophies.sort_by(|a, b| a.id.cmp(&b.id));
+    items.policies.sort_by(|a, b| a.id.cmp(&b.id));
+    items.requirements.sort_by(|a, b| a.id.cmp(&b.id));
+    items.features.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(items)
+}
+
+fn determine_spec_update_reasons(
+    outcome: &ClassificationOutcome,
+    persistent_items: &JsonTaskPlanPersistentItems,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if persistent_items.requirements.is_empty() {
+        reasons.push(
+            "No durable requirement was identified, so a new or expanded requirement is likely needed before implementation."
+                .to_string(),
+        );
+    }
+    if persistent_items.features.is_empty() {
+        reasons.push(
+            "No feature anchor was identified, so the plan is still provisional and may need a new feature definition."
+                .to_string(),
+        );
+    }
+    if outcome.explicit_items.is_empty() {
+        reasons.push(
+            "The request does not name concrete spec IDs, so the mapping is inferred from the current graph and request text."
+                .to_string(),
+        );
+    }
+    if outcome.explicit_items.is_empty() && outcome.related_items.is_empty() {
+        reasons.push(
+            "No close graph matches were found, which is a strong signal that spec updates are likely required."
+                .to_string(),
+        );
+    }
+
+    reasons
+}
+
+fn collect_task_plan_scope_entries(
+    workspace: &crate::workspace::Workspace,
+    persistent_items: &JsonTaskPlanPersistentItems,
+    explicit_ids: &[String],
+) -> Result<Vec<JsonTaskPlanScopeEntry>> {
+    let mut files = BTreeMap::<String, BTreeSet<String>>::new();
+
+    let feature_ids = persistent_items
+        .features
+        .iter()
+        .map(|item| item.id.as_str())
+        .chain(
+            explicit_ids
+                .iter()
+                .map(|id| id.as_str())
+                .filter(|id| id.starts_with("FEAT-")),
+        );
+
+    for feature_id in feature_ids {
+        collect_feature_scope_entries(workspace, feature_id, &mut files);
+    }
+
+    for requirement in persistent_items
+        .requirements
+        .iter()
+        .filter_map(|item| lookup_requirement(workspace, &item.id))
+    {
+        for feature_id in &requirement.linked_features {
+            collect_feature_scope_entries(workspace, feature_id, &mut files);
+        }
+    }
+
+    let mut entries = files
+        .into_iter()
+        .map(|(file, symbols)| JsonTaskPlanScopeEntry {
+            file,
+            symbols: symbols.into_iter().collect(),
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.file.cmp(&b.file));
+    entries.dedup_by(|a, b| a.file == b.file && a.symbols == b.symbols);
+    Ok(entries)
+}
+
+fn collect_feature_scope_entries(
+    workspace: &crate::workspace::Workspace,
+    feature_id: &str,
+    files: &mut BTreeMap<String, BTreeSet<String>>,
+) {
+    let Some(feature) = workspace.features.iter().find(|item| item.id == feature_id) else {
+        return;
+    };
+
+    for references in feature.implementations.values() {
+        for reference in references {
+            let file = normalize_relative_path(&reference.file)
+                .display()
+                .to_string();
+            let symbols = files.entry(file).or_default();
+            for symbol in &reference.symbols {
+                symbols.insert(symbol.clone());
+            }
+        }
+    }
+}
+
+fn collect_task_plan_tests(
+    workspace: &crate::workspace::Workspace,
+    persistent_items: &JsonTaskPlanPersistentItems,
+    outcome: &ClassificationOutcome,
+) -> Result<JsonTaskPlanTestPlan> {
+    let mut required_tests = BTreeMap::<String, Vec<JsonTaskPlanScopeEntry>>::new();
+    let mut seen = BTreeSet::new();
+
+    for requirement in persistent_items
+        .requirements
+        .iter()
+        .filter_map(|item| lookup_requirement(workspace, &item.id))
+    {
+        for (language, tests) in &requirement.tests {
+            let entries = required_tests.entry(language.clone()).or_default();
+            for reference in tests {
+                let file = normalize_relative_path(&reference.file)
+                    .display()
+                    .to_string();
+                let key = format!("{language}:{file}:{}", reference.symbols.join(","));
+                if !seen.insert(key) {
+                    continue;
+                }
+                entries.push(JsonTaskPlanScopeEntry {
+                    file,
+                    symbols: reference.symbols.clone(),
+                });
+            }
+        }
+    }
+
+    for feature in persistent_items
+        .features
+        .iter()
+        .filter_map(|item| lookup_feature(workspace, &item.id))
+    {
+        for requirement_id in &feature.linked_requirements {
+            if let Some(requirement) = lookup_requirement(workspace, requirement_id) {
+                for (language, tests) in &requirement.tests {
+                    let entries = required_tests.entry(language.clone()).or_default();
+                    for reference in tests {
+                        let file = normalize_relative_path(&reference.file)
+                            .display()
+                            .to_string();
+                        let key = format!("{language}:{file}:{}", reference.symbols.join(","));
+                        if !seen.insert(key) {
+                            continue;
+                        }
+                        entries.push(JsonTaskPlanScopeEntry {
+                            file,
+                            symbols: reference.symbols.clone(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    for entries in required_tests.values_mut() {
+        entries.sort_by(|a, b| a.file.cmp(&b.file));
+        entries.dedup_by(|a, b| a.file == b.file && a.symbols == b.symbols);
+    }
+
+    let selection_mode = if required_tests.is_empty() {
+        "minimal"
+    } else {
+        "linked-declarations"
+    };
+    let confidence = task_plan_confidence_for_tests(required_tests.len(), outcome);
+
+    Ok(JsonTaskPlanTestPlan {
+        selection_mode: selection_mode.to_string(),
+        confidence: confidence.to_string(),
+        required_tests,
+    })
+}
+
+fn task_plan_confidence(
+    scope_include_count: usize,
+    outcome: &ClassificationOutcome,
+) -> &'static str {
+    if scope_include_count == 0 || outcome.related_items.is_empty() {
+        "low"
+    } else if outcome.explicit_items.is_empty() {
+        "medium"
+    } else {
+        "high"
+    }
+}
+
+fn task_plan_confidence_for_tests(
+    test_group_count: usize,
+    outcome: &ClassificationOutcome,
+) -> &'static str {
+    if test_group_count == 0 || outcome.related_items.is_empty() {
+        "low"
+    } else {
+        "high"
+    }
+}
+
+fn collect_task_plan_warnings(outcome: &ClassificationOutcome) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if outcome.explicit_items.is_empty() {
+        warnings.push(
+            "The plan is inferred from request text and graph matches, so review the proposed scope carefully."
+                .to_string(),
+        );
+    }
+    if outcome.related_items.is_empty() {
+        warnings.push(
+            "No close graph matches were found, so the plan may need a new requirement or feature before implementation."
+                .to_string(),
+        );
+    }
+    warnings
+}
+
+fn lookup_requirement<'a>(
+    workspace: &'a crate::workspace::Workspace,
+    id: &str,
+) -> Option<&'a crate::model::Requirement> {
+    workspace.requirements.iter().find(|item| item.id == id)
+}
+
+fn lookup_feature<'a>(
+    workspace: &'a crate::workspace::Workspace,
+    id: &str,
+) -> Option<&'a crate::model::Feature> {
+    workspace.features.iter().find(|item| item.id == id)
 }
 
 impl RequestArtifact {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@
 // FEAT-BROWSE-001
 // FEAT-LSP-001
 // FEAT-TASK-001
+// FEAT-TASK-003
 // REQ-CORE-021
 // REQ-CORE-023
 // REQ-CORE-024
 // REQ-CORE-028
+// REQ-CORE-030
 
 pub mod cli;
 pub mod command;

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -296,6 +296,24 @@ fn task_help_mentions_request_artifacts_and_json_output() {
 }
 
 #[test]
+fn task_plan_help_mentions_goal_plans_and_output_path() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "plan", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task plan help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Goal Plan"));
+    assert!(stdout.contains("--output"));
+    assert!(stdout.contains("syu task plan request.yaml"));
+    assert!(stdout.contains("syu task plan request.yaml --output .syu/tasks/current.yaml"));
+    assert!(stdout.contains("syu task plan request.yaml --format json"));
+}
+
+#[test]
 // REQ-CORE-024
 fn validate_help_mentions_warning_exit_code_for_automation() {
     let output = Command::cargo_bin("syu")

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -1,5 +1,7 @@
+// FEAT-TASK-003
 // REQ-CORE-028
 // REQ-CORE-029
+// REQ-CORE-030
 
 use std::fs;
 
@@ -38,8 +40,13 @@ fn write_workspace(root: &std::path::Path) {
     )
     .expect("scaffold requirement doc");
     fs::write(
+        root.join("docs/syu/requirements/core/plan.yaml"),
+        "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-030\n    title: Generate temporary Goal Plans from request artifacts\n    description: The task plan command should turn request artifacts into reviewable Goal Plan artifacts without mutating persistent spec files.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-003\n    tests:\n      rust:\n        - file: tests/task_command.rs\n          symbols:\n            - task_plan_prints_yaml_output_and_writes_plan_file\n        - file: tests/help_command.rs\n          symbols:\n            - task_plan_help_mentions_goal_plans_and_output_path\n",
+    )
+    .expect("plan requirement doc");
+    fs::write(
         root.join("docs/syu/features/features.yaml"),
-        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n",
+        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n  - kind: task\n    file: core/plan.yaml\n",
     )
     .expect("feature registry");
     fs::write(
@@ -52,6 +59,11 @@ fn write_workspace(root: &std::path::Path) {
         "category: Core Workspace\nversion: 1\nfeatures:\n  - id: FEAT-TASK-002\n    title: Planned task scaffold preview\n    summary: Preview reviewable planned requirement and feature updates that follow the existing add and registry conventions.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-029\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scaffold_command\n",
     )
     .expect("scaffold feature doc");
+    fs::write(
+        root.join("docs/syu/features/core/plan.yaml"),
+        "category: Core Workspace\nversion: 1\nfeatures:\n  - id: FEAT-TASK-003\n    title: Temporary Goal Plan generation\n    summary: Generate a temporary Goal Plan artifact from request artifacts while mapping the request to the current spec graph and keeping the plan outside the persistent spec tree.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-030\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_plan_command\n            - build_goal_plan\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskPlanArgs\n        - file: src/lib.rs\n          symbols:\n            - dispatch\n            - run_dispatch\n      markdown:\n        - file: docs/guide/request-artifact-format.md\n          symbols:\n            - syu task plan\n        - file: docs/guide/implementation-planning.md\n          symbols:\n            - syu task plan\n",
+    )
+    .expect("plan feature doc");
 }
 
 fn write_request(root: &std::path::Path, request: &str, affected_area: &str, linked_ids: &[&str]) {
@@ -200,4 +212,94 @@ fn task_scaffold_rejects_delete_requests() {
     assert!(!output.status.success(), "delete scaffold should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only supports request artifacts"));
+}
+
+#[test]
+fn task_plan_prints_yaml_output_and_writes_plan_file() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Update REQ-CORE-030 and FEAT-TASK-003 so Goal Plan output stays stable.",
+        "task planning",
+        &["REQ-CORE-030", "FEAT-TASK-003"],
+    );
+    let output_file = tempdir.path().join("docs/generated/task-plan.yaml");
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "plan",
+            "request.yaml",
+            "--output",
+            "docs/generated/task-plan.yaml",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task plan should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("wrote goal plan to"));
+    assert!(output_file.is_file(), "goal plan file should exist");
+    let rendered = fs::read_to_string(&output_file).expect("plan file should be readable");
+    assert!(rendered.contains("kind: syu.goal_plan"));
+    assert!(rendered.contains("spec_updates_required: false"));
+    assert!(rendered.contains("run_task_plan_command"));
+}
+
+#[test]
+fn task_plan_prints_json_output_for_explicit_ids() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Update PHIL-001, POL-001, REQ-CORE-030, and FEAT-TASK-003 together.",
+        "task planning",
+        &["PHIL-001", "POL-001", "REQ-CORE-030", "FEAT-TASK-003"],
+    );
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "plan", "request.yaml", "--format", "json"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task plan should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"kind\": \"syu.goal_plan\""));
+    assert!(stdout.contains("\"spec_updates_required\": false"));
+    assert!(stdout.contains("\"run_task_plan_command\""));
+}
+
+#[test]
+fn task_plan_warns_when_output_is_inside_spec_root() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_request(
+        tempdir.path(),
+        "Create a new request-driven Goal Plan for reviewers.",
+        "task planning",
+        &[],
+    );
+
+    let output = {
+        let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "plan",
+            "request.yaml",
+            "--output",
+            "docs/syu/tasks/current.yaml",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task plan should succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("inside spec.root"));
+    assert!(tempdir.path().join("docs/syu/tasks/current.yaml").is_file());
 }


### PR DESCRIPTION
Summary:
- Add `syu task plan` to generate temporary Goal Plan artifacts from request artifacts.
- Support text, YAML, and JSON output, plus `--output` file writing and spec-root warnings.
- Update task CLI help, task workflow docs, and checked-in spec coverage for the new command.

Validation:
- `cargo test --test task_command --test help_command -- --nocapture`
- `cargo fmt --check`
- Pre-commit hook and repository quality gates during `git commit` and `git push`

Closes #702
