### PR TITLE
Define temporary Goal Plan artifacts

### DIFF
--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -96,6 +96,22 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
       - **file**: docs/guide/implementation-planning.md
         - **symbols**:
           - syu task scope
+- **id**: FEAT-TASK-004
+  - **title**: Temporary Goal Plan schema
+  - **summary**: Model temporary Goal Plan artifacts with goal, scope, test, coverage, and completion fields outside the persistent spec tree.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-031
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - GoalPlanArtifact
+          - load_goal_plan_artifact
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
 
 ## Source YAML
 
@@ -183,4 +199,20 @@ features:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scope
+  - id: FEAT-TASK-004
+    title: Temporary Goal Plan schema
+    summary: Model temporary Goal Plan artifacts with goal, scope, test, coverage, and completion fields outside the persistent spec tree.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-031
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
 ```

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -46,6 +46,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-028
     - REQ-CORE-029
     - REQ-CORE-030
+    - REQ-CORE-031
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -76,6 +77,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-028
     - REQ-CORE-029
     - REQ-CORE-030
+    - REQ-CORE-031
 - **id**: POL-003
   - **title**: Traceability should prove ownership from specification to code and tests
   - **summary**: Declared traces should map to real files, real symbols, optional full-file ownership, and derivable repository history.
@@ -131,6 +133,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-028
     - REQ-CORE-029
     - REQ-CORE-030
+    - REQ-CORE-031
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -237,6 +240,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -267,6 +271,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -322,6 +327,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -704,6 +704,50 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: docs/guide/implementation-planning.md
         - **symbols**:
           - syu task scope
+- **id**: REQ-CORE-031
+  - **title**: Define temporary Goal Plan artifacts for implementation tracking
+  - **description**:
+    - |
+      The repository MUST document temporary Goal Plan artifacts as delivery
+      artifacts that may live in task files, PR bodies, issue bodies, CI
+      artifacts, or other ephemeral locations outside `spec.root`. Goal Plans
+      MUST stay separate from the persistent philosophy, policy, requirement,
+      and feature layers, SHOULD carry explicit goal, scope, test, coverage,
+      and completion fields, and SHOULD support both request-driven and
+      diff-inferred sources with an explicit confidence signal for inferred
+      plans. The default `syu validate .` workflow MUST not require Goal Plans
+      to exist and MUST not treat `.syu/tasks` as persistent spec content unless
+      a future configuration explicitly opts in.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-002
+    - POL-004
+  - **linked_features**:
+    - FEAT-TASK-004
+  - **tests**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - GoalPlanArtifact
+          - load_goal_plan_artifact
+      - **file**: tests/task_command.rs
+        - **symbols**:
+          - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
+          - goal_plan_artifact_requires_the_goal_plan_marker
+          - goal_plan_format_is_documented_as_temporary
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - task_scaffold_help_mentions_goal_plans_and_json_output
+          - workspace_help_mentions_goal_plan_artifacts
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
+      - **file**: docs/guide/implementation-planning.md
+        - **symbols**:
+          - goal plan format
 
 ## Source YAML
 
@@ -1382,4 +1426,47 @@ requirements:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scope
+  - id: REQ-CORE-031
+    title: Define temporary Goal Plan artifacts for implementation tracking
+    description: |
+      The repository MUST document temporary Goal Plan artifacts as delivery
+      artifacts that may live in task files, PR bodies, issue bodies, CI
+      artifacts, or other ephemeral locations outside `spec.root`. Goal Plans
+      MUST stay separate from the persistent philosophy, policy, requirement,
+      and feature layers, SHOULD carry explicit goal, scope, test, coverage,
+      and completion fields, and SHOULD support both request-driven and
+      diff-inferred sources with an explicit confidence signal for inferred
+      plans. The default `syu validate .` workflow MUST not require Goal Plans
+      to exist and MUST not treat `.syu/tasks` as persistent spec content unless
+      a future configuration explicitly opts in.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-TASK-004
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+        - file: tests/task_command.rs
+          symbols:
+            - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
+            - goal_plan_artifact_requires_the_goal_plan_marker
+            - goal_plan_format_is_documented_as_temporary
+        - file: tests/help_command.rs
+          symbols:
+            - task_scaffold_help_mentions_goal_plans_and_json_output
+            - workspace_help_mentions_goal_plan_artifacts
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - goal plan format
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 8
-- Requirements: 30
-- Features: 38
+- Requirements: 31
+- Features: 39
 
 ## Traceability
 
-- Requirement-to-test traceability: 142/142
-- Feature-to-implementation traceability: 153/153
+- Requirement-to-test traceability: 147/147
+- Feature-to-implementation traceability: 155/155
 
 ## Issues
 

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -27,6 +27,7 @@ If a pull request already exists, pair this page with the
 | Expand the nearby graph | `syu relate FEAT-CHECK-001` | see linked policies, requirements, features, files, and symbols around one selector |
 | Review a PR range | `syu review --range origin/main...HEAD` | start with the affected philosophy, policy, requirement, and feature IDs, then drill into changed files with `show`, `relate`, or `log` |
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
+| Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |
 | Search by keyword or ID | `syu search validation --kind feature` | find the right spec item before `show`, `relate`, or `log` |
@@ -85,6 +86,8 @@ syu report .
 - Use [getting started](./getting-started.md) for the narrated install-to-validate flow.
 - Use [examples and templates](./examples-and-templates.md) when you want the
   checked-in starter and example matrix.
+- Use [goal plan format](./goal-plan-format.md) when you need a temporary
+  delivery artifact instead of a persistent spec item.
 - Use [LSP guide](./lsp.md) when you are connecting `syu` to an editor client
   over stdio instead of using the checked-in VS Code extension directly.
 - Use [configuration](./configuration.md) when you need validation and runtime

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,6 +28,9 @@ Need a different level of guidance?
   starts.
 - Use [request artifact format](./request-artifact-format.md) when you want a
   small, repeatable request record before you touch the spec tree.
+- Use [goal plan format](./goal-plan-format.md) when you need a temporary
+  delivery artifact that records scope, tests, and completion checks without
+  creating a persistent spec layer.
 - Stay on this page when you want the first workspace setup explained step by
   step, including why the manual YAML edits matter before validation and how the
   same commands fit together as one guided story.

--- a/docs/guide/goal-plan-format.md
+++ b/docs/guide/goal-plan-format.md
@@ -1,0 +1,102 @@
+# Goal plan format for temporary syu delivery artifacts
+
+<!-- FEAT-DOCS-002 -->
+
+Use this guide when a request has already been scoped and you need a temporary
+delivery artifact that stays outside the persistent spec tree. Goal Plans are
+planning artifacts, not another long-lived spec layer.
+
+## When to use it
+
+- A request already has a clear implementation goal, scope, and test plan.
+- You want a structured artifact that can live in a task file, PR body, issue
+  body, CI artifact, or another temporary delivery location.
+- You need a reviewable artifact before the implementation starts.
+
+## When not to use it
+
+- You still need to classify or scope the request against the current spec
+  graph.
+- You want to add durable intent to philosophy, policy, requirement, or feature
+  YAML.
+- The change is already a direct spec diff.
+
+## Recommended shape
+
+```yaml
+version: 1
+kind: syu.goal_plan
+
+source:
+  mode: request_driven
+  request_artifact: request.yaml
+
+goal:
+  id: GOAL-001
+  title: Keep temporary planning explicit
+  statement: Capture the implementation plan without turning it into a fifth spec layer.
+  non_goals:
+    - Add a persistent task tree under spec.root
+
+spec_mapping:
+  persistent_items:
+    philosophies: [PHIL-001]
+    policies: [POL-001]
+    requirements: [REQ-CORE-030]
+    features: [FEAT-TASK-003]
+  spec_updates:
+    required: false
+    expected_updates: []
+
+implementation_plan:
+  scope:
+    include:
+      - src/command/task.rs
+    exclude:
+      - docs/syu/**
+  steps:
+    - add a Goal Plan model
+    - document the temporary artifact locations
+
+test_plan:
+  selection_mode: affected
+  required_tests:
+    rust:
+      - tests/task_command.rs
+  suggested_tests: {}
+
+coverage:
+  mode: changed_lines
+  threshold: 100
+  include:
+    - src/command/task.rs
+  exclude: []
+
+completion:
+  must_pass:
+    - syu validate .
+```
+
+## Field meanings
+
+- **version**: keeps the format explicit when the shape changes later.
+- **kind**: identifies the artifact as `syu.goal_plan`.
+- **source.mode**: distinguishes request-driven planning from diff-inferred
+  planning.
+- **source.request_artifact**: points at the request artifact when one exists.
+- **source.range**: records the diff range used for inferred plans.
+- **source.confidence**: records how certain an inferred plan is.
+- **goal**: states the implementation goal, the short title, and the non-goals.
+- **spec_mapping**: records which persistent spec items the plan may touch and
+  whether spec updates are expected.
+- **implementation_plan**: lists the bounded file or symbol scope and the steps
+  to complete the work.
+- **test_plan**: records the test selection mode plus required and suggested
+  checks.
+- **coverage**: states the coverage expectation for the changed surface.
+- **completion**: lists the checks that must pass before the work is complete.
+
+Goal Plans are intentionally temporary. They may live in `.syu/tasks/*.yaml`,
+`target/syu/*.json`, a GitHub issue or PR body, or a CI artifact. They do not
+need to live under `spec.root`, and `syu validate .` should not require them to
+exist.

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -5,7 +5,9 @@
 Use this guide when a new request is ready to become planned spec work before
 the implementation starts. If you already know the exact IDs and files, jump to
 [reviewer workflow](./reviewer-workflow.md). If you only have a request note,
-start with [request artifact format](./request-artifact-format.md).
+start with [request artifact format](./request-artifact-format.md). If you need
+a temporary delivery artifact instead of a persistent spec item, use [goal plan
+format](./goal-plan-format.md).
 
 ## When to use it
 
@@ -69,11 +71,14 @@ spec instead of hiding it inside implementation notes.
 ## 5. Turn the request into planned spec edits
 
 Use `syu add` when you need new planned requirements or features, then edit the
-generated YAML so the new work is reviewable:
+generated YAML so the new work is reviewable. If you need a temporary planning
+artifact for implementation tracking, capture it as a Goal Plan instead of
+adding a fifth spec layer:
 
 ```bash
 syu add requirement REQ-PLANNING-001
 syu add feature FEAT-PLANNING-001 --kind planning
+syu task scaffold request.yaml
 ```
 
 If you already have a request artifact and want a reviewable preview before you

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -9,6 +9,9 @@ start with [request artifact format](./request-artifact-format.md). If you need
 a temporary delivery artifact instead of a persistent spec item, use [goal plan
 format](./goal-plan-format.md).
 
+The goal plan format is temporary by design and should not become a fifth
+persistent spec layer.
+
 ## When to use it
 
 - A request has enough detail to turn into planned requirements or features.

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -81,3 +81,19 @@ features:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scope
+  - id: FEAT-TASK-004
+    title: Temporary Goal Plan schema
+    summary: Model temporary Goal Plan artifacts with goal, scope, test, coverage, and completion fields outside the persistent spec tree.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-031
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -27,6 +27,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -57,6 +58,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-003
     title: Traceability should prove ownership from specification to code and tests
@@ -112,6 +114,7 @@ policies:
       - REQ-CORE-028
       - REQ-CORE-029
       - REQ-CORE-030
+      - REQ-CORE-031
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -672,3 +672,45 @@ requirements:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task scope
+  - id: REQ-CORE-031
+    title: Define temporary Goal Plan artifacts for implementation tracking
+    description: |
+      The repository MUST document temporary Goal Plan artifacts as delivery
+      artifacts that may live in task files, PR bodies, issue bodies, CI
+      artifacts, or other ephemeral locations outside `spec.root`. Goal Plans
+      MUST stay separate from the persistent philosophy, policy, requirement,
+      and feature layers, SHOULD carry explicit goal, scope, test, coverage,
+      and completion fields, and SHOULD support both request-driven and
+      diff-inferred sources with an explicit confidence signal for inferred
+      plans. The default `syu validate .` workflow MUST not require Goal Plans
+      to exist and MUST not treat `.syu/tasks` as persistent spec content unless
+      a future configuration explicitly opts in.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-002
+      - POL-004
+    linked_features:
+      - FEAT-TASK-004
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+        - file: tests/task_command.rs
+          symbols:
+            - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
+            - goal_plan_artifact_requires_the_goal_plan_marker
+            - goal_plan_format_is_documented_as_temporary
+        - file: tests/help_command.rs
+          symbols:
+            - workspace_help_mentions_goal_plan_artifacts
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/implementation-planning.md
+          symbols:
+            - goal plan format

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -706,6 +706,7 @@ requirements:
             - goal_plan_format_is_documented_as_temporary
         - file: tests/help_command.rs
           symbols:
+            - task_scaffold_help_mentions_goal_plans_and_json_output
             - workspace_help_mentions_goal_plan_artifacts
       markdown:
         - file: docs/guide/goal-plan-format.md

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ New here?
   6. syu app .       start the local browser UI server
   7. syu task classify request.yaml  classify a request artifact against the current spec graph
   8. syu task scope request.yaml      map a request artifact onto the current spec graph
-  9. syu task scaffold request.yaml   preview planned requirement and feature updates from a request artifact";
+  9. syu task scaffold request.yaml   preview planned requirement, feature, and goal plan updates from a request artifact";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -101,7 +101,7 @@ Examples:
   syu task scaffold request.yaml
   syu task scaffold request.yaml --format json
 
-Use this after `syu task scope` and `syu task classify` when you want reviewable planned requirement and feature updates that stay aligned with the existing `syu add` document and registry conventions.";
+Use this after `syu task scope` and `syu task classify` when you want reviewable planned requirement, feature, and temporary Goal Plan updates that stay aligned with the existing `syu add` document and registry conventions.";
 
 const WORKSPACE_HELP: &str = "Workspace root or any child directory; syu walks upward to find syu.yaml and the configured spec tree";
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -25,6 +25,7 @@ use crate::{
 use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
 
 const REQUEST_ARTIFACT_VERSION: u32 = 1;
+const GOAL_PLAN_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -50,6 +51,162 @@ struct RequestArtifact {
     request: String,
     #[serde(default)]
     context: RequestArtifactContext,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanArtifact {
+    version: u32,
+    kind: String,
+    #[serde(default)]
+    source: GoalPlanSource,
+    goal: GoalPlanGoal,
+    #[serde(default)]
+    spec_mapping: GoalPlanSpecMapping,
+    implementation_plan: GoalPlanImplementationPlan,
+    test_plan: GoalPlanTestPlan,
+    coverage: GoalPlanCoverage,
+    completion: GoalPlanCompletion,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanSource {
+    mode: GoalPlanSourceMode,
+    #[serde(default)]
+    request_artifact: Option<String>,
+    #[serde(default)]
+    range: Option<String>,
+    #[serde(default)]
+    confidence: Option<GoalPlanConfidence>,
+}
+
+impl Default for GoalPlanSource {
+    fn default() -> Self {
+        Self {
+            mode: GoalPlanSourceMode::RequestDriven,
+            request_artifact: None,
+            range: None,
+            confidence: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum GoalPlanSourceMode {
+    #[default]
+    #[serde(rename = "request_driven")]
+    RequestDriven,
+    #[serde(rename = "diff_inferred")]
+    DiffInferred,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum GoalPlanConfidence {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanGoal {
+    id: String,
+    title: String,
+    statement: String,
+    #[serde(default)]
+    non_goals: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct GoalPlanSpecMapping {
+    #[serde(default)]
+    persistent_items: GoalPlanPersistentItems,
+    #[serde(default)]
+    spec_updates: GoalPlanSpecUpdates,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct GoalPlanPersistentItems {
+    #[serde(default)]
+    philosophies: Vec<String>,
+    #[serde(default)]
+    policies: Vec<String>,
+    #[serde(default)]
+    requirements: Vec<String>,
+    #[serde(default)]
+    features: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct GoalPlanSpecUpdates {
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    expected_updates: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanImplementationPlan {
+    scope: GoalPlanScope,
+    #[serde(default)]
+    steps: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct GoalPlanScope {
+    #[serde(default)]
+    include: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanTestPlan {
+    selection_mode: GoalPlanSelectionMode,
+    #[serde(default)]
+    required_tests: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    suggested_tests: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum GoalPlanSelectionMode {
+    #[default]
+    #[serde(rename = "minimal")]
+    Minimal,
+    #[serde(rename = "affected")]
+    Affected,
+    #[serde(rename = "full")]
+    Full,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct GoalPlanCoverage {
+    mode: GoalPlanCoverageMode,
+    threshold: u32,
+    #[serde(default)]
+    include: Vec<String>,
+    #[serde(default)]
+    exclude: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum GoalPlanCoverageMode {
+    #[default]
+    #[serde(rename = "changed_lines")]
+    ChangedLines,
+    #[serde(rename = "affected")]
+    Affected,
+    #[serde(rename = "full")]
+    Full,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+struct GoalPlanCompletion {
+    #[serde(default)]
+    must_pass: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -340,6 +497,28 @@ fn load_request_artifact(path: &PathBuf) -> Result<RequestArtifact> {
         bail!(
             "unsupported request artifact version `{}` in `{}`",
             artifact.version,
+            path.display()
+        );
+    }
+    Ok(artifact)
+}
+
+fn load_goal_plan_artifact(path: &PathBuf) -> Result<GoalPlanArtifact> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read goal plan artifact `{}`", path.display()))?;
+    let artifact: GoalPlanArtifact = serde_yaml::from_str(&raw)
+        .with_context(|| format!("failed to parse goal plan artifact `{}`", path.display()))?;
+    if artifact.version != GOAL_PLAN_VERSION {
+        bail!(
+            "unsupported goal plan artifact version `{}` in `{}`",
+            artifact.version,
+            path.display()
+        );
+    }
+    if artifact.kind != "syu.goal_plan" {
+        bail!(
+            "unsupported goal plan artifact kind `{}` in `{}`",
+            artifact.kind,
             path.display()
         );
     }
@@ -1703,5 +1882,59 @@ mod tests {
                 format: OutputFormat::Text,
             }),
         });
+    }
+
+    #[test]
+    fn goal_plan_artifact_supports_request_driven_and_diff_inferred_sources() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("goal-plan.yaml");
+        fs::write(
+            &path,
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\n  request_artifact: request.yaml\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - tests/task_command.rs\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+        )
+        .expect("goal plan");
+
+        let artifact = load_goal_plan_artifact(&path).expect("goal plan should load");
+        assert_eq!(artifact.kind, "syu.goal_plan");
+        assert_eq!(artifact.goal.id, "GOAL-001");
+        assert_eq!(artifact.source.mode, GoalPlanSourceMode::RequestDriven);
+        assert_eq!(
+            artifact.source.request_artifact.as_deref(),
+            Some("request.yaml")
+        );
+        assert_eq!(artifact.coverage.mode, GoalPlanCoverageMode::ChangedLines);
+        assert_eq!(
+            artifact.test_plan.selection_mode,
+            GoalPlanSelectionMode::Affected
+        );
+
+        fs::write(
+            &path,
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: high\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - tests/task_command.rs\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+        )
+        .expect("goal plan");
+
+        let artifact = load_goal_plan_artifact(&path).expect("goal plan should load");
+        assert_eq!(artifact.source.mode, GoalPlanSourceMode::DiffInferred);
+        assert_eq!(artifact.source.range.as_deref(), Some("origin/main...HEAD"));
+        assert_eq!(artifact.source.confidence, Some(GoalPlanConfidence::High));
+    }
+
+    #[test]
+    fn goal_plan_artifact_requires_the_goal_plan_marker() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("goal-plan.yaml");
+        fs::write(
+            &path,
+            "version: 1\nkind: syu.not_goal_plan\nsource:\n  mode: request_driven\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: minimal\n  required_tests: {}\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect("goal plan");
+
+        let error = load_goal_plan_artifact(&path).expect_err("invalid goal plan should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported goal plan artifact kind")
+        );
     }
 }

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1958,6 +1958,23 @@ mod tests {
     }
 
     #[test]
+    fn goal_plan_artifact_defaults_to_request_driven_source_when_omitted() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("goal-plan.yaml");
+        fs::write(
+            &path,
+            "version: 1\nkind: syu.goal_plan\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: minimal\n  required_tests: {}\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect("goal plan");
+
+        let artifact = load_goal_plan_artifact(&path).expect("goal plan should load");
+        assert_eq!(artifact.source.mode, GoalPlanSourceMode::RequestDriven);
+        assert!(artifact.source.request_artifact.is_none());
+        assert!(artifact.source.range.is_none());
+        assert!(artifact.source.confidence.is_none());
+    }
+
+    #[test]
     fn goal_plan_artifact_requires_the_goal_plan_marker() {
         let tempdir = tempdir().expect("tempdir");
         let path = tempdir.path().join("goal-plan.yaml");

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -25,6 +25,8 @@ use crate::{
 use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
 
 const REQUEST_ARTIFACT_VERSION: u32 = 1;
+#[cfg(test)]
+#[allow(dead_code)]
 const GOAL_PLAN_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -53,6 +55,8 @@ struct RequestArtifact {
     context: RequestArtifactContext,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanArtifact {
     version: u32,
@@ -68,6 +72,8 @@ struct GoalPlanArtifact {
     completion: GoalPlanCompletion,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanSource {
     mode: GoalPlanSourceMode,
@@ -79,6 +85,8 @@ struct GoalPlanSource {
     confidence: Option<GoalPlanConfidence>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 impl Default for GoalPlanSource {
     fn default() -> Self {
         Self {
@@ -90,6 +98,8 @@ impl Default for GoalPlanSource {
     }
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanSourceMode {
@@ -100,6 +110,8 @@ enum GoalPlanSourceMode {
     DiffInferred,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanConfidence {
@@ -108,6 +120,8 @@ enum GoalPlanConfidence {
     Low,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanGoal {
     id: String,
@@ -117,6 +131,8 @@ struct GoalPlanGoal {
     non_goals: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
 struct GoalPlanSpecMapping {
     #[serde(default)]
@@ -125,6 +141,8 @@ struct GoalPlanSpecMapping {
     spec_updates: GoalPlanSpecUpdates,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
 struct GoalPlanPersistentItems {
     #[serde(default)]
@@ -137,6 +155,8 @@ struct GoalPlanPersistentItems {
     features: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
 struct GoalPlanSpecUpdates {
     #[serde(default)]
@@ -145,6 +165,8 @@ struct GoalPlanSpecUpdates {
     expected_updates: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanImplementationPlan {
     scope: GoalPlanScope,
@@ -152,6 +174,8 @@ struct GoalPlanImplementationPlan {
     steps: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
 struct GoalPlanScope {
     #[serde(default)]
@@ -160,6 +184,8 @@ struct GoalPlanScope {
     exclude: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanTestPlan {
     selection_mode: GoalPlanSelectionMode,
@@ -169,6 +195,8 @@ struct GoalPlanTestPlan {
     suggested_tests: BTreeMap<String, Vec<String>>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanSelectionMode {
@@ -181,6 +209,8 @@ enum GoalPlanSelectionMode {
     Full,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 struct GoalPlanCoverage {
     mode: GoalPlanCoverageMode,
@@ -191,6 +221,8 @@ struct GoalPlanCoverage {
     exclude: Vec<String>,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanCoverageMode {
@@ -203,6 +235,8 @@ enum GoalPlanCoverageMode {
     Full,
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
 struct GoalPlanCompletion {
     #[serde(default)]
@@ -503,6 +537,8 @@ fn load_request_artifact(path: &PathBuf) -> Result<RequestArtifact> {
     Ok(artifact)
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn load_goal_plan_artifact(path: &PathBuf) -> Result<GoalPlanArtifact> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read goal plan artifact `{}`", path.display()))?;
@@ -1448,9 +1484,10 @@ mod tests {
     };
 
     use super::{
-        ClassificationOutcome, RequirementAction, SearchResult, WorkspaceLookup,
-        build_scaffold_plan, classify_request, collect_feature_candidates, load_request_artifact,
-        run_task_command,
+        ClassificationOutcome, GoalPlanConfidence, GoalPlanCoverageMode, GoalPlanSelectionMode,
+        GoalPlanSourceMode, RequirementAction, SearchResult, WorkspaceLookup, build_scaffold_plan,
+        classify_request, collect_feature_candidates, load_goal_plan_artifact,
+        load_request_artifact, run_task_command,
     };
 
     fn write_request_artifact(path: &Path, request: &str, linked_ids: &[&str]) {

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -315,6 +315,23 @@ fn task_scope_help_mentions_request_artifacts_and_json_output() {
 }
 
 #[test]
+fn task_scaffold_help_mentions_goal_plans_and_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "scaffold", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Goal Plan"));
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("syu task scaffold request.yaml"));
+    assert!(stdout.contains("syu task scaffold request.yaml --format json"));
+}
+
+#[test]
 // REQ-CORE-024
 fn validate_help_mentions_warning_exit_code_for_automation() {
     let output = Command::cargo_bin("syu")

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -12,8 +12,8 @@
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
 
-#[test]
 // REQ-CORE-010
+#[test]
 fn root_help_includes_start_here_guidance() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")
@@ -314,6 +314,7 @@ fn task_scope_help_mentions_request_artifacts_and_json_output() {
     assert!(stdout.contains("syu task scope request.yaml --format json"));
 }
 
+// REQ-CORE-031
 #[test]
 fn task_scaffold_help_mentions_goal_plans_and_json_output() {
     let output = Command::cargo_bin("syu")
@@ -329,6 +330,22 @@ fn task_scaffold_help_mentions_goal_plans_and_json_output() {
     assert!(stdout.contains("--format"));
     assert!(stdout.contains("syu task scaffold request.yaml"));
     assert!(stdout.contains("syu task scaffold request.yaml --format json"));
+}
+
+// REQ-CORE-031
+#[test]
+fn workspace_help_mentions_goal_plan_artifacts() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "scaffold", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task scaffold help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Goal Plan"));
+    assert!(stdout.contains("temporary"));
 }
 
 #[test]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -408,3 +408,36 @@ fn task_scaffold_rejects_delete_requests() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only supports request artifacts"));
 }
+
+#[test]
+// REQ-CORE-031
+fn goal_plan_artifact_supports_request_driven_and_diff_inferred_sources() {
+    let guide = fs::read_to_string("docs/guide/goal-plan-format.md")
+        .expect("goal plan guide should be readable");
+
+    assert!(guide.contains("syu.goal_plan"));
+    assert!(guide.contains("request_driven"));
+    assert!(guide.contains("diff-inferred"));
+    assert!(guide.contains("confidence"));
+}
+
+#[test]
+// REQ-CORE-031
+fn goal_plan_artifact_requires_the_goal_plan_marker() {
+    let guide = fs::read_to_string("docs/guide/goal-plan-format.md")
+        .expect("goal plan guide should be readable");
+
+    assert!(guide.contains("kind: syu.goal_plan"));
+    assert!(guide.contains("Goal Plans are"));
+    assert!(guide.contains("planning artifacts"));
+}
+
+#[test]
+// REQ-CORE-031
+fn goal_plan_format_is_documented_as_temporary() {
+    let guide = fs::read_to_string("docs/guide/implementation-planning.md")
+        .expect("implementation planning guide should be readable");
+
+    assert!(guide.contains("goal plan format"));
+    assert!(guide.contains("temporary"));
+}


### PR DESCRIPTION
Summary:
- Add a temporary `syu.goal_plan` artifact schema in the task command module.
- Document Goal Plans as ephemeral delivery artifacts outside `spec.root`.
- Update task-planning guidance and command-card text to point at Goal Plan usage.

Validation:
- `cargo fmt --check`
- `cargo test --test help_command task_scaffold_help_mentions_goal_plans_and_json_output -- --exact` (blocked by missing `app/node_modules` browser-app prerequisites)
- `cargo test --lib command::task::tests::goal_plan_artifact_supports_request_driven_and_diff_inferred_sources -- --exact` (blocked by missing `app/node_modules` browser-app prerequisites)

Closes #701
