### PR TITLE
Keep CI coverage reporting, but remove minimum coverage thresholds

### DIFF
--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -44,7 +44,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
         - **symbols**:
           - configure_llvm_tools
           - enforce_diff_coverage
-          - enforce_lcov_threshold
+          - report_lcov_coverage
           - run_coverage
       - **file**: scripts/ci/check-generated-docs-freshness.sh
         - **symbols**:
@@ -190,7 +190,7 @@ features:
           symbols:
             - configure_llvm_tools
             - enforce_diff_coverage
-            - enforce_lcov_threshold
+            - report_lcov_coverage
             - run_coverage
         - file: scripts/ci/check-generated-docs-freshness.sh
           symbols:

--- a/docs/generated/site-spec/requirements/core/repository.md
+++ b/docs/generated/site-spec/requirements/core/repository.md
@@ -41,11 +41,12 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
           - repository_declares_precommit_and_quality_gates
           - repository_keeps_node_majors_aligned_across_docs_packages_and_ci
 - **id**: REQ-CORE-006
-  - **title**: Enforce 100 percent line coverage in CI
+  - **title**: Report coverage in CI without gating on percentage
   - **description**:
     - |
-      The repository MUST gate CI on 100 percent Rust line coverage using a
-      repeatable command so regressions in verification logic remain visible.
+      The repository MUST measure and report Rust line coverage in CI using a
+      repeatable command so regressions in verification logic remain visible,
+      but it MUST NOT block merges on a minimum coverage percentage.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -56,7 +57,7 @@ description: "Generated reference for docs/syu/requirements/core/repository.yaml
     - **rust**:
       - **file**: tests/repository_quality.rs
         - **symbols**:
-          - repository_declares_coverage_gate_at_one_hundred_percent
+          - repository_declares_coverage_reporting_without_percentage_gate
       - **file**: tests/spec_coverage_summary_script.rs
         - **symbols**:
           - *
@@ -232,10 +233,11 @@ requirements:
             - repository_declares_precommit_and_quality_gates
             - repository_keeps_node_majors_aligned_across_docs_packages_and_ci
   - id: REQ-CORE-006
-    title: Enforce 100 percent line coverage in CI
+    title: Report coverage in CI without gating on percentage
     description: |
-      The repository MUST gate CI on 100 percent Rust line coverage using a
-      repeatable command so regressions in verification logic remain visible.
+      The repository MUST measure and report Rust line coverage in CI using a
+      repeatable command so regressions in verification logic remain visible,
+      but it MUST NOT block merges on a minimum coverage percentage.
     priority: high
     status: implemented
     linked_policies:
@@ -246,7 +248,7 @@ requirements:
       rust:
         - file: tests/repository_quality.rs
           symbols:
-            - repository_declares_coverage_gate_at_one_hundred_percent
+            - repository_declares_coverage_reporting_without_percentage_gate
         - file: tests/spec_coverage_summary_script.rs
           symbols:
             - '*'

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -29,7 +29,7 @@ features:
           symbols:
             - configure_llvm_tools
             - enforce_diff_coverage
-            - enforce_lcov_threshold
+            - report_lcov_coverage
             - run_coverage
         - file: scripts/ci/check-generated-docs-freshness.sh
           symbols:

--- a/docs/syu/requirements/core/repository.yaml
+++ b/docs/syu/requirements/core/repository.yaml
@@ -24,10 +24,11 @@ requirements:
             - repository_declares_precommit_and_quality_gates
             - repository_keeps_node_majors_aligned_across_docs_packages_and_ci
   - id: REQ-CORE-006
-    title: Enforce 100 percent line coverage in CI
+    title: Report coverage in CI without gating on percentage
     description: |
-      The repository MUST gate CI on 100 percent Rust line coverage using a
-      repeatable command so regressions in verification logic remain visible.
+      The repository MUST measure and report Rust line coverage in CI using a
+      repeatable command so regressions in verification logic remain visible,
+      but it MUST NOT block merges on a minimum coverage percentage.
     priority: high
     status: implemented
     linked_policies:
@@ -38,7 +39,7 @@ requirements:
       rust:
         - file: tests/repository_quality.rs
           symbols:
-            - repository_declares_coverage_gate_at_one_hundred_percent
+            - repository_declares_coverage_reporting_without_percentage_gate
         - file: tests/spec_coverage_summary_script.rs
           symbols:
             - '*'

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -202,6 +202,7 @@ if misses:
     print("changed lines without coverage:")
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
+    raise SystemExit(1)
 else:
     print("changed-line coverage: 100.00%")
 PY

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -202,7 +202,6 @@ if misses:
     print("changed lines without coverage:")
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
-    raise SystemExit(1)
 else:
     print("changed-line coverage: 100.00%")
 PY

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -202,7 +202,6 @@ if misses:
     print("changed lines without coverage:")
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
-    sys.exit(1)
 else:
     print("coverage measure script")
 PY

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -202,6 +202,7 @@ if misses:
     print("changed lines without coverage:")
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
+    sys.exit(1)
 else:
     print("coverage measure script")
 PY

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -203,7 +203,7 @@ if misses:
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
 else:
-    print("changed-line coverage: 100.00%")
+    print("coverage measure script")
 PY
 }
 

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-LINE_THRESHOLD=100
-
 ensure_cargo_bin_in_path() {
   local cargo_bin_dir
 
@@ -50,16 +48,13 @@ generate_spec_coverage_summary() {
   fi
 }
 
-enforce_lcov_threshold() {
+report_lcov_coverage() {
   local lcov_path="$1"
 
-  # Keep the repository contract equivalent to cargo llvm-cov --fail-under-lines 100,
-  # but evaluate it from LCOV's executed-line data so the gate reflects true line coverage.
-  python3 - "$lcov_path" "$LINE_THRESHOLD" <<'PY'
+  python3 - "$lcov_path" <<'PY'
 import sys
 
 lcov_path = sys.argv[1]
-threshold = float(sys.argv[2])
 covered = 0
 total = 0
 current_file = None
@@ -83,7 +78,8 @@ with open(lcov_path, encoding="utf-8") as handle:
 
 coverage = 100.0 if total == 0 else covered * 100.0 / total
 print(f"line coverage: {coverage:.2f}% ({covered}/{total})")
-if coverage + 1e-9 < threshold:
+
+if misses:
     print("\nuncovered executable lines:")
     by_file = {}
     for filename, line_number in misses:
@@ -100,7 +96,6 @@ if coverage + 1e-9 < threshold:
             if 1 <= line_number <= len(source_lines):
                 snippet = source_lines[line_number - 1].strip()
             print(f"  {line_number}: {snippet}")
-    raise SystemExit(1)
 PY
 }
 
@@ -207,9 +202,8 @@ if misses:
     print("changed lines without coverage:")
     for path, line_number in misses:
         print(f"- {path.relative_to(repo_root)}:{line_number}")
-    raise SystemExit(1)
-
-print("changed-line coverage: 100.00%")
+else:
+    print("changed-line coverage: 100.00%")
 PY
 }
 
@@ -238,17 +232,17 @@ run_coverage() {
     summary)
       generate_lcov target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
-      enforce_lcov_threshold target/coverage/lcov.info
+      report_lcov_coverage target/coverage/lcov.info
       ;;
     lcov)
       generate_lcov target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
-      enforce_lcov_threshold target/coverage/lcov.info
+      report_lcov_coverage target/coverage/lcov.info
       ;;
     html)
       generate_lcov target/coverage/lcov.info
       generate_spec_coverage_summary target/coverage/lcov.info target/coverage/spec-coverage-summary.md
-      enforce_lcov_threshold target/coverage/lcov.info
+      report_lcov_coverage target/coverage/lcov.info
       cargo llvm-cov --no-run --html
       ;;
     *)

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -184,15 +184,18 @@ fn repository_declares_precommit_and_quality_gates() {
 
 #[test]
 // REQ-CORE-006
-fn repository_declares_coverage_gate_at_one_hundred_percent() {
+fn repository_declares_coverage_reporting_without_percentage_gate() {
     let coverage_script = read_file("scripts/ci/coverage.sh");
     let spec_summary_script = read_file("scripts/ci/write-spec-coverage-summary.py");
     let ci_workflow = read_file(".github/workflows/ci.yml");
 
     assert!(coverage_script.contains("FEAT-QUALITY-001"));
     assert!(coverage_script.contains("run_coverage"));
-    assert!(coverage_script.contains("LINE_THRESHOLD=100"));
-    assert!(coverage_script.contains("--fail-under-lines 100"));
+    assert!(coverage_script.contains("generate_lcov"));
+    assert!(coverage_script.contains("report_lcov_coverage"));
+    assert!(coverage_script.contains("enforce_diff_coverage"));
+    assert!(!coverage_script.contains("LINE_THRESHOLD=100"));
+    assert!(!coverage_script.contains("--fail-under-lines 100"));
     assert!(coverage_script.contains("cargo llvm-cov"));
     assert!(coverage_script.contains("generate_spec_coverage_summary"));
     assert!(coverage_script.contains("target/coverage/spec-coverage-summary.md"));


### PR DESCRIPTION
Summary:
- Remove coverage percentage enforcement from CI while keeping LCOV generation, coverage summaries, artifact upload, and changed-line reporting.
- Update the repository quality spec references to the new non-blocking coverage-reporting function.

Validation:
- bash -n scripts/ci/coverage.sh
- python3 -m py_compile scripts/ci/write-spec-coverage-summary.py
- git diff --check

Closes #715
