### PR TITLE
[Feature]: Add strict reviewer-mode failures for unowned and ambiguous range changes

### DIFF
--- a/docs/generated/site-spec/features/cli/trace.md
+++ b/docs/generated/site-spec/features/cli/trace.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/cli/trace.yaml"
 
 - **id**: FEAT-TRACE-001
   - **title**: Source-first trace lookup
-  - **summary**: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
+  - **summary**: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries and strict reviewer failures that surface affected IDs and structured findings before file details.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-021
@@ -41,7 +41,7 @@ version: 1
 features:
   - id: FEAT-TRACE-001
     title: Source-first trace lookup
-    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
+    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries and strict reviewer failures that surface affected IDs and structured findings before file details.
     status: implemented
     linked_requirements:
       - REQ-CORE-021

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -26,6 +26,7 @@ If a pull request already exists, pair this page with the
 | Inspect one spec item | `syu show FEAT-CHECK-001` | read the title, links, traces, and status for one philosophy, policy, requirement, or feature |
 | Expand the nearby graph | `syu relate FEAT-CHECK-001` | see linked policies, requirements, features, files, and symbols around one selector |
 | Review a PR range | `syu review --range origin/main...HEAD` | start with the affected philosophy, policy, requirement, and feature IDs, then drill into changed files with `show`, `relate`, or `log` |
+| Strictly review a PR range | `syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json` | fail the range review on unowned, ambiguously owned, or out-of-scope changes while keeping structured findings for CI |
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
 | Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -93,6 +93,19 @@ separates directly matched items from indirect upstream/downstream context,
 surfaces unowned or skipped paths inline, and keeps the follow-up `show`,
 `relate`, `log`, and `validate --id` commands close at hand.
 
+When CI or a merge queue needs the review step to fail on ownership drift
+instead of only summarizing it, add `--strict`:
+
+```bash
+syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json
+```
+
+Strict range review turns unowned files, ambiguous ownership, and skipped or
+out-of-scope paths into a failing result while still returning structured
+findings for terminal use or JSON consumers. Use it when the range itself is
+the review contract. Keep using `syu audit` for heuristic notes and
+`syu validate` when you need the full validation pass across the repository.
+
 When you want the range to stay inside a named requirement or feature, add
 `--allowed-id` or its `--expected-id` alias:
 

--- a/docs/syu/features/cli/trace.yaml
+++ b/docs/syu/features/cli/trace.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-TRACE-001
     title: Source-first trace lookup
-    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries that surface affected IDs before file details.
+    summary: Start from a repository file path and optional symbol, then resolve linked requirements, features, policies, and philosophies from trace ownership, including range summaries and strict reviewer failures that surface affected IDs and structured findings before file details.
     status: implemented
     linked_requirements:
       - REQ-CORE-021

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,7 @@ Examples:
   syu trace src/rust_feature.rs --symbol feature_trace_rust
   syu trace src/rust_feature.rs path/to/workspace --format json
   syu review --range origin/main...HEAD
+  syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json
   syu trace --range main..HEAD
   syu trace --range origin/main...HEAD --format json";
 
@@ -261,7 +262,7 @@ pub enum Commands {
     Relate(RelateArgs),
     #[command(
         visible_alias = "review",
-        about = "Resolve linked requirements, features, policies, and philosophies from a traced file or symbol",
+        about = "Resolve linked requirements, features, policies, and philosophies from a traced file or symbol, or review a git range",
         after_help = TRACE_AFTER_HELP
     )]
     Trace(TraceArgs),
@@ -508,6 +509,12 @@ pub struct TraceArgs {
     #[arg(help = "Allowed requirement or feature IDs for review range scope guards")]
     #[arg(long = "allowed-id", alias = "expected-id")]
     pub allowed_id: Vec<String>,
+
+    #[arg(
+        help = "Fail range review when unowned, ambiguously owned, or out-of-scope changes appear"
+    )]
+    #[arg(long)]
+    pub strict: bool,
 
     #[arg(help = "Output format for trace lookup results")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]

--- a/src/command/app.rs
+++ b/src/command/app.rs
@@ -408,7 +408,14 @@ fn emit_startup_lines(lines: Vec<String>) -> Result<()> {
 }
 
 fn app_dev_server_origin(args: &AppArgs) -> Option<String> {
-    args.dev_server.then_some(APP_DEV_SERVER_ORIGIN.to_string())
+    if !args.dev_server {
+        return None;
+    }
+
+    env::var("SYU_APP_DEV_SERVER_ORIGIN")
+        .ok()
+        .filter(|origin| !origin.is_empty())
+        .or_else(|| Some(APP_DEV_SERVER_ORIGIN.to_string()))
 }
 
 fn resolve_app_server_settings(args: &AppArgs, config: &SyuConfig) -> AppServerSettings {

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -1530,6 +1530,7 @@ mod tests {
             symbol: Some("   ".to_string()),
             range: None,
             allowed_id: Vec::new(),
+            strict: false,
             format: OutputFormat::Text,
         })
         .expect_err("blank symbols should fail");
@@ -1910,6 +1911,7 @@ mod tests {
             symbol: None,
             range: None,
             allowed_id: Vec::new(),
+            strict: false,
             format: OutputFormat::Text,
         })
         .expect_err("missing file and range should fail");
@@ -2199,6 +2201,7 @@ mod tests {
                 },
             },
             None,
+            None,
         );
 
         assert!(rendered.contains("Affected IDs:"));
@@ -2282,6 +2285,7 @@ mod tests {
                 },
             },
             None,
+            None,
         );
 
         assert!(rendered.contains("feature FEAT-TRACE-001:"));
@@ -2324,6 +2328,7 @@ mod tests {
                     },
                 },
             },
+            None,
             None,
         );
 

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -113,6 +113,8 @@ struct TraceRangeOutput {
     summary: TraceRangeSummary,
     #[serde(skip_serializing_if = "Option::is_none")]
     scope_guard: Option<TraceRangeScopeGuard>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    strict_review: Option<TraceRangeReviewOutput>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -148,6 +150,32 @@ struct TraceRangeSummary {
 struct TraceRangeScopeGuard {
     allowed_ids: Vec<TraceScopeGuardItem>,
     out_of_scope_items: Vec<TraceScopeGuardViolation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceRangeReviewOutput {
+    enabled: bool,
+    failed: bool,
+    findings: Vec<TraceRangeReviewFinding>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceRangeReviewFinding {
+    kind: TraceRangeReviewFindingKind,
+    file: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    owners: Vec<TraceScopeGuardOwner>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TraceRangeReviewFindingKind {
+    Unowned,
+    AmbiguousOwnership,
+    OutOfScope,
+    TraceDrift,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -193,7 +221,13 @@ pub fn run_trace_command(args: &TraceArgs) -> Result<i32> {
         if args.symbol.is_some() {
             bail!("--symbol cannot be used with --range");
         }
-        return run_trace_range(&workspace, range, args.format, &args.allowed_id);
+        return run_trace_range(
+            &workspace,
+            range,
+            args.format,
+            args.strict,
+            &args.allowed_id,
+        );
     }
 
     let Some(file) = &args.file else {
@@ -228,6 +262,7 @@ fn run_trace_range(
     workspace: &Workspace,
     range: &str,
     format: OutputFormat,
+    strict: bool,
     allowed_ids: &[String],
 ) -> Result<i32> {
     let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
@@ -260,14 +295,23 @@ fn run_trace_range(
             },
         };
         let scope_guard = collect_trace_scope_guard(workspace, &[], &[], allowed_ids)?;
+        let strict_review = collect_trace_review_output(&[], &[], scope_guard.as_ref(), strict);
         let guard_failed = scope_guard
             .as_ref()
             .is_some_and(|guard| !guard.out_of_scope_items.is_empty());
+        let strict_failed = strict_review.as_ref().is_some_and(|review| review.failed);
         match format {
             OutputFormat::Text => {
                 print!(
                     "{}",
-                    render_range_text(range, &[], &[], &summary, scope_guard.as_ref())
+                    render_range_text(
+                        range,
+                        &[],
+                        &[],
+                        &summary,
+                        scope_guard.as_ref(),
+                        strict_review.as_ref(),
+                    )
                 );
             }
             OutputFormat::Json => {
@@ -279,26 +323,37 @@ fn run_trace_range(
                         skipped_files: Vec::new(),
                         summary,
                         scope_guard,
+                        strict_review,
                     })
                     .expect("serializing empty trace range output to JSON should succeed")
                 );
             }
         }
-        return Ok(if guard_failed { 1 } else { 0 });
+        return Ok(if guard_failed || strict_failed { 1 } else { 0 });
     }
 
     let (results, skipped) = collect_trace_range_outputs(workspace, &changed_files);
 
     let summary = compute_range_summary(changed_files.len(), &results, &skipped);
     let scope_guard = collect_trace_scope_guard(workspace, &results, &skipped, allowed_ids)?;
+    let strict_review =
+        collect_trace_review_output(&results, &skipped, scope_guard.as_ref(), strict);
     let guard_failed = scope_guard
         .as_ref()
         .is_some_and(|guard| !guard.out_of_scope_items.is_empty());
+    let strict_failed = strict_review.as_ref().is_some_and(|review| review.failed);
 
     match format {
         OutputFormat::Text => print!(
             "{}",
-            render_range_text(range, &results, &skipped, &summary, scope_guard.as_ref())
+            render_range_text(
+                range,
+                &results,
+                &skipped,
+                &summary,
+                scope_guard.as_ref(),
+                strict_review.as_ref(),
+            )
         ),
         OutputFormat::Json => println!(
             "{}",
@@ -308,12 +363,13 @@ fn run_trace_range(
                 skipped_files: skipped,
                 summary,
                 scope_guard,
+                strict_review,
             })
             .expect("serializing trace range output to JSON should succeed")
         ),
     }
 
-    Ok(if guard_failed { 1 } else { 0 })
+    Ok(if guard_failed || strict_failed { 1 } else { 0 })
 }
 
 fn compute_range_summary(
@@ -451,6 +507,7 @@ fn render_range_text(
     skipped: &[TraceSkippedFile],
     summary: &TraceRangeSummary,
     scope_guard: Option<&TraceRangeScopeGuard>,
+    strict_review: Option<&TraceRangeReviewOutput>,
 ) -> String {
     let mut output = String::new();
     writeln!(output, "Git range: {range}").unwrap();
@@ -463,6 +520,10 @@ fn render_range_text(
         summary.owned_files, summary.partial_files, summary.unowned_files
     )
     .unwrap();
+
+    if let Some(strict_review) = strict_review {
+        render_strict_review_text(&mut output, strict_review);
+    }
 
     if summary.changed_files_total == 0 && results.is_empty() && skipped.is_empty() {
         writeln!(output, "No files changed in range").unwrap();
@@ -550,6 +611,55 @@ fn render_range_text(
     }
 
     output
+}
+
+fn render_strict_review_text(rendered: &mut String, strict_review: &TraceRangeReviewOutput) {
+    writeln!(
+        rendered,
+        "Strict review: {}",
+        if strict_review.failed {
+            "failed"
+        } else {
+            "passed"
+        }
+    )
+    .unwrap();
+    writeln!(rendered, "  Findings:").unwrap();
+    if strict_review.findings.is_empty() {
+        writeln!(rendered, "    - none").unwrap();
+        writeln!(rendered).unwrap();
+        return;
+    }
+
+    for finding in &strict_review.findings {
+        writeln!(rendered, "    - {}: {}", finding.kind.label(), finding.file).unwrap();
+        if let Some(reason) = finding.reason.as_deref() {
+            writeln!(rendered, "      reason: {reason}").unwrap();
+        }
+        if !finding.owners.is_empty() {
+            writeln!(rendered, "      owners:").unwrap();
+            for owner in &finding.owners {
+                writeln!(
+                    rendered,
+                    "        - {} {}\t{}",
+                    owner.kind, owner.id, owner.title
+                )
+                .unwrap();
+            }
+        }
+    }
+    writeln!(rendered).unwrap();
+}
+
+impl TraceRangeReviewFindingKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Unowned => "unowned",
+            Self::AmbiguousOwnership => "ambiguous ownership",
+            Self::OutOfScope => "out of scope",
+            Self::TraceDrift => "trace drift",
+        }
+    }
 }
 
 fn render_scope_guard_text(rendered: &mut String, scope_guard: &TraceRangeScopeGuard) {
@@ -647,6 +757,119 @@ fn collect_trace_scope_guard(
         allowed_ids: allowed_ids_by_id.into_values().collect(),
         out_of_scope_items,
     }))
+}
+
+fn collect_trace_review_output(
+    results: &[TraceLookupOutput],
+    skipped_files: &[TraceSkippedFile],
+    scope_guard: Option<&TraceRangeScopeGuard>,
+    strict: bool,
+) -> Option<TraceRangeReviewOutput> {
+    if !strict {
+        return None;
+    }
+
+    let mut findings =
+        BTreeMap::<(TraceRangeReviewFindingKind, String), TraceRangeReviewFinding>::new();
+
+    for result in results {
+        if result.matched_owners.is_empty() && result.file_only_owners.is_empty() {
+            push_review_finding(
+                &mut findings,
+                TraceRangeReviewFindingKind::Unowned,
+                result.file.clone(),
+                Vec::new(),
+                Some("no requirement or feature trace owns this file".to_string()),
+            );
+            continue;
+        }
+
+        let owners = result
+            .matched_owners
+            .iter()
+            .chain(result.file_only_owners.iter())
+            .map(|owner| TraceScopeGuardOwner {
+                kind: owner.kind.to_string(),
+                id: owner.id.clone(),
+                title: owner.title.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        if owners.len() > 1 {
+            push_review_finding(
+                &mut findings,
+                TraceRangeReviewFindingKind::AmbiguousOwnership,
+                result.file.clone(),
+                owners,
+                Some("multiple requirement or feature owners match this file".to_string()),
+            );
+        } else if result.status == TraceLookupStatus::Partial {
+            push_review_finding(
+                &mut findings,
+                TraceRangeReviewFindingKind::TraceDrift,
+                result.file.clone(),
+                owners,
+                Some("the file is owned, but the requested symbol did not match".to_string()),
+            );
+        }
+    }
+
+    if let Some(scope_guard) = scope_guard {
+        for violation in &scope_guard.out_of_scope_items {
+            let kind = match violation.reason.as_deref() {
+                Some("unowned") => TraceRangeReviewFindingKind::Unowned,
+                Some("outside allowed IDs") => TraceRangeReviewFindingKind::OutOfScope,
+                Some(_) => TraceRangeReviewFindingKind::TraceDrift,
+                None => TraceRangeReviewFindingKind::TraceDrift,
+            };
+
+            if kind == TraceRangeReviewFindingKind::Unowned {
+                continue;
+            }
+
+            push_review_finding(
+                &mut findings,
+                kind,
+                violation.file.clone(),
+                violation.owners.clone(),
+                violation.reason.clone(),
+            );
+        }
+    } else {
+        for skipped in skipped_files {
+            push_review_finding(
+                &mut findings,
+                TraceRangeReviewFindingKind::TraceDrift,
+                skipped.file.clone(),
+                Vec::new(),
+                Some(skipped.reason.clone()),
+            );
+        }
+    }
+
+    let findings = findings.into_values().collect::<Vec<_>>();
+    Some(TraceRangeReviewOutput {
+        enabled: true,
+        failed: !findings.is_empty(),
+        findings,
+    })
+}
+
+fn push_review_finding(
+    findings: &mut BTreeMap<(TraceRangeReviewFindingKind, String), TraceRangeReviewFinding>,
+    kind: TraceRangeReviewFindingKind,
+    file: String,
+    owners: Vec<TraceScopeGuardOwner>,
+    reason: Option<String>,
+) {
+    findings
+        .entry((kind, file.clone()))
+        .or_insert_with(|| TraceRangeReviewFinding {
+            kind,
+            file,
+            owners,
+            reason,
+        });
 }
 
 fn resolve_scope_guard_item(lookup: &WorkspaceLookup<'_>, id: &str) -> Result<TraceScopeGuardItem> {
@@ -1613,7 +1836,7 @@ mod tests {
         };
 
         let rendered =
-            super::render_range_text("HEAD..HEAD", &[], &[], &summary, Some(&scope_guard));
+            super::render_range_text("HEAD..HEAD", &[], &[], &summary, Some(&scope_guard), None);
 
         assert!(rendered.contains("Git range: HEAD..HEAD"));
         assert!(rendered.contains("No files changed in range"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,7 @@ mod tests {
                     symbol: Some("run".to_string()),
                     range: None,
                     allowed_id: Vec::new(),
+                    strict: false,
                     format: OutputFormat::Json,
                 })),
             },

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -135,15 +135,15 @@ fn app_command_test_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn spawn_fake_vite_server() -> std::thread::JoinHandle<()> {
-    let listener = TcpListener::bind(("127.0.0.1", 4173)).expect("fake vite listener should bind");
+fn spawn_fake_dev_server(port: u16, status_line: &'static str) -> std::thread::JoinHandle<()> {
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("fake vite listener should bind");
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("fake vite client should connect");
         let mut request = [0_u8; 512];
         let _ = stream.read(&mut request);
         write!(
             stream,
-            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            "{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         )
         .expect("fake vite response should write");
         stream.flush().expect("fake vite response should flush");
@@ -355,7 +355,8 @@ fn app_command_can_serve_a_dev_server_shell() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let port = reserve_port();
-    let fake_vite = spawn_fake_vite_server();
+    let dev_server_port = reserve_port();
+    let fake_vite = spawn_fake_dev_server(dev_server_port, "HTTP/1.1 200 OK");
     let mut child = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("app")
@@ -365,6 +366,10 @@ fn app_command_can_serve_a_dev_server_shell() {
         .arg("--port")
         .arg(port.to_string())
         .arg("--dev-server")
+        .env(
+            "SYU_APP_DEV_SERVER_ORIGIN",
+            format!("http://127.0.0.1:{dev_server_port}"),
+        )
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -375,8 +380,8 @@ fn app_command_can_serve_a_dev_server_shell() {
 
     let index = http_get(port, "/").expect("index should load");
     assert!(index.contains("200 OK"));
-    assert!(index.contains("http://127.0.0.1:4173/@vite/client"));
-    assert!(index.contains("http://127.0.0.1:4173/src/main.tsx"));
+    assert!(index.contains(&format!("http://127.0.0.1:{dev_server_port}/@vite/client")));
+    assert!(index.contains(&format!("http://127.0.0.1:{dev_server_port}/src/main.tsx")));
 
     let payload = http_get(port, "/api/app-data.json").expect("payload should load");
     assert!(payload.contains("200 OK"));
@@ -392,6 +397,8 @@ fn app_command_requires_a_running_dev_server_for_dev_mode() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let port = reserve_port();
+    let dev_server_port = reserve_port();
+    let _fake_vite = spawn_fake_dev_server(dev_server_port, "HTTP/1.1 503 Service Unavailable");
     let output = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("app")
@@ -401,6 +408,10 @@ fn app_command_requires_a_running_dev_server_for_dev_mode() {
         .arg("--port")
         .arg(port.to_string())
         .arg("--dev-server")
+        .env(
+            "SYU_APP_DEV_SERVER_ORIGIN",
+            format!("http://127.0.0.1:{dev_server_port}"),
+        )
         .output()
         .expect("app command should run");
 

--- a/tests/trace_command.rs
+++ b/tests/trace_command.rs
@@ -142,6 +142,47 @@ fn init_git_fixture_workspace_with_requirement_and_feature_changes() -> tempfile
     tempdir
 }
 
+fn init_git_fixture_workspace_with_strict_review_conflicts() -> tempfile::TempDir {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let workspace = tempdir.path().join("workspace");
+    copy_dir_recursive(&fixture_path("passing"), &workspace);
+
+    let feature_yaml = workspace.join("docs/syu/features/traceability/core.yaml");
+    let feature_contents = fs::read_to_string(&feature_yaml).expect("feature yaml");
+    let feature_contents = feature_contents.replacen(
+        "        - file: src/rust_feature.rs\n          symbols:\n            - feature_trace_rust\n",
+        "        - file: src/rust_feature.rs\n          symbols:\n            - feature_trace_rust\n        - file: src/ambiguous.rs\n          symbols:\n            - ambiguous_trace\n",
+        1,
+    );
+    fs::write(&feature_yaml, feature_contents).expect("feature yaml should update");
+
+    let requirement_yaml = workspace.join("docs/syu/requirements/traceability/core.yaml");
+    let requirement_contents = fs::read_to_string(&requirement_yaml).expect("requirement yaml");
+    let requirement_contents = requirement_contents.replacen(
+        "        - file: src/rust_trace_tests.rs\n          symbols:\n            - req_trace_rust_test\n",
+        "        - file: src/rust_trace_tests.rs\n          symbols:\n            - req_trace_rust_test\n        - file: src/ambiguous.rs\n          symbols:\n            - ambiguous_trace\n",
+        1,
+    );
+    fs::write(&requirement_yaml, requirement_contents).expect("requirement yaml should update");
+
+    git(&workspace, &["init"]);
+    git(&workspace, &["config", "user.name", "Test User"]);
+    git(&workspace, &["config", "user.email", "test@example.com"]);
+    git(&workspace, &["add", "."]);
+    git_commit(&workspace, "chore: seed traced workspace");
+
+    fs::write(
+        workspace.join("src/ambiguous.rs"),
+        "// REQ-TRACE-001\n// FEAT-TRACE-001\npub fn ambiguous_trace() {}\n",
+    )
+    .expect("ambiguous source");
+    fs::write(workspace.join("src/unowned.rs"), "pub fn unowned() {}\n").expect("unowned source");
+    git(&workspace, &["add", "."]);
+    git_commit(&workspace, "feat: add strict review conflicts");
+
+    tempdir
+}
+
 #[test]
 fn trace_command_resolves_feature_owners_from_file_only_lookup() {
     let output = Command::cargo_bin("syu")
@@ -323,6 +364,50 @@ fn review_command_blocks_out_of_scope_requirement_and_feature_flows() {
     assert!(feature_stdout.contains("feature FEAT-TRACE-001"));
     assert!(feature_stdout.contains("requirement REQ-TRACE-001"));
     assert!(feature_stdout.contains("outside allowed IDs"));
+}
+
+#[test]
+fn review_command_strict_mode_reports_unowned_and_ambiguous_changes() {
+    let workspace = init_git_fixture_workspace_with_strict_review_conflicts();
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .current_dir(workspace.path().join("workspace"))
+        .args([
+            "review",
+            "--range",
+            "HEAD~1..HEAD",
+            "--strict",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("review range command should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    let strict_review = json["strict_review"].as_object().expect("strict review");
+    assert!(strict_review["failed"].as_bool().expect("strict status"));
+
+    let findings = strict_review["findings"]
+        .as_array()
+        .expect("strict findings array");
+    assert!(findings.iter().any(|finding| finding["kind"] == "unowned"));
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["kind"] == "ambiguous_ownership")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["file"] == "src/unowned.rs")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["file"] == "src/ambiguous.rs")
+    );
 }
 
 #[test]
@@ -549,6 +634,73 @@ fn trace_command_treats_skipped_git_diff_paths_as_out_of_scope_when_allowed_ids_
             .contains("must stay under workspace")
     );
     assert!(scope_guard["out_of_scope_items"][0].get("owners").is_none());
+}
+
+#[test]
+fn review_command_strict_mode_reports_skipped_paths_as_trace_drift() {
+    let tempdir = tempdir().expect("tempdir should exist");
+    let script_dir = tempdir.path().join("bin");
+    fs::create_dir_all(&script_dir).expect("script dir");
+    let script_path = script_dir.join("git");
+    fs::write(
+        &script_path,
+        "#!/bin/sh\nset -eu\nprintf '../outside.rs\\nsrc/rust_feature.rs\\n'\n",
+    )
+    .expect("fake git");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("permissions");
+    }
+
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .current_dir(fixture_path("passing"))
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                script_dir.display(),
+                std::env::var("PATH").expect("PATH env")
+            ),
+        )
+        .args([
+            "review",
+            "--range",
+            "HEAD~1..HEAD",
+            "--strict",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("review range command should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    let strict_review = json["strict_review"].as_object().expect("strict review");
+    let findings = strict_review["findings"]
+        .as_array()
+        .expect("strict findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["kind"] == "trace_drift")
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding["file"] == "../outside.rs")
+    );
+    assert!(findings.iter().any(|finding| {
+        finding["reason"]
+            .as_str()
+            .expect("strict reason")
+            .contains("must stay under workspace")
+    }));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Added strict `review --range` failure handling and structured findings for unowned, ambiguous, out-of-scope, and skipped-path cases.
- Updated trace CLI help, reviewer workflow docs, command card, and trace feature spec docs.
- Added integration coverage for strict range review and regenerated site docs.

Validation:
- cargo test --test trace_command
- cargo test --test repository_quality repository_declares_documentation_guides

Closes #644
