### PR TITLE
Add syu task check for Goal Plan conformance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +993,7 @@ dependencies = [
  "axum",
  "clap",
  "clap_complete",
+ "globset",
  "include_dir",
  "libc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.100"
 axum = "0.8.9"
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.5"
+globset = "0.4.15"
 include_dir = "0.7.4"
 regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -130,6 +130,35 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan
+- **id**: FEAT-TASK-005
+  - **title**: Goal Plan conformance checking
+  - **summary**: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-032
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - run_task_command
+          - run_task_check_command
+          - GoalPlanArtifact
+          - load_goal_plan_artifact
+      - **file**: src/cli.rs
+        - **symbols**:
+          - TaskArgs
+          - TaskCheckArgs
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatch
+          - run_dispatch
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task check goal-plan.yaml --range origin/main...HEAD
 
 ## Source YAML
 
@@ -251,4 +280,33 @@ features:
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+  - id: FEAT-TASK-005
+    title: Goal Plan conformance checking
+    summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-032
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_check_command
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskCheckArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task check goal-plan.yaml --range origin/main...HEAD
 ```

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -47,6 +47,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-029
     - REQ-CORE-030
     - REQ-CORE-031
+    - REQ-CORE-032
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -134,6 +135,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-029
     - REQ-CORE-030
     - REQ-CORE-031
+    - REQ-CORE-032
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.
@@ -241,6 +243,7 @@ policies:
       - REQ-CORE-029
       - REQ-CORE-030
       - REQ-CORE-031
+      - REQ-CORE-032
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -328,6 +331,7 @@ policies:
       - REQ-CORE-029
       - REQ-CORE-030
       - REQ-CORE-031
+      - REQ-CORE-032
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -639,6 +639,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - dispatch
           - run_dispatch
           - dispatches_task_subcommands_without_rewriting_them
+          - dispatches_task_check_subcommands_without_rewriting_them
       - **file**: tests/task_command.rs
         - **symbols**:
           - task_scaffold_prints_text_preview_for_new_planned_updates
@@ -685,6 +686,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - dispatch
           - run_dispatch
           - dispatches_task_subcommands_without_rewriting_them
+          - dispatches_task_check_subcommands_without_rewriting_them
       - **file**: tests/task_command.rs
         - **symbols**:
           - task_scope_prints_text_output_with_candidate_requirements_and_flags
@@ -781,6 +783,69 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan
+- **id**: REQ-CORE-032
+  - **title**: Validate temporary Goal Plans against the current spec graph and git range
+  - **description**:
+    - |
+      The CLI MUST provide a `task check` command that validates a temporary
+      Goal Plan against the changed files, linked spec IDs, required tests, and
+      completion commands before review or merge. The command SHOULD report the
+      validation status in text or JSON, SHOULD reject required test references
+      that point outside the workspace, and SHOULD reject required test symbols
+      that are empty or only appear in comments or string literals. Goal Plan
+      checks MUST keep their validation requirements separate from the generated
+      Goal Plan artifact so the plan can be authored before the conformance check
+      runs.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-004
+  - **linked_features**:
+    - FEAT-TASK-005
+  - **tests**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - GoalPlanArtifact
+          - load_goal_plan_artifact
+          - run_task_check_command
+          - check_goal_plan
+          - validate_goal_plan_spec_ids
+          - validate_goal_plan_required_tests
+          - validate_goal_plan_test_reference
+          - resolve_goal_plan_test_path
+          - goal_plan_required_test_symbol_exists
+      - **file**: src/cli.rs
+        - **symbols**:
+          - TaskArgs
+          - TaskCheckArgs
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatch
+          - run_dispatch
+          - dispatches_task_subcommands_without_rewriting_them
+      - **file**: tests/task_command.rs
+        - **symbols**:
+          - task_check_reports_pass_fail_results_for_goal_plans
+          - task_check_prints_json_output_for_goal_plans
+          - task_check_fails_for_out_of_scope_changed_files
+          - task_check_reports_unknown_linked_requirement_and_feature_ids
+          - task_check_reports_missing_required_test_files
+          - task_check_reports_missing_required_test_symbols
+          - task_check_rejects_empty_required_test_symbols
+          - task_check_rejects_absolute_required_test_files_outside_workspace
+          - task_check_rejects_malformed_goal_plans
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - task_check_help_mentions_goal_plans_and_json_output
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task check goal-plan.yaml --range origin/main...HEAD
 
 ## Source YAML
 
@@ -1395,6 +1460,7 @@ requirements:
             - dispatch
             - run_dispatch
             - dispatches_task_subcommands_without_rewriting_them
+            - dispatches_task_check_subcommands_without_rewriting_them
         - file: tests/task_command.rs
           symbols:
             - task_scaffold_prints_text_preview_for_new_planned_updates
@@ -1440,6 +1506,7 @@ requirements:
             - dispatch
             - run_dispatch
             - dispatches_task_subcommands_without_rewriting_them
+            - dispatches_task_check_subcommands_without_rewriting_them
         - file: tests/task_command.rs
           symbols:
             - task_scope_prints_text_output_with_candidate_requirements_and_flags
@@ -1535,4 +1602,66 @@ requirements:
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+  - id: REQ-CORE-032
+    title: Validate temporary Goal Plans against the current spec graph and git range
+    description: |
+      The CLI MUST provide a `task check` command that validates a temporary
+      Goal Plan against the changed files, linked spec IDs, required tests, and
+      completion commands before review or merge. The command SHOULD report the
+      validation status in text or JSON, SHOULD reject required test references
+      that point outside the workspace, and SHOULD reject required test symbols
+      that are empty or only appear in comments or string literals. Goal Plan
+      checks MUST keep their validation requirements separate from the generated
+      Goal Plan artifact so the plan can be authored before the conformance check
+      runs.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-004
+    linked_features:
+      - FEAT-TASK-005
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+            - run_task_check_command
+            - check_goal_plan
+            - validate_goal_plan_spec_ids
+            - validate_goal_plan_required_tests
+            - validate_goal_plan_test_reference
+            - resolve_goal_plan_test_path
+            - goal_plan_required_test_symbol_exists
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskCheckArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: tests/task_command.rs
+          symbols:
+            - task_check_reports_pass_fail_results_for_goal_plans
+            - task_check_prints_json_output_for_goal_plans
+            - task_check_fails_for_out_of_scope_changed_files
+            - task_check_reports_unknown_linked_requirement_and_feature_ids
+            - task_check_reports_missing_required_test_files
+            - task_check_reports_missing_required_test_symbols
+            - task_check_rejects_empty_required_test_symbols
+            - task_check_rejects_absolute_required_test_files_outside_workspace
+            - task_check_rejects_malformed_goal_plans
+        - file: tests/help_command.rs
+          symbols:
+            - task_check_help_mentions_goal_plans_and_json_output
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task check goal-plan.yaml --range origin/main...HEAD
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 8
-- Requirements: 31
-- Features: 39
+- Requirements: 32
+- Features: 40
 
 ## Traceability
 
-- Requirement-to-test traceability: 150/150
-- Feature-to-implementation traceability: 159/159
+- Requirement-to-test traceability: 157/157
+- Feature-to-implementation traceability: 164/164
 
 ## Issues
 

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -29,6 +29,7 @@ If a pull request already exists, pair this page with the
 | Strictly review a PR range | `syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json` | fail the range review on unowned, ambiguously owned, or out-of-scope changes while keeping structured findings for CI |
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
 | Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
+| Check a temporary goal plan | `syu task check goal-plan.yaml --range origin/main...HEAD` | validate a temporary Goal Plan against the changed files, linked spec IDs, required tests, and completion commands before review |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |
 | Search by keyword or ID | `syu search validation --kind feature` | find the right spec item before `show`, `relate`, or `log` |

--- a/docs/guide/goal-plan-format.md
+++ b/docs/guide/goal-plan-format.md
@@ -62,7 +62,9 @@ test_plan:
   selection_mode: affected
   required_tests:
     rust:
-      - tests/task_command.rs
+      - file: tests/task_command.rs
+        symbols:
+          - task_plan_generates_goal_from_request
   suggested_tests: {}
 
 coverage:
@@ -92,7 +94,8 @@ completion:
 - **implementation_plan**: lists the bounded file or symbol scope and the steps
   to complete the work.
 - **test_plan**: records the test selection mode plus required and suggested
-  checks.
+  checks, including file and symbol references when a plan needs explicit test
+  coverage.
 - **coverage**: states the coverage expectation for the changed surface.
 - **completion**: lists the checks that must pass before the work is complete.
 

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -97,3 +97,32 @@ features:
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+  - id: FEAT-TASK-005
+    title: Goal Plan conformance checking
+    summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-031
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_check_command
+            - GoalPlanArtifact
+            - load_goal_plan_artifact
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskCheckArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task check goal-plan.yaml --range origin/main...HEAD

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -693,21 +693,31 @@ requirements:
       - POL-004
     linked_features:
       - FEAT-TASK-004
+      - FEAT-TASK-005
     tests:
       rust:
         - file: src/command/task.rs
           symbols:
             - GoalPlanArtifact
             - load_goal_plan_artifact
+            - run_task_check_command
         - file: tests/task_command.rs
           symbols:
             - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
             - goal_plan_artifact_requires_the_goal_plan_marker
             - goal_plan_format_is_documented_as_temporary
+            - task_check_reports_pass_fail_results_for_goal_plans
+            - task_check_prints_json_output_for_goal_plans
+            - task_check_fails_for_out_of_scope_changed_files
+            - task_check_reports_unknown_linked_requirement_and_feature_ids
+            - task_check_reports_missing_required_test_files
+            - task_check_reports_missing_required_test_symbols
+            - task_check_rejects_malformed_goal_plans
         - file: tests/help_command.rs
           symbols:
             - task_scaffold_help_mentions_goal_plans_and_json_output
             - workspace_help_mentions_goal_plan_artifacts
+            - task_check_help_mentions_goal_plans_and_json_output
       markdown:
         - file: docs/guide/goal-plan-format.md
           symbols:

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -712,6 +712,8 @@ requirements:
             - task_check_reports_unknown_linked_requirement_and_feature_ids
             - task_check_reports_missing_required_test_files
             - task_check_reports_missing_required_test_symbols
+            - task_check_rejects_empty_required_test_symbols
+            - task_check_rejects_absolute_required_test_files_outside_workspace
             - task_check_rejects_malformed_goal_plans
         - file: tests/help_command.rs
           symbols:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1036,8 +1036,7 @@ mod tests {
     use super::{
         Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskCheckArgs,
         TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskPlanFormat, TaskScaffoldArgs,
-        TaskScopeArgs, ValidationGenreFilter,
-        ValidationSeverityFilter,
+        TaskScopeArgs, ValidationGenreFilter, ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1035,8 +1035,8 @@ impl ValidationGenreFilter {
 mod tests {
     use super::{
         Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskCheckArgs,
-        TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskPlanFormat, TaskScaffoldArgs,
-        TaskScopeArgs, ValidationGenreFilter, ValidationSeverityFilter,
+        TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskScaffoldArgs, TaskScopeArgs,
+        ValidationGenreFilter, ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,11 @@
 // FEAT-INIT-002
 // FEAT-DOCTOR-001
 // FEAT-TASK-003
+// FEAT-TASK-004
+// FEAT-TASK-005
 // REQ-CORE-001
 // REQ-CORE-030
+// REQ-CORE-031
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
 use clap_complete::Shell;
@@ -38,7 +41,8 @@ New here?
   6. syu app .       start the local browser UI server
   7. syu task classify request.yaml  classify a request artifact against the current spec graph
   8. syu task scope request.yaml      map a request artifact onto the current spec graph
-  9. syu task scaffold request.yaml   preview planned requirement, feature, and goal plan updates from a request artifact";
+  9. syu task scaffold request.yaml   preview planned requirement, feature, and goal plan updates from a request artifact
+ 10. syu task check goal-plan.yaml    validate a Goal Plan against a git range and the current spec graph";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -102,6 +106,13 @@ Examples:
   syu task scaffold request.yaml --format json
 
 Use this after `syu task scope` and `syu task classify` when you want reviewable planned requirement, feature, and temporary Goal Plan updates that stay aligned with the existing `syu add` document and registry conventions.";
+
+const TASK_CHECK_AFTER_HELP: &str = "\
+Examples:
+  syu task check .syu/tasks/current.yaml --range origin/main...HEAD
+  syu task check target/syu/inferred-goal.yaml --range origin/main...HEAD --format json
+
+Use this when you already have a Goal Plan artifact and want a static conformance check against the changed files, linked spec IDs, required tests, and completion commands before review or merge.";
 
 const WORKSPACE_HELP: &str = "Workspace root or any child directory; syu walks upward to find syu.yaml and the configured spec tree";
 
@@ -299,7 +310,7 @@ pub enum Commands {
     )]
     Completion(CompletionArgs),
     #[command(
-        about = "Classify, scope, or scaffold request-driven task planning work",
+        about = "Classify, scope, scaffold, or check request-driven task planning work",
         after_help = TASK_CLASSIFY_AFTER_HELP
     )]
     Task(TaskArgs),
@@ -797,6 +808,11 @@ pub enum TaskCommands {
         after_help = TASK_SCAFFOLD_AFTER_HELP
     )]
     Scaffold(TaskScaffoldArgs),
+    #[command(
+        about = "Validate a Goal Plan against the current spec graph and a git range",
+        after_help = TASK_CHECK_AFTER_HELP
+    )]
+    Check(TaskCheckArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -837,6 +853,24 @@ pub struct TaskScaffoldArgs {
     pub workspace: PathBuf,
 
     #[arg(help = "Output format for the scaffold preview")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskCheckArgs {
+    #[arg(help = "Goal Plan artifact to validate")]
+    pub plan: PathBuf,
+
+    #[arg(help = "Git revision range to compare against the plan scope")]
+    #[arg(long)]
+    pub range: String,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Output format for the Goal Plan check")]
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
 }
@@ -952,8 +986,9 @@ impl ValidationGenreFilter {
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskClassifyArgs, TaskCommands,
-        TaskScaffoldArgs, TaskScopeArgs, ValidationGenreFilter, ValidationSeverityFilter,
+        Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskCheckArgs,
+        TaskClassifyArgs, TaskCommands, TaskScaffoldArgs, TaskScopeArgs, ValidationGenreFilter,
+        ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;
@@ -1101,6 +1136,37 @@ mod tests {
                     format,
                 }),
             })) if request == std::path::Path::new("request.yaml")
+                && workspace == std::path::Path::new(".")
+                && format == super::OutputFormat::Json
+        ));
+    }
+
+    #[test]
+    fn task_check_args_parse_plan_paths_range_and_json_format() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+            ".",
+            "--format",
+            "json",
+        ])
+        .expect("task check args should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(super::Commands::Task(TaskArgs {
+                command: TaskCommands::Check(TaskCheckArgs {
+                    plan,
+                    range,
+                    workspace,
+                    format,
+                }),
+            })) if plan == std::path::Path::new("goal-plan.yaml")
+                && range == "origin/main...HEAD"
                 && workspace == std::path::Path::new(".")
                 && format == super::OutputFormat::Json
         ));

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1257,21 +1257,20 @@ fn check_goal_plan(
         }
     }
 
-    if let Some(source_range) = artifact.source.range.as_deref() {
-        if matches!(artifact.source.mode, GoalPlanSourceMode::DiffInferred)
-            && source_range.trim() != range
-        {
-            issues.push(Issue::warning(
-                "GOAL-TASK-PLAN-011",
-                "source.range",
-                None,
-                "plan source range does not match the requested git range",
-                Some(
-                    "Rebuild or update the Goal Plan so its recorded range matches the check input."
-                        .to_string(),
-                ),
-            ));
-        }
+    if let Some(source_range) = artifact.source.range.as_deref()
+        && matches!(artifact.source.mode, GoalPlanSourceMode::DiffInferred)
+        && source_range.trim() != range
+    {
+        issues.push(Issue::warning(
+            "GOAL-TASK-PLAN-011",
+            "source.range",
+            None,
+            "plan source range does not match the requested git range",
+            Some(
+                "Rebuild or update the Goal Plan so its recorded range matches the check input."
+                    .to_string(),
+            ),
+        ));
     }
 
     let include_matcher = build_globset(&artifact.implementation_plan.scope.include)?;

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -2234,7 +2234,7 @@ mod tests {
         );
         assert_eq!(
             super::next_available_scaffold_id(&lookup, crate::cli::LookupKind::Feature, "task"),
-            "FEAT-TASK-004"
+            "FEAT-TASK-005"
         );
         assert_eq!(
             super::next_available_scaffold_id(

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1,8 +1,11 @@
 // FEAT-TASK-001
 // FEAT-TASK-003
+// FEAT-TASK-004
+// FEAT-TASK-005
 // REQ-CORE-028
 // REQ-CORE-029
 // REQ-CORE-030
+// REQ-CORE-031
 
 use std::{
     collections::BTreeMap,
@@ -11,22 +14,24 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     cli::{
-        LookupKind, OutputFormat, TaskArgs, TaskClassifyArgs, TaskCommands, TaskScaffoldArgs,
-        TaskScopeArgs,
+        LookupKind, OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands,
+        TaskScaffoldArgs, TaskScopeArgs,
     },
+    model::{Issue, Severity},
     workspace::load_workspace,
 };
 
+use super::issue_text::{TextIssueFormat, format_text_issue};
+use super::log::resolve_git_range_changed_files;
 use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
 
 const REQUEST_ARTIFACT_VERSION: u32 = 1;
-#[cfg(test)]
-#[allow(dead_code)]
 const GOAL_PLAN_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -55,9 +60,9 @@ struct RequestArtifact {
     context: RequestArtifactContext,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanArtifact {
     version: u32,
     kind: String,
@@ -72,9 +77,9 @@ struct GoalPlanArtifact {
     completion: GoalPlanCompletion,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanSource {
     mode: GoalPlanSourceMode,
     #[serde(default)]
@@ -85,8 +90,6 @@ struct GoalPlanSource {
     confidence: Option<GoalPlanConfidence>,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 impl Default for GoalPlanSource {
     fn default() -> Self {
         Self {
@@ -98,8 +101,6 @@ impl Default for GoalPlanSource {
     }
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanSourceMode {
@@ -110,8 +111,6 @@ enum GoalPlanSourceMode {
     DiffInferred,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanConfidence {
@@ -120,9 +119,9 @@ enum GoalPlanConfidence {
     Low,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanGoal {
     id: String,
     title: String,
@@ -131,9 +130,9 @@ struct GoalPlanGoal {
     non_goals: Vec<String>,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanSpecMapping {
     #[serde(default)]
     persistent_items: GoalPlanPersistentItems,
@@ -141,9 +140,8 @@ struct GoalPlanSpecMapping {
     spec_updates: GoalPlanSpecUpdates,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanPersistentItems {
     #[serde(default)]
     philosophies: Vec<String>,
@@ -155,9 +153,9 @@ struct GoalPlanPersistentItems {
     features: Vec<String>,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanSpecUpdates {
     #[serde(default)]
     required: bool,
@@ -165,18 +163,18 @@ struct GoalPlanSpecUpdates {
     expected_updates: Vec<String>,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanImplementationPlan {
     scope: GoalPlanScope,
     #[serde(default)]
     steps: Vec<String>,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanScope {
     #[serde(default)]
     include: Vec<String>,
@@ -184,19 +182,17 @@ struct GoalPlanScope {
     exclude: Vec<String>,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanTestPlan {
     selection_mode: GoalPlanSelectionMode,
     #[serde(default)]
-    required_tests: BTreeMap<String, Vec<String>>,
+    required_tests: BTreeMap<String, Vec<crate::model::TraceReference>>,
     #[serde(default)]
-    suggested_tests: BTreeMap<String, Vec<String>>,
+    suggested_tests: BTreeMap<String, Vec<crate::model::TraceReference>>,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanSelectionMode {
@@ -209,9 +205,9 @@ enum GoalPlanSelectionMode {
     Full,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanCoverage {
     mode: GoalPlanCoverageMode,
     threshold: u32,
@@ -221,8 +217,6 @@ struct GoalPlanCoverage {
     exclude: Vec<String>,
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 enum GoalPlanCoverageMode {
@@ -235,9 +229,9 @@ enum GoalPlanCoverageMode {
     Full,
 }
 
-#[cfg(test)]
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct GoalPlanCompletion {
     #[serde(default)]
     must_pass: Vec<String>,
@@ -289,6 +283,18 @@ struct JsonTaskScaffoldOutput {
 }
 
 #[derive(Debug, Serialize)]
+struct JsonTaskCheckOutput {
+    plan_path: String,
+    range: String,
+    passed: bool,
+    changed_files: Vec<String>,
+    issue_count: usize,
+    warning_count: usize,
+    error_count: usize,
+    issues: Vec<Issue>,
+}
+
+#[derive(Debug, Serialize)]
 struct JsonScaffoldUpdate {
     kind: String,
     action: String,
@@ -311,6 +317,36 @@ struct JsonScopeSignals {
     policy_discussion: bool,
     philosophy_discussion: bool,
     planned_feature_updates: bool,
+}
+
+#[derive(Debug)]
+struct GoalPlanCheckReport {
+    plan_path: String,
+    range: String,
+    changed_files: Vec<String>,
+    issues: Vec<Issue>,
+}
+
+impl GoalPlanCheckReport {
+    fn passed(&self) -> bool {
+        self.issues
+            .iter()
+            .all(|issue| issue.severity != Severity::Error)
+    }
+
+    fn warning_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Warning)
+            .count()
+    }
+
+    fn error_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Error)
+            .count()
+    }
 }
 
 #[derive(Debug)]
@@ -403,6 +439,7 @@ pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
         TaskCommands::Classify(classify) => run_task_classify_command(classify),
         TaskCommands::Scope(scope) => run_task_scope_command(scope),
         TaskCommands::Scaffold(scaffold) => run_task_scaffold_command(scaffold),
+        TaskCommands::Check(check) => run_task_check_command(check),
     }
 }
 
@@ -522,6 +559,38 @@ pub fn run_task_scaffold_command(args: &TaskScaffoldArgs) -> Result<i32> {
     Ok(0)
 }
 
+pub fn run_task_check_command(args: &TaskCheckArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let range = args.range.trim();
+    if range.is_empty() {
+        bail!("--range must not be empty");
+    }
+
+    let artifact = load_goal_plan_artifact(&args.plan)?;
+    let mut report = check_goal_plan(&workspace, &artifact, range)?;
+    report.plan_path = args.plan.display().to_string();
+
+    match args.format {
+        OutputFormat::Text => print_task_check_text_output(&args.plan, &report),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&JsonTaskCheckOutput {
+                plan_path: report.plan_path.clone(),
+                range: range.to_string(),
+                passed: report.passed(),
+                changed_files: report.changed_files.clone(),
+                issue_count: report.issues.len(),
+                warning_count: report.warning_count(),
+                error_count: report.error_count(),
+                issues: report.issues.clone(),
+            })
+            .expect("serializing task check output to JSON should succeed")
+        ),
+    }
+
+    Ok(if report.passed() { 0 } else { 1 })
+}
+
 fn load_request_artifact(path: &PathBuf) -> Result<RequestArtifact> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read request artifact `{}`", path.display()))?;
@@ -537,8 +606,6 @@ fn load_request_artifact(path: &PathBuf) -> Result<RequestArtifact> {
     Ok(artifact)
 }
 
-#[cfg(test)]
-#[allow(dead_code)]
 fn load_goal_plan_artifact(path: &PathBuf) -> Result<GoalPlanArtifact> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read goal plan artifact `{}`", path.display()))?;
@@ -1059,6 +1126,357 @@ fn print_scaffold_text_output(
     }
 }
 
+fn print_task_check_text_output(plan_path: &Path, report: &GoalPlanCheckReport) {
+    println!("goal plan: {}", plan_path.display());
+    println!("git range: {}", report.range);
+    println!("status: {}", if report.passed() { "passed" } else { "failed" });
+    println!();
+    println!("changed files:");
+    if report.changed_files.is_empty() {
+        println!("- none");
+    } else {
+        for file in &report.changed_files {
+            println!("- {file}");
+        }
+    }
+    println!();
+    if report.issues.is_empty() {
+        println!("findings: none");
+        return;
+    }
+
+    println!("findings:");
+    for issue in &report.issues {
+        for line in format_text_issue(issue, TextIssueFormat::Validate) {
+            println!("{line}");
+        }
+    }
+}
+
+fn check_goal_plan(
+    workspace: &crate::workspace::Workspace,
+    artifact: &GoalPlanArtifact,
+    range: &str,
+) -> Result<GoalPlanCheckReport> {
+    let lookup = WorkspaceLookup::new(workspace);
+    let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
+    let changed_file_strings = changed_files
+        .iter()
+        .map(|path| path_label(path))
+        .collect::<Vec<_>>();
+    let mut issues = Vec::new();
+
+    if artifact.implementation_plan.scope.include.is_empty() {
+        issues.push(Issue::error(
+            "GOAL-TASK-PLAN-004",
+            "implementation_plan.scope.include",
+            None,
+            "implementation scope does not declare any include patterns",
+            Some(
+                "Add the files or directories that this Goal Plan is allowed to change so range checks can evaluate scope accurately."
+                    .to_string(),
+            ),
+        ));
+    }
+
+    if artifact.implementation_plan.steps.is_empty() {
+        issues.push(Issue::warning(
+            "GOAL-TASK-PLAN-005",
+            "implementation_plan.steps",
+            None,
+            "implementation plan does not list any steps",
+            Some(
+                "List the bounded steps reviewers should expect before the implementation is complete."
+                    .to_string(),
+            ),
+        ));
+    }
+
+    if artifact.test_plan.required_tests.is_empty() {
+        issues.push(Issue::warning(
+            "GOAL-TASK-PLAN-006",
+            "test_plan.required_tests",
+            None,
+            "required tests are not declared",
+            Some(
+                "Add the repository tests that must be present before the plan can be considered complete."
+                    .to_string(),
+            ),
+        ));
+    }
+
+    if artifact.completion.must_pass.is_empty() {
+        issues.push(Issue::error(
+            "GOAL-TASK-PLAN-007",
+            "completion.must_pass",
+            None,
+            "required completion commands are not declared",
+            Some(
+                "List the commands reviewers or automation should require before accepting the plan."
+                    .to_string(),
+            ),
+        ));
+    }
+
+    if matches!(artifact.source.mode, GoalPlanSourceMode::DiffInferred) {
+        match artifact.source.confidence {
+            Some(GoalPlanConfidence::High) => {}
+            Some(GoalPlanConfidence::Medium) => issues.push(Issue::warning(
+                "GOAL-TASK-PLAN-008",
+                "source.confidence",
+                None,
+                "diff-inferred plan source confidence is medium",
+                Some(
+                    "Treat medium confidence as a review signal and make the risky sections explicit."
+                        .to_string(),
+                ),
+            )),
+            Some(GoalPlanConfidence::Low) => issues.push(Issue::warning(
+                "GOAL-TASK-PLAN-009",
+                "source.confidence",
+                None,
+                "diff-inferred plan source confidence is low",
+                Some(
+                    "Revisit the inferred plan before review because the source confidence is low."
+                        .to_string(),
+                ),
+            )),
+            None => issues.push(Issue::warning(
+                "GOAL-TASK-PLAN-010",
+                "source.confidence",
+                None,
+                "diff-inferred plan source does not declare confidence",
+                Some(
+                    "Add source.confidence so reviewers know how reliable the inferred plan is."
+                        .to_string(),
+                ),
+            )),
+        }
+    }
+
+    if let Some(source_range) = artifact.source.range.as_deref() {
+        if matches!(artifact.source.mode, GoalPlanSourceMode::DiffInferred)
+            && source_range.trim() != range
+        {
+            issues.push(Issue::warning(
+                "GOAL-TASK-PLAN-011",
+                "source.range",
+                None,
+                "plan source range does not match the requested git range",
+                Some(
+                    "Rebuild or update the Goal Plan so its recorded range matches the check input."
+                        .to_string(),
+                ),
+            ));
+        }
+    }
+
+    let include_matcher = build_globset(&artifact.implementation_plan.scope.include)?;
+    let exclude_matcher = build_globset(&artifact.implementation_plan.scope.exclude)?;
+    if !artifact.implementation_plan.scope.include.is_empty() {
+        for file in &changed_files {
+            if !path_matches_scope(file, include_matcher.as_ref(), exclude_matcher.as_ref()) {
+                let file_string = path_label(file);
+                let production_path = is_production_path(file);
+                let issue = if production_path {
+                    Issue::error(
+                        "GOAL-TASK-PLAN-001",
+                        "implementation_plan.scope",
+                        Some(file_string.clone()),
+                        "changed production file is outside the implementation scope",
+                        Some(
+                            "Update implementation_plan.scope.include/exclude or move the change into the listed scope."
+                                .to_string(),
+                        ),
+                    )
+                } else {
+                    Issue::warning(
+                        "GOAL-TASK-PLAN-001",
+                        "implementation_plan.scope",
+                        Some(file_string),
+                        "changed file is outside the implementation scope",
+                        Some(
+                            "Confirm whether the file should be included in the plan or excluded from the change set."
+                                .to_string(),
+                        ),
+                    )
+                };
+                issues.push(issue);
+            }
+        }
+    }
+
+    validate_goal_plan_spec_ids(&lookup, artifact, &mut issues);
+    validate_goal_plan_required_tests(workspace, artifact, &mut issues)?;
+
+    Ok(GoalPlanCheckReport {
+        plan_path: String::new(),
+        range: range.to_string(),
+        changed_files: changed_file_strings,
+        issues,
+    })
+}
+
+fn validate_goal_plan_spec_ids(
+    lookup: &WorkspaceLookup<'_>,
+    artifact: &GoalPlanArtifact,
+    issues: &mut Vec<Issue>,
+) {
+    for id in artifact
+        .spec_mapping
+        .persistent_items
+        .philosophies
+        .iter()
+        .chain(artifact.spec_mapping.persistent_items.policies.iter())
+        .chain(artifact.spec_mapping.persistent_items.requirements.iter())
+        .chain(artifact.spec_mapping.persistent_items.features.iter())
+    {
+        if lookup.find(id).is_none() {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-002",
+                "spec_mapping.persistent_items",
+                Some(id.clone()),
+                "linked persistent spec ID does not exist",
+                Some(
+                    "Fix the Goal Plan or add the missing spec item before the plan is reviewed."
+                        .to_string(),
+                ),
+            ));
+        }
+    }
+}
+
+fn validate_goal_plan_required_tests(
+    workspace: &crate::workspace::Workspace,
+    artifact: &GoalPlanArtifact,
+    issues: &mut Vec<Issue>,
+) -> Result<()> {
+    for (language, references) in &artifact.test_plan.required_tests {
+        for reference in references {
+            validate_goal_plan_test_reference(workspace, language, reference, issues)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_goal_plan_test_reference(
+    workspace: &crate::workspace::Workspace,
+    language: &str,
+    reference: &crate::model::TraceReference,
+    issues: &mut Vec<Issue>,
+) -> Result<()> {
+    let test_path = if reference.file.is_absolute() {
+        reference.file.clone()
+    } else {
+        workspace.root.join(&reference.file)
+    };
+    let location = reference.file.display().to_string();
+    let contents = match fs::read_to_string(&test_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-003",
+                "test_plan.required_tests",
+                Some(location.clone()),
+                "required test file is missing",
+                Some(
+                    "Create the referenced test file or update the Goal Plan to point at an existing repository test."
+                        .to_string(),
+                ),
+            ));
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to read required test file `{}` for language `{}`",
+                    reference.file.display(),
+                    language
+                )
+            });
+        }
+    };
+
+    for symbol in &reference.symbols {
+        if symbol.trim() == "*" {
+            continue;
+        }
+        if !contents.contains(symbol) {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-003",
+                "test_plan.required_tests",
+                Some(format!("{location}::{symbol}")),
+                "required test symbol is missing",
+                Some(
+                    "Add the named test function, method, or symbol to the referenced test file."
+                        .to_string(),
+                ),
+            ));
+        }
+    }
+
+    for snippet in &reference.doc_contains {
+        if snippet.trim() == "*" {
+            continue;
+        }
+        if !contents.contains(snippet) {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-003",
+                "test_plan.required_tests",
+                Some(format!("{location}::{snippet}")),
+                "required test text is missing",
+                Some(
+                    "Add the expected documentation text to the referenced test file."
+                        .to_string(),
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        builder.add(
+            Glob::new(pattern).with_context(|| format!("invalid scope glob `{pattern}`"))?,
+        );
+    }
+
+    Ok(Some(builder.build().context("failed to build scope glob set")?))
+}
+
+fn path_matches_scope(
+    path: &Path,
+    include: Option<&GlobSet>,
+    exclude: Option<&GlobSet>,
+) -> bool {
+    let included = include.is_none_or(|set| set.is_match(path));
+    let excluded = exclude.is_some_and(|set| set.is_match(path));
+    included && !excluded
+}
+
+fn is_production_path(path: &Path) -> bool {
+    let rendered = path_label(path);
+    rendered.starts_with("src/")
+        || rendered.starts_with("app/")
+        || rendered.starts_with("crates/")
+        || rendered.starts_with("examples/")
+        || rendered.starts_with("website/")
+        || rendered.starts_with("repo/")
+        || rendered.starts_with("scripts/")
+        || matches!(
+            rendered.as_str(),
+            "build.rs" | "Cargo.toml" | "Cargo.lock"
+        )
+}
+
 fn print_items(heading: &str, items: &[SearchResult]) {
     println!("{heading}:");
     if items.is_empty() {
@@ -1480,7 +1898,8 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::cli::{
-        OutputFormat, TaskArgs, TaskClassifyArgs, TaskCommands, TaskScaffoldArgs, TaskScopeArgs,
+        OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands, TaskScaffoldArgs,
+        TaskScopeArgs,
     };
 
     use super::{
@@ -1546,13 +1965,18 @@ mod tests {
         )
         .expect("scope requirement doc");
         fs::write(
+            root.join("docs/syu/requirements/core/check.yaml"),
+            "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-031\n    title: Validate temporary Goal Plans against the current spec graph and git range\n    description: The task check command should validate Goal Plan conformance against changed files, linked spec IDs, required tests, and completion commands.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-004\n    tests:\n      rust:\n        - file: tests/task_command.rs\n          symbols:\n            - task_check_reports_pass_fail_results_for_goal_plans\n",
+        )
+        .expect("check requirement doc");
+        fs::write(
             root.join("docs/syu/features/features.yaml"),
             "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n  - kind: task\n    file: core/scope.yaml\n",
         )
         .expect("feature registry");
         fs::write(
             root.join("docs/syu/features/core/task.yaml"),
-            "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify planned request artifacts into create, change, or delete decisions using the current spec graph and a brief explanation.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskClassifyArgs\n  - id: FEAT-TASK-003\n    title: Request artifact scoping\n    summary: Map request artifacts onto candidate requirements, policies, philosophies, and features before planning begins.\n    status: planned\n    linked_requirements:\n      - REQ-CORE-030\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scope_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskScopeArgs\n",
+            "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify planned request artifacts into create, change, or delete decisions using the current spec graph and a brief explanation.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskClassifyArgs\n  - id: FEAT-TASK-003\n    title: Request artifact scoping\n    summary: Map request artifacts onto candidate requirements, policies, philosophies, and features before planning begins.\n    status: planned\n    linked_requirements:\n      - REQ-CORE-030\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scope_command\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskScopeArgs\n  - id: FEAT-TASK-004\n    title: Goal Plan conformance checking\n    summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-031\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_check_command\n            - load_goal_plan_artifact\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskCheckArgs\n",
         )
         .expect("feature doc");
         fs::write(
@@ -1896,7 +2320,7 @@ mod tests {
     }
 
     #[test]
-    fn run_task_command_dispatches_classify_scope_and_scaffold() {
+    fn run_task_command_dispatches_classify_scope_scaffold_and_check() {
         let _ = TaskCommands::Classify(TaskClassifyArgs {
             request: PathBuf::from("request.yaml"),
             workspace: PathBuf::from("."),
@@ -1909,6 +2333,12 @@ mod tests {
         });
         let _ = TaskCommands::Scaffold(TaskScaffoldArgs {
             request: PathBuf::from("request.yaml"),
+            workspace: PathBuf::from("."),
+            format: OutputFormat::Text,
+        });
+        let _ = TaskCommands::Check(TaskCheckArgs {
+            plan: PathBuf::from("goal-plan.yaml"),
+            range: "origin/main...HEAD".to_string(),
             workspace: PathBuf::from("."),
             format: OutputFormat::Text,
         });
@@ -1927,7 +2357,7 @@ mod tests {
         let path = tempdir.path().join("goal-plan.yaml");
         fs::write(
             &path,
-            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\n  request_artifact: request.yaml\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - tests/task_command.rs\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\n  request_artifact: request.yaml\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: tests/task_command.rs\n        symbols:\n          - task_plan_generates_goal_from_request\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
         )
         .expect("goal plan");
 
@@ -1947,7 +2377,7 @@ mod tests {
 
         fs::write(
             &path,
-            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: high\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - tests/task_command.rs\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: high\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-030\n    features:\n      - FEAT-TASK-003\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\n    - document the temporary artifact locations\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: tests/task_command.rs\n        symbols:\n          - task_plan_generates_goal_from_request\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
         )
         .expect("goal plan");
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1129,7 +1129,10 @@ fn print_scaffold_text_output(
 fn print_task_check_text_output(plan_path: &Path, report: &GoalPlanCheckReport) {
     println!("goal plan: {}", plan_path.display());
     println!("git range: {}", report.range);
-    println!("status: {}", if report.passed() { "passed" } else { "failed" });
+    println!(
+        "status: {}",
+        if report.passed() { "passed" } else { "failed" }
+    );
     println!();
     println!("changed files:");
     if report.changed_files.is_empty() {
@@ -1427,8 +1430,7 @@ fn validate_goal_plan_test_reference(
                 Some(format!("{location}::{snippet}")),
                 "required test text is missing",
                 Some(
-                    "Add the expected documentation text to the referenced test file."
-                        .to_string(),
+                    "Add the expected documentation text to the referenced test file.".to_string(),
                 ),
             ));
         }
@@ -1444,19 +1446,15 @@ fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>> {
 
     let mut builder = GlobSetBuilder::new();
     for pattern in patterns {
-        builder.add(
-            Glob::new(pattern).with_context(|| format!("invalid scope glob `{pattern}`"))?,
-        );
+        builder.add(Glob::new(pattern).with_context(|| format!("invalid scope glob `{pattern}`"))?);
     }
 
-    Ok(Some(builder.build().context("failed to build scope glob set")?))
+    Ok(Some(
+        builder.build().context("failed to build scope glob set")?,
+    ))
 }
 
-fn path_matches_scope(
-    path: &Path,
-    include: Option<&GlobSet>,
-    exclude: Option<&GlobSet>,
-) -> bool {
+fn path_matches_scope(path: &Path, include: Option<&GlobSet>, exclude: Option<&GlobSet>) -> bool {
     let included = include.is_none_or(|set| set.is_match(path));
     let excluded = exclude.is_some_and(|set| set.is_match(path));
     included && !excluded
@@ -1471,10 +1469,7 @@ fn is_production_path(path: &Path) -> bool {
         || rendered.starts_with("website/")
         || rendered.starts_with("repo/")
         || rendered.starts_with("scripts/")
-        || matches!(
-            rendered.as_str(),
-            "build.rs" | "Cargo.toml" | "Cargo.lock"
-        )
+        || matches!(rendered.as_str(), "build.rs" | "Cargo.toml" | "Cargo.lock")
 }
 
 fn print_items(heading: &str, items: &[SearchResult]) {

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1491,9 +1491,7 @@ fn resolve_goal_plan_test_path(
             "test_plan.required_tests",
             Some(reference_file.display().to_string()),
             "required test file must stay within the workspace",
-            Some(
-                "Point required tests at a repository file under the workspace root.".to_string(),
-            ),
+            Some("Point required tests at a repository file under the workspace root.".to_string()),
         ));
         return Ok(None);
     }

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -3016,7 +3016,7 @@ mod tests {
         );
         assert_eq!(
             super::next_available_scaffold_id(&lookup, crate::cli::LookupKind::Feature, "task"),
-            "FEAT-TASK-005"
+            "FEAT-TASK-006"
         );
         assert_eq!(
             super::next_available_scaffold_id(

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -23,6 +23,7 @@ use crate::{
         LookupKind, OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands,
         TaskScaffoldArgs, TaskScopeArgs,
     },
+    language::adapter_for_language,
     model::{Issue, Severity},
     workspace::load_workspace,
 };
@@ -1368,12 +1369,11 @@ fn validate_goal_plan_test_reference(
     reference: &crate::model::TraceReference,
     issues: &mut Vec<Issue>,
 ) -> Result<()> {
-    let test_path = if reference.file.is_absolute() {
-        reference.file.clone()
-    } else {
-        workspace.root.join(&reference.file)
-    };
     let location = reference.file.display().to_string();
+    let test_path = match resolve_goal_plan_test_path(workspace, &reference.file, issues)? {
+        Some(path) => path,
+        None => return Ok(()),
+    };
     let contents = match fs::read_to_string(&test_path) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -1401,10 +1401,21 @@ fn validate_goal_plan_test_reference(
     };
 
     for symbol in &reference.symbols {
-        if symbol.trim() == "*" {
+        let symbol = symbol.trim();
+        if symbol == "*" {
             continue;
         }
-        if !contents.contains(symbol) {
+        if symbol.is_empty() {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-003",
+                "test_plan.required_tests",
+                Some(location.clone()),
+                "required test symbol is empty",
+                Some("Specify a test function, method, or symbol name.".to_string()),
+            ));
+            continue;
+        }
+        if !goal_plan_required_test_symbol_exists(language, &contents, symbol) {
             issues.push(Issue::error(
                 "GOAL-TASK-PLAN-003",
                 "test_plan.required_tests",
@@ -1436,6 +1447,73 @@ fn validate_goal_plan_test_reference(
     }
 
     Ok(())
+}
+
+fn resolve_goal_plan_test_path(
+    workspace: &crate::workspace::Workspace,
+    reference_file: &Path,
+    issues: &mut Vec<Issue>,
+) -> Result<Option<PathBuf>> {
+    let candidate = if reference_file.is_absolute() {
+        reference_file.to_path_buf()
+    } else {
+        workspace.root.join(reference_file)
+    };
+
+    let resolved = match fs::canonicalize(&candidate) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            issues.push(Issue::error(
+                "GOAL-TASK-PLAN-003",
+                "test_plan.required_tests",
+                Some(reference_file.display().to_string()),
+                "required test file is missing",
+                Some(
+                    "Create the referenced test file or update the Goal Plan to point at an existing repository test."
+                        .to_string(),
+                ),
+            ));
+            return Ok(None);
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to resolve required test file `{}`",
+                    reference_file.display()
+                )
+            });
+        }
+    };
+
+    if !resolved.starts_with(&workspace.root) {
+        issues.push(Issue::error(
+            "GOAL-TASK-PLAN-003",
+            "test_plan.required_tests",
+            Some(reference_file.display().to_string()),
+            "required test file must stay within the workspace",
+            Some(
+                "Point required tests at a repository file under the workspace root.".to_string(),
+            ),
+        ));
+        return Ok(None);
+    }
+
+    Ok(Some(resolved))
+}
+
+fn goal_plan_required_test_symbol_exists(language: &str, contents: &str, symbol: &str) -> bool {
+    adapter_for_language(language)
+        .map(|adapter| {
+            let mut patterns = adapter.patterns(symbol);
+            if patterns.len() > 1 {
+                patterns.pop();
+            }
+            patterns
+                .into_iter()
+                .filter_map(|pattern| Regex::new(&pattern).ok())
+                .any(|regex| regex.is_match(contents))
+        })
+        .unwrap_or_else(|| contents.contains(symbol))
 }
 
 fn build_globset(patterns: &[String]) -> Result<Option<GlobSet>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,8 @@ mod tests {
     use crate::cli::{
         AddArgs, AppArgs, AuditArgs, Cli, Commands, CompletionArgs, ExplainArgs, HistoryKind,
         ListArgs, LogArgs, LookupKind, OutputFormat, RelateArgs, SearchArgs, ShowArgs, TaskArgs,
-        TaskCheckArgs, TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskPlanFormat,
-        TaskScopeArgs, TemplatesArgs, TraceArgs,
+        TaskCheckArgs, TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskPlanFormat, TaskScopeArgs,
+        TemplatesArgs, TraceArgs,
     };
     use clap_complete::Shell;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,14 @@
 // FEAT-LSP-001
 // FEAT-TASK-001
 // FEAT-TASK-003
+// FEAT-TASK-004
+// FEAT-TASK-005
 // REQ-CORE-021
 // REQ-CORE-023
 // REQ-CORE-024
 // REQ-CORE-028
 // REQ-CORE-030
+// REQ-CORE-031
 
 pub mod cli;
 pub mod command;
@@ -167,7 +170,7 @@ mod tests {
     use crate::cli::{
         AddArgs, AppArgs, AuditArgs, Cli, Commands, CompletionArgs, ExplainArgs, HistoryKind,
         ListArgs, LogArgs, LookupKind, OutputFormat, RelateArgs, SearchArgs, ShowArgs, TaskArgs,
-        TaskClassifyArgs, TaskCommands, TaskScopeArgs, TemplatesArgs, TraceArgs,
+        TaskCheckArgs, TaskClassifyArgs, TaskCommands, TaskScopeArgs, TemplatesArgs, TraceArgs,
     };
     use clap_complete::Shell;
 
@@ -415,6 +418,34 @@ mod tests {
                     format,
                 })
             }) if request == Path::new("request.yaml")
+                && workspace == Path::new("workspace")
+                && format == OutputFormat::Json
+        ));
+        let check = super::dispatch(
+            Cli {
+                command: Some(Commands::Task(TaskArgs {
+                    command: TaskCommands::Check(TaskCheckArgs {
+                        plan: PathBuf::from("goal-plan.yaml"),
+                        range: "origin/main...HEAD".to_string(),
+                        workspace: PathBuf::from("workspace"),
+                        format: OutputFormat::Json,
+                    }),
+                })),
+            },
+            true,
+            true,
+        );
+        assert!(matches!(
+            check,
+            super::Dispatch::Task(crate::cli::TaskArgs {
+                command: TaskCommands::Check(TaskCheckArgs {
+                    plan,
+                    range,
+                    workspace,
+                    format,
+                })
+            }) if plan == Path::new("goal-plan.yaml")
+                && range == "origin/main...HEAD"
                 && workspace == Path::new("workspace")
                 && format == OutputFormat::Json
         ));

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -9,7 +9,7 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::{Mutex, OnceLock},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tempfile::tempdir;
 
@@ -144,15 +144,41 @@ fn app_command_test_lock() -> &'static Mutex<()> {
 fn spawn_fake_dev_server(port: u16, status_line: &'static str) -> std::thread::JoinHandle<()> {
     let listener = TcpListener::bind(("127.0.0.1", port)).expect("fake vite listener should bind");
     thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("fake vite client should connect");
-        let mut request = [0_u8; 512];
-        let _ = stream.read(&mut request);
-        write!(
-            stream,
-            "{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-        )
-        .expect("fake vite response should write");
-        stream.flush().expect("fake vite response should flush");
+        listener
+            .set_nonblocking(true)
+            .expect("fake vite listener should be nonblocking");
+
+        let deadline = Instant::now() + Duration::from_secs(600);
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut request = [0_u8; 512];
+                    let _ = stream.read(&mut request);
+                    let response = write!(
+                        stream,
+                        "{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .and_then(|_| stream.flush());
+
+                    match response {
+                        Ok(()) => return,
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                std::io::ErrorKind::BrokenPipe
+                                    | std::io::ErrorKind::ConnectionReset
+                            ) => {}
+                        Err(error) => panic!("fake vite response should write: {error}"),
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => panic!("fake vite client should connect: {error}"),
+            }
+
+            thread::sleep(Duration::from_millis(50));
+        }
+
+        panic!("fake vite client should connect");
     })
 }
 

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -116,7 +116,10 @@ fn shutdown_child(child: &mut Child) {
     child.kill().expect("child should terminate");
 
     let status = child.wait().expect("child should exit");
-    assert!(clean_shutdown(&status), "app command should exit cleanly");
+    assert!(
+        clean_shutdown(&status),
+        "app command should exit cleanly: {status:?}"
+    );
 }
 
 fn terminate_child(child: &mut Child) {

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -148,7 +148,7 @@ fn spawn_fake_dev_server(port: u16, status_line: &'static str) -> std::thread::J
             .set_nonblocking(true)
             .expect("fake vite listener should be nonblocking");
 
-        let deadline = Instant::now() + Duration::from_secs(600);
+        let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
             match listener.accept() {
                 Ok((mut stream, _)) => {
@@ -177,8 +177,6 @@ fn spawn_fake_dev_server(port: u16, status_line: &'static str) -> std::thread::J
 
             thread::sleep(Duration::from_millis(50));
         }
-
-        panic!("fake vite client should connect");
     })
 }
 

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -33,6 +33,7 @@ fn root_help_includes_start_here_guidance() {
     assert!(stdout.contains("syu app ."));
     assert!(stdout.contains("syu task classify request.yaml"));
     assert!(stdout.contains("syu task scope request.yaml"));
+    assert!(stdout.contains("syu task check goal-plan.yaml"));
     assert!(stdout.contains(
         "Browse the specification in your terminal (interactive prompts or text output)"
     ));
@@ -74,6 +75,7 @@ fn workspace_help_uses_current_directory_default_consistently() {
         &["log"][..],
         &["audit"][..],
         &["explain"][..],
+        &["task", "check"][..],
     ] {
         let output = Command::cargo_bin("syu")
             .expect("binary should build")
@@ -330,6 +332,26 @@ fn task_scaffold_help_mentions_goal_plans_and_json_output() {
     assert!(stdout.contains("--format"));
     assert!(stdout.contains("syu task scaffold request.yaml"));
     assert!(stdout.contains("syu task scaffold request.yaml --format json"));
+}
+
+#[test]
+fn task_check_help_mentions_goal_plans_and_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "check", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task check help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Goal Plan"));
+    assert!(stdout.contains("--range"));
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("syu task check .syu/tasks/current.yaml --range origin/main...HEAD"));
+    assert!(stdout.contains(
+        "syu task check target/syu/inferred-goal.yaml --range origin/main...HEAD --format json"
+    ));
 }
 
 // REQ-CORE-031

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -1,8 +1,9 @@
 // REQ-CORE-028
 // REQ-CORE-029
 // REQ-CORE-030
+// REQ-CORE-031
 
-use std::fs;
+use std::{fs, path::Path, process::Command};
 
 use assert_cmd::cargo::CommandCargoExt;
 use tempfile::tempdir;
@@ -44,13 +45,18 @@ fn write_workspace(root: &std::path::Path) {
     )
     .expect("scope requirement doc");
     fs::write(
+        root.join("docs/syu/requirements/core/check.yaml"),
+        "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-031\n    title: Validate temporary Goal Plans against the current spec graph and git range\n    description: The task check command should validate Goal Plan conformance against changed files, linked spec IDs, required tests, and completion commands.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-004\n    tests:\n      rust:\n        - file: tests/task_command.rs\n          symbols:\n            - task_check_reports_pass_fail_results_for_goal_plans\n",
+    )
+    .expect("check requirement doc");
+    fs::write(
         root.join("docs/syu/features/features.yaml"),
         "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n  - kind: task\n    file: core/scope.yaml\n",
     )
     .expect("feature registry");
     fs::write(
         root.join("docs/syu/features/core/task.yaml"),
-        "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify captured request artifacts into create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n  - id: FEAT-TASK-003\n    title: Request artifact scoping\n    summary: Map request artifacts onto candidate requirements, policies, philosophies, and features before planning begins.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-030\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scope_command\n",
+        "category: Task Planning CLI\nversion: 1\nfeatures:\n  - id: FEAT-TASK-001\n    title: Request artifact classification\n    summary: Classify captured request artifacts into create, change, or delete decisions using the current spec graph, with a short explanation and text or JSON output.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-028\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_classify_command\n  - id: FEAT-TASK-003\n    title: Request artifact scoping\n    summary: Map request artifacts onto candidate requirements, policies, philosophies, and features before planning begins.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-030\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scope_command\n  - id: FEAT-TASK-004\n    title: Goal Plan conformance checking\n    summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-031\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_check_command\n            - load_goal_plan_artifact\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskCheckArgs\n",
     )
     .expect("feature doc");
     fs::write(
@@ -82,6 +88,81 @@ fn write_request(root: &std::path::Path, request: &str, affected_area: &str, lin
         ),
     )
     .expect("request");
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git command should run");
+    assert!(output.status.success(), "git {:?} failed", args);
+    String::from_utf8(output.stdout)
+        .expect("git output should be valid utf-8")
+        .trim()
+        .to_string()
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .status()
+        .expect("git command should run");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn init_git_repo(root: &Path) {
+    git(root, &["init", "-b", "main"]);
+    git(root, &["config", "user.email", "syu@example.com"]);
+    git(root, &["config", "user.name", "syu"]);
+}
+
+fn commit_all(root: &Path, message: &str) {
+    git(root, &["add", "-A"]);
+    git(root, &["commit", "--quiet", "-m", message]);
+}
+
+fn write_goal_plan(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("goal plan");
+}
+
+fn goal_plan_yaml(
+    linked_requirement: &str,
+    linked_feature: &str,
+    test_file: &str,
+    test_symbol: &str,
+    confidence: &str,
+) -> String {
+    format!(
+        "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: {confidence}\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - {linked_requirement}\n    features:\n      - {linked_feature}\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: {test_file}\n        symbols:\n          - {test_symbol}\n  suggested_tests: {{}}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n"
+    )
+}
+
+fn prepare_git_workspace(root: &Path, test_symbol: &str) {
+    write_workspace(root);
+    fs::create_dir_all(root.join("src/command")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+    fs::write(
+        root.join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n",
+    )
+    .expect("task source");
+    fs::write(
+        root.join("src/command/report.rs"),
+        "pub fn run_report_command() {}\n",
+    )
+    .expect("report source");
+    fs::write(
+        root.join("tests/task_command.rs"),
+        format!("fn {test_symbol}() {{}}\n"),
+    )
+    .expect("task tests");
+
+    init_git_repo(root);
+    commit_all(root, "base");
+    let base = git_output(root, &["rev-parse", "HEAD"]);
+    git(root, &["update-ref", "refs/remotes/origin/main", &base]);
 }
 
 #[test]
@@ -407,6 +488,303 @@ fn task_scaffold_rejects_delete_requests() {
     assert!(!output.status.success(), "delete scaffold should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only supports request artifacts"));
+}
+
+#[test]
+fn task_check_reports_pass_fail_results_for_goal_plans() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for goal plan check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            "tests/task_command.rs",
+            "task_plan_generates_goal_from_request",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task check should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("goal plan: goal-plan.yaml"));
+    assert!(stdout.contains("git range: origin/main...HEAD"));
+    assert!(stdout.contains("status: passed"));
+    assert!(stdout.contains("findings: none"));
+}
+
+#[test]
+fn task_check_prints_json_output_for_goal_plans() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for goal plan check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            "tests/task_command.rs",
+            "task_plan_generates_goal_from_request",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+            "--format",
+            "json",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task check should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"plan_path\": \"goal-plan.yaml\""));
+    assert!(stdout.contains("\"range\": \"origin/main...HEAD\""));
+    assert!(stdout.contains("\"passed\": true"));
+    assert!(stdout.contains("\"issue_count\": 0"));
+    assert!(stdout.contains("\"warning_count\": 0"));
+    assert!(stdout.contains("\"error_count\": 0"));
+}
+
+#[test]
+fn task_check_fails_for_out_of_scope_changed_files() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/report.rs"),
+        "pub fn run_report_command() {}\n// changed outside scope\n",
+    )
+    .expect("updated report source");
+    commit_all(tempdir.path(), "update report");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            "tests/task_command.rs",
+            "task_plan_generates_goal_from_request",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("status: failed"));
+    assert!(stdout.contains("changed production file is outside the implementation scope"));
+    assert!(stdout.contains("src/command/report.rs"));
+}
+
+#[test]
+fn task_check_reports_unknown_linked_requirement_and_feature_ids() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for unknown-id check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-MISSING-001",
+            "FEAT-MISSING-001",
+            "tests/task_command.rs",
+            "task_plan_generates_goal_from_request",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("linked persistent spec ID does not exist"));
+    assert!(stdout.contains("REQ-MISSING-001"));
+    assert!(stdout.contains("FEAT-MISSING-001"));
+}
+
+#[test]
+fn task_check_reports_missing_required_test_files() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for missing-file check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            "tests/missing.rs",
+            "missing_test",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("required test file is missing"));
+    assert!(stdout.contains("tests/missing.rs"));
+}
+
+#[test]
+fn task_check_reports_missing_required_test_symbols() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for missing-symbol check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            "tests/task_command.rs",
+            "task_plan_missing_symbol",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("required test symbol is missing"));
+    assert!(stdout.contains("task_plan_missing_symbol"));
+}
+
+#[test]
+fn task_check_rejects_malformed_goal_plans() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n",
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "malformed goal plan should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to parse goal plan artifact"));
 }
 
 #[test]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -815,8 +815,11 @@ fn task_check_rejects_absolute_required_test_files_outside_workspace() {
 
     let external = tempfile::tempdir().expect("external tempdir");
     let external_test = external.path().join("outside.rs");
-    fs::write(&external_test, "fn task_plan_generates_goal_from_request() {}\n")
-        .expect("external test file");
+    fs::write(
+        &external_test,
+        "fn task_plan_generates_goal_from_request() {}\n",
+    )
+    .expect("external test file");
 
     let plan = tempdir.path().join("goal-plan.yaml");
     write_goal_plan(

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -728,6 +728,11 @@ fn task_check_reports_missing_required_test_symbols() {
     commit_all(tempdir.path(), "update task");
 
     let plan = tempdir.path().join("goal-plan.yaml");
+    fs::write(
+        tempdir.path().join("tests/task_command.rs"),
+        "fn actual_test_name() {}\n// task_plan_missing_symbol\n",
+    )
+    .expect("updated task tests");
     write_goal_plan(
         &plan,
         &goal_plan_yaml(
@@ -756,6 +761,92 @@ fn task_check_reports_missing_required_test_symbols() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("required test symbol is missing"));
     assert!(stdout.contains("task_plan_missing_symbol"));
+}
+
+// REQ-CORE-031
+#[test]
+fn task_check_rejects_empty_required_test_symbols() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for empty-symbol check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: high\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-CORE-031\n    features:\n      - FEAT-TASK-004\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: tests/task_command.rs\n        symbols:\n          - \"\"\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("required test symbol is empty"));
+}
+
+// REQ-CORE-031
+#[test]
+fn task_check_rejects_absolute_required_test_files_outside_workspace() {
+    let tempdir = tempdir().expect("tempdir");
+    prepare_git_workspace(tempdir.path(), "task_plan_generates_goal_from_request");
+
+    fs::write(
+        tempdir.path().join("src/command/task.rs"),
+        "pub fn run_task_command() {}\n// updated for absolute-path check\n",
+    )
+    .expect("updated task source");
+    commit_all(tempdir.path(), "update task");
+
+    let external = tempfile::tempdir().expect("external tempdir");
+    let external_test = external.path().join("outside.rs");
+    fs::write(&external_test, "fn task_plan_generates_goal_from_request() {}\n")
+        .expect("external test file");
+
+    let plan = tempdir.path().join("goal-plan.yaml");
+    write_goal_plan(
+        &plan,
+        &goal_plan_yaml(
+            "REQ-CORE-031",
+            "FEAT-TASK-004",
+            &external_test.display().to_string(),
+            "task_plan_generates_goal_from_request",
+            "high",
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args([
+            "task",
+            "check",
+            "goal-plan.yaml",
+            "--range",
+            "origin/main...HEAD",
+        ]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task check should fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("required test file must stay within the workspace"));
+    assert!(stdout.contains(&external_test.display().to_string()));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Added `syu task check` to validate Goal Plans against a git range, linked spec IDs, required tests, and completion commands.
- Reused git range diff lookup and added scope/test/link validation with text and JSON output.
- Updated task command docs, help text, and spec fixtures for the new feature.

Validation:
- `cargo test task_check -- --nocapture`
- `cargo test dispatches_task_subcommands_without_rewriting_them -- --nocapture`

Closes #703
