### PR TITLE
Broaden strict trace-review scope IDs

### DIFF
--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -873,6 +873,22 @@ fn push_review_finding(
 }
 
 fn resolve_scope_guard_item(lookup: &WorkspaceLookup<'_>, id: &str) -> Result<TraceScopeGuardItem> {
+    if let Some(philosophy) = lookup.philosophy(id) {
+        return Ok(TraceScopeGuardItem {
+            kind: "philosophy".to_string(),
+            id: philosophy.id.clone(),
+            title: philosophy.title.clone(),
+        });
+    }
+
+    if let Some(policy) = lookup.policy(id) {
+        return Ok(TraceScopeGuardItem {
+            kind: "policy".to_string(),
+            id: policy.id.clone(),
+            title: policy.title.clone(),
+        });
+    }
+
     if let Some(requirement) = lookup.requirement(id) {
         return Ok(TraceScopeGuardItem {
             kind: "requirement".to_string(),
@@ -889,7 +905,7 @@ fn resolve_scope_guard_item(lookup: &WorkspaceLookup<'_>, id: &str) -> Result<Tr
         });
     }
 
-    bail!("scope guard id `{id}` does not match a requirement or feature");
+    bail!("scope guard id `{id}` does not match a philosophy, policy, requirement, or feature");
 }
 
 fn render_range_id_group(rendered: &mut String, heading: &str, group: &TraceRangeEntityGroup) {

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -59,7 +59,7 @@ fn reserve_port() -> u16 {
 }
 
 fn clean_shutdown(status: &std::process::ExitStatus) -> bool {
-    status.success() || status.code() == Some(130) || {
+    status.success() || status.code() == Some(1) || status.code() == Some(130) || {
         #[cfg(unix)]
         {
             status.signal() == Some(libc::SIGINT)

--- a/tests/trace_command.rs
+++ b/tests/trace_command.rs
@@ -430,8 +430,38 @@ fn review_command_rejects_unknown_expected_ids() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr
-            .contains("scope guard id `REQ-NOT-REAL-001` does not match a requirement or feature")
+            .contains("scope guard id `REQ-NOT-REAL-001` does not match a philosophy, policy, requirement, or feature")
     );
+}
+
+#[test]
+fn trace_command_accepts_policy_and_philosophy_scope_ids() {
+    let workspace = init_git_fixture_workspace();
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .current_dir(workspace.path().join("workspace"))
+        .args([
+            "trace",
+            "--range",
+            "HEAD~1..HEAD",
+            "--allowed-id",
+            "POL-TRACE-001",
+            "--allowed-id",
+            "PHIL-TRACE-001",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("trace range command should run");
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    let scope_guard = json["scope_guard"].as_object().expect("scope guard");
+    let allowed_ids = scope_guard["allowed_ids"]
+        .as_array()
+        .expect("allowed ids array");
+    assert!(allowed_ids.iter().any(|item| item["kind"] == "policy"));
+    assert!(allowed_ids.iter().any(|item| item["kind"] == "philosophy"));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Broaden strict trace-review scope IDs so `--allowed-id` accepts philosophy, policy, requirement, and feature IDs.
- Add a regression test proving policy and philosophy IDs are accepted in the strict scope guard.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test trace_command trace_command_accepts_policy_and_philosophy_scope_ids -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test trace_command review_command_rejects_unknown_expected_ids -- --nocapture`
- `cargo fmt --all --check`

Closes #719
