### PR TITLE
[Feature]: Add syu task infer to derive provisional Goal Plans from existing diffs

### DIFF
--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -108,13 +108,16 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - run_task_command
           - run_task_plan_command
+          - run_task_infer_command
           - build_goal_plan
+          - build_diff_inferred_goal_plan
           - GoalPlanArtifact
           - load_goal_plan_artifact
       - **file**: src/cli.rs
         - **symbols**:
           - TaskArgs
           - TaskPlanArgs
+          - TaskInferArgs
           - TaskPlanFormat
       - **file**: src/lib.rs
         - **symbols**:
@@ -130,6 +133,9 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task infer --range origin/main...HEAD
 - **id**: FEAT-TASK-005
   - **title**: Goal Plan conformance checking
   - **summary**: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.
@@ -258,13 +264,16 @@ features:
           symbols:
             - run_task_command
             - run_task_plan_command
+            - run_task_infer_command
             - build_goal_plan
+            - build_diff_inferred_goal_plan
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs
           symbols:
             - TaskArgs
             - TaskPlanArgs
+            - TaskInferArgs
             - TaskPlanFormat
         - file: src/lib.rs
           symbols:
@@ -280,6 +289,9 @@ features:
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task infer --range origin/main...HEAD
   - id: FEAT-TASK-005
     title: Goal Plan conformance checking
     summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -742,7 +742,9 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - GoalPlanArtifact
           - load_goal_plan_artifact
           - run_task_plan_command
+          - run_task_infer_command
           - build_goal_plan
+          - build_diff_inferred_goal_plan
           - render_goal_plan_output
           - resolve_task_plan_output_path
           - goal_plan_builder_renders_outputs_and_writes_files
@@ -754,6 +756,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
         - **symbols**:
           - TaskArgs
           - TaskPlanArgs
+          - TaskInferArgs
           - TaskPlanFormat
       - **file**: src/lib.rs
         - **symbols**:
@@ -765,6 +768,14 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - task_plan_prints_text_output_and_writes_goal_plan_file
           - task_plan_prints_json_output_with_scope_and_test_sections
           - task_plan_warns_when_output_is_inside_spec_root
+          - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
+          - task_infer_reports_medium_confidence_for_shared_utility_diffs
+          - task_infer_reports_low_confidence_for_unmapped_files
+          - task_infer_reports_low_confidence_for_ambiguous_ownership
+          - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
+          - task_infer_is_deterministic_for_json_and_yaml_outputs
+          - task_infer_rejects_empty_diffs
+          - task_infer_keeps_spec_updates_optional_for_medium_confidence_planned_features
           - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
           - goal_plan_artifact_requires_the_goal_plan_marker
           - goal_plan_format_is_documented_as_temporary
@@ -780,9 +791,13 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: docs/guide/implementation-planning.md
         - **symbols**:
           - syu task plan
+          - syu task infer --range origin/main...HEAD
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task infer --range origin/main...HEAD
 - **id**: REQ-CORE-032
   - **title**: Validate temporary Goal Plans against the current spec graph and git range
   - **description**:
@@ -1561,7 +1576,9 @@ requirements:
             - GoalPlanArtifact
             - load_goal_plan_artifact
             - run_task_plan_command
+            - run_task_infer_command
             - build_goal_plan
+            - build_diff_inferred_goal_plan
             - render_goal_plan_output
             - resolve_task_plan_output_path
             - goal_plan_builder_renders_outputs_and_writes_files
@@ -1573,6 +1590,7 @@ requirements:
           symbols:
             - TaskArgs
             - TaskPlanArgs
+            - TaskInferArgs
             - TaskPlanFormat
         - file: src/lib.rs
           symbols:
@@ -1584,6 +1602,14 @@ requirements:
             - task_plan_prints_text_output_and_writes_goal_plan_file
             - task_plan_prints_json_output_with_scope_and_test_sections
             - task_plan_warns_when_output_is_inside_spec_root
+            - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
+            - task_infer_reports_medium_confidence_for_shared_utility_diffs
+            - task_infer_reports_low_confidence_for_unmapped_files
+            - task_infer_reports_low_confidence_for_ambiguous_ownership
+            - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
+            - task_infer_is_deterministic_for_json_and_yaml_outputs
+            - task_infer_rejects_empty_diffs
+            - task_infer_keeps_spec_updates_optional_for_medium_confidence_planned_features
             - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
             - goal_plan_artifact_requires_the_goal_plan_marker
             - goal_plan_format_is_documented_as_temporary
@@ -1599,9 +1625,13 @@ requirements:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task plan
+            - syu task infer --range origin/main...HEAD
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task infer --range origin/main...HEAD
   - id: REQ-CORE-032
     title: Validate temporary Goal Plans against the current spec graph and git range
     description: |

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,8 +14,8 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 157/157
-- Feature-to-implementation traceability: 164/164
+- Requirement-to-test traceability: 158/158
+- Feature-to-implementation traceability: 165/165
 
 ## Issues
 

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -29,6 +29,7 @@ If a pull request already exists, pair this page with the
 | Strictly review a PR range | `syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json` | fail the range review on unowned, ambiguously owned, or out-of-scope changes while keeping structured findings for CI |
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
 | Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
+| Infer a goal plan from a diff | `syu task infer --range origin/main...HEAD` | derive a provisional Goal Plan from changed files, traced owners, evidence, and confidence before review |
 | Check a temporary goal plan | `syu task check goal-plan.yaml --range origin/main...HEAD` | validate a temporary Goal Plan against the changed files, linked spec IDs, required tests, and completion commands before review |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |

--- a/docs/guide/goal-plan-format.md
+++ b/docs/guide/goal-plan-format.md
@@ -30,11 +30,20 @@ kind: syu.goal_plan
 source:
   mode: request_driven
   request_artifact: request.yaml
+  confidence: medium
+  evidence:
+    changed_files:
+      - src/command/task.rs
+    traced_requirements:
+      - REQ-CORE-030
+    traced_features:
+      - FEAT-TASK-003
 
 goal:
   id: GOAL-001
   title: Keep temporary planning explicit
   statement: Capture the implementation plan without turning it into a fifth spec layer.
+  inferred: false
   non_goals:
     - Add a persistent task tree under spec.root
 
@@ -88,7 +97,9 @@ completion:
 - **source.request_artifact**: points at the request artifact when one exists.
 - **source.range**: records the diff range used for inferred plans.
 - **source.confidence**: records how certain an inferred plan is.
+- **source.evidence**: records the changed files and traced IDs that shaped a diff-inferred plan.
 - **goal**: states the implementation goal, the short title, and the non-goals.
+- **goal.inferred**: marks a goal that came from diff inference rather than request-driven planning.
 - **spec_mapping**: records which persistent spec items the plan may touch and
   whether spec updates are expected.
 - **implementation_plan**: lists the bounded file or symbol scope and the steps

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -96,6 +96,10 @@ syu task scaffold request.yaml
 ```
 
 Use `syu task plan` when you need the temporary Goal Plan artifact itself.
+Use `syu task infer --range origin/main...HEAD` when implementation already
+exists and you want a provisional Goal Plan inferred from the changed files,
+their traced owners, and the current graph.
+
 That is the step that should capture the implementation plan, test plan,
 coverage target, completion checks, and any warnings that still need review.
 

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -93,13 +93,16 @@ features:
           symbols:
             - run_task_command
             - run_task_plan_command
+            - run_task_infer_command
             - build_goal_plan
+            - build_diff_inferred_goal_plan
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs
           symbols:
             - TaskArgs
             - TaskPlanArgs
+            - TaskInferArgs
             - TaskPlanFormat
         - file: src/lib.rs
           symbols:
@@ -115,6 +118,9 @@ features:
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task infer --range origin/main...HEAD
   - id: FEAT-TASK-005
     title: Goal Plan conformance checking
     summary: Validate temporary Goal Plan artifacts against changed files, linked spec IDs, required tests, and declared completion commands before review.

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -741,6 +741,8 @@ requirements:
             - task_infer_reports_low_confidence_for_ambiguous_ownership
             - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
             - task_infer_is_deterministic_for_json_and_yaml_outputs
+            - task_infer_rejects_empty_diffs
+            - task_infer_keeps_spec_updates_optional_for_medium_confidence_planned_features
             - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
             - goal_plan_artifact_requires_the_goal_plan_marker
             - goal_plan_format_is_documented_as_temporary

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -709,7 +709,9 @@ requirements:
             - GoalPlanArtifact
             - load_goal_plan_artifact
             - run_task_plan_command
+            - run_task_infer_command
             - build_goal_plan
+            - build_diff_inferred_goal_plan
             - render_goal_plan_output
             - resolve_task_plan_output_path
             - goal_plan_builder_renders_outputs_and_writes_files
@@ -721,6 +723,7 @@ requirements:
           symbols:
             - TaskArgs
             - TaskPlanArgs
+            - TaskInferArgs
             - TaskPlanFormat
         - file: src/lib.rs
           symbols:
@@ -732,6 +735,12 @@ requirements:
             - task_plan_prints_text_output_and_writes_goal_plan_file
             - task_plan_prints_json_output_with_scope_and_test_sections
             - task_plan_warns_when_output_is_inside_spec_root
+            - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
+            - task_infer_reports_medium_confidence_for_shared_utility_diffs
+            - task_infer_reports_low_confidence_for_unmapped_files
+            - task_infer_reports_low_confidence_for_ambiguous_ownership
+            - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
+            - task_infer_is_deterministic_for_json_and_yaml_outputs
             - goal_plan_artifact_supports_request_driven_and_diff_inferred_sources
             - goal_plan_artifact_requires_the_goal_plan_marker
             - goal_plan_format_is_documented_as_temporary
@@ -747,9 +756,13 @@ requirements:
         - file: docs/guide/implementation-planning.md
           symbols:
             - syu task plan
+            - syu task infer --range origin/main...HEAD
         - file: docs/guide/goal-plan-format.md
           symbols:
             - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task infer --range origin/main...HEAD
   - id: REQ-CORE-032
     title: Validate temporary Goal Plans against the current spec graph and git range
     description: |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,8 @@ New here?
   8. syu task scope request.yaml      map a request artifact onto the current spec graph
   9. syu task scaffold request.yaml   preview planned requirement and feature updates from a request artifact
  10. syu task plan request.yaml      generate a temporary Goal Plan from a request artifact
- 11. syu task check goal-plan.yaml   validate a Goal Plan against a git range and the current spec graph";
+ 11. syu task infer --range ...      infer a provisional Goal Plan from a git diff
+ 12. syu task check goal-plan.yaml   validate a Goal Plan against a git range and the current spec graph";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -109,6 +110,14 @@ Examples:
 
 Use this when a scoped request is ready to become a temporary Goal Plan that stays outside the persistent spec tree while still mapping the request to existing philosophy, policy, requirement, and feature items.";
 
+const TASK_INFER_AFTER_HELP: &str = "\
+Examples:
+  syu task infer --range origin/main...HEAD
+  syu task infer --range origin/main...HEAD --format json
+  syu task infer --range origin/main...HEAD --output target/syu/inferred-goal.yaml
+
+Use this when implementation has already happened and you want syu to infer a provisional Goal Plan from the changed files, their traced owners, and nearby spec context without modifying persistent spec files.";
+
 const TASK_SCAFFOLD_AFTER_HELP: &str = "\
 Examples:
   syu task scaffold request.yaml
@@ -129,6 +138,7 @@ Examples:
   syu task scope request.yaml
   syu task scaffold request.yaml
   syu task plan request.yaml --output .syu/tasks/current.yaml
+  syu task infer --range origin/main...HEAD --output target/syu/inferred-goal.yaml
   syu task check .syu/tasks/current.yaml --range origin/main...HEAD
   syu task check target/syu/inferred-goal.yaml --range origin/main...HEAD --format json";
 
@@ -827,6 +837,11 @@ pub enum TaskCommands {
     )]
     Plan(TaskPlanArgs),
     #[command(
+        about = "Infer a provisional Goal Plan from a git diff",
+        after_help = TASK_INFER_AFTER_HELP
+    )]
+    Infer(TaskInferArgs),
+    #[command(
         about = "Preview planned requirement and feature scaffolds from a request artifact",
         after_help = TASK_SCAFFOLD_AFTER_HELP
     )]
@@ -881,6 +896,25 @@ pub struct TaskPlanArgs {
 
     #[arg(help = "Output format for the Goal Plan artifact or summary")]
     #[arg(long, value_enum, default_value_t = TaskPlanFormat::Text)]
+    pub format: TaskPlanFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskInferArgs {
+    #[arg(help = "Git revision range whose diff should be inferred into a Goal Plan")]
+    #[arg(long)]
+    pub range: String,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Write the inferred Goal Plan artifact to a file instead of stdout")]
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    #[arg(help = "Output format for the inferred Goal Plan artifact or summary")]
+    #[arg(long, value_enum, default_value_t = TaskPlanFormat::Yaml)]
     pub format: TaskPlanFormat,
 }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cli::{
         LookupKind, OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands,
-        TaskPlanArgs, TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs,
+        TaskInferArgs, TaskPlanArgs, TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs,
     },
     coverage::normalize_relative_path,
     language::adapter_for_language,
@@ -80,6 +80,22 @@ struct GoalPlanArtifact {
 }
 
 #[allow(dead_code)]
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+struct GoalPlanSourceEvidence {
+    #[serde(default)]
+    changed_files: Vec<String>,
+    #[serde(default)]
+    traced_requirements: Vec<String>,
+    #[serde(default)]
+    traced_features: Vec<String>,
+    #[serde(default)]
+    traced_policies: Vec<String>,
+    #[serde(default)]
+    traced_philosophies: Vec<String>,
+}
+
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 struct GoalPlanSource {
@@ -87,9 +103,13 @@ struct GoalPlanSource {
     #[serde(default)]
     request_artifact: Option<String>,
     #[serde(default)]
+    classification: Option<String>,
+    #[serde(default)]
     range: Option<String>,
     #[serde(default)]
     confidence: Option<GoalPlanConfidence>,
+    #[serde(default)]
+    evidence: Option<GoalPlanSourceEvidence>,
 }
 
 impl Default for GoalPlanSource {
@@ -97,8 +117,10 @@ impl Default for GoalPlanSource {
         Self {
             mode: GoalPlanSourceMode::RequestDriven,
             request_artifact: None,
+            classification: None,
             range: None,
             confidence: None,
+            evidence: None,
         }
     }
 }
@@ -130,6 +152,8 @@ struct GoalPlanGoal {
     statement: String,
     #[serde(default)]
     non_goals: Vec<String>,
+    #[serde(default)]
+    inferred: bool,
 }
 
 #[allow(dead_code)]
@@ -314,6 +338,15 @@ struct JsonTaskPlanOutput {
 }
 
 #[derive(Debug, Serialize)]
+struct JsonTaskPlanSourceEvidence {
+    changed_files: Vec<String>,
+    traced_requirements: Vec<String>,
+    traced_features: Vec<String>,
+    traced_policies: Vec<String>,
+    traced_philosophies: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
 struct JsonScaffoldUpdate {
     kind: String,
     action: String,
@@ -326,9 +359,15 @@ struct JsonScaffoldUpdate {
 #[derive(Debug, Serialize)]
 struct JsonTaskPlanSource {
     mode: String,
-    request_artifact: String,
-    classification: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_artifact: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    classification: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    range: Option<String>,
     confidence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    evidence: Option<JsonTaskPlanSourceEvidence>,
 }
 
 #[derive(Debug, Serialize)]
@@ -337,6 +376,12 @@ struct JsonTaskPlanGoal {
     title: String,
     statement: String,
     non_goals: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    inferred: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Serialize)]
@@ -486,6 +531,15 @@ struct ScaffoldPlan {
 }
 
 #[derive(Debug)]
+struct DiffInferenceOutcome {
+    scope: ScopeOutcome,
+    scope_entries: Vec<JsonTaskPlanScopeEntry>,
+    source: JsonTaskPlanSourceEvidence,
+    confidence: &'static str,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug)]
 struct ScaffoldUpdate {
     kind: ScaffoldUpdateKind,
     action: ScaffoldAction,
@@ -533,6 +587,7 @@ pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
         TaskCommands::Classify(classify) => run_task_classify_command(classify),
         TaskCommands::Scope(scope) => run_task_scope_command(scope),
         TaskCommands::Plan(plan) => run_task_plan_command(plan),
+        TaskCommands::Infer(infer) => run_task_infer_command(infer),
         TaskCommands::Scaffold(scaffold) => run_task_scaffold_command(scaffold),
         TaskCommands::Check(check) => run_task_check_command(check),
     }
@@ -702,13 +757,56 @@ pub fn run_task_plan_command(args: &TaskPlanArgs) -> Result<i32> {
         &args.request,
         args.output.as_deref(),
     )?;
-    let rendered = render_goal_plan_output(&args.request, &plan, args.format)?;
+    let rendered = render_goal_plan_output(
+        "request",
+        &args.request.display().to_string(),
+        &plan,
+        args.format,
+    )?;
 
     if let Some(_output) = &args.output {
         let resolved_output = resolved_output.expect("output path should be resolved");
         if resolved_output.starts_with(&workspace.spec_root) {
             eprintln!(
                 "warning: task plan output `{}` is inside spec.root `{}`; the plan is intended to stay outside the persistent spec tree",
+                resolved_output.display(),
+                workspace.spec_root.display()
+            );
+        }
+        if let Some(parent) = resolved_output.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&resolved_output, rendered)?;
+        println!("wrote goal plan to {}", resolved_output.display());
+    } else {
+        print!("{rendered}");
+        if !rendered.ends_with('\n') {
+            println!();
+        }
+    }
+
+    Ok(0)
+}
+
+pub fn run_task_infer_command(args: &TaskInferArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let range = args.range.trim();
+    if range.is_empty() {
+        bail!("--range must not be empty");
+    }
+
+    let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
+    let plan =
+        build_diff_inferred_goal_plan(&workspace, range, &changed_files, args.output.as_deref())?;
+    let rendered = render_goal_plan_output("range", range, &plan, args.format)?;
+
+    if let Some(output) = &args.output {
+        let resolved_output = resolve_task_plan_output_path(&workspace.root, output);
+        if resolved_output.starts_with(&workspace.spec_root) {
+            bail!(
+                "inferred Goal Plan output `{}` must stay outside the persistent spec tree `{}`",
                 resolved_output.display(),
                 workspace.spec_root.display()
             );
@@ -769,9 +867,11 @@ fn build_goal_plan(
         classification: outcome.classification.classification.label().to_string(),
         source: JsonTaskPlanSource {
             mode: "request_driven".to_string(),
-            request_artifact: request_path.display().to_string(),
-            classification: outcome.classification.classification.label().to_string(),
+            request_artifact: Some(request_path.display().to_string()),
+            classification: Some(outcome.classification.classification.label().to_string()),
+            range: None,
             confidence: source_confidence.to_string(),
+            evidence: None,
         },
         goal: JsonTaskPlanGoal {
             id: "GOAL-TASK-PLAN-001".to_string(),
@@ -785,6 +885,7 @@ fn build_goal_plan(
                 "Do not add a fifth persistent spec layer.".to_string(),
                 "Do not skip validation or coverage checks.".to_string(),
             ],
+            inferred: false,
         },
         spec_mapping: JsonTaskPlanSpecMapping {
             persistent_items,
@@ -821,13 +922,25 @@ fn task_plan_completion_checks(output_path: Option<&Path>) -> Vec<String> {
     ]
 }
 
+fn inferred_goal_plan_completion_checks(range: &str, output_path: Option<&Path>) -> Vec<String> {
+    let plan_path = output_path
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "target/syu/inferred-goal.yaml".to_string());
+
+    vec![
+        format!("syu task check {plan_path} --range {range}"),
+        "syu validate .".to_string(),
+    ]
+}
+
 fn render_goal_plan_output(
-    request_path: &Path,
+    label_name: &str,
+    label_value: &str,
     plan: &JsonTaskPlanOutput,
     format: TaskPlanFormat,
 ) -> Result<String> {
     let output = match format {
-        TaskPlanFormat::Text => render_goal_plan_text_output(request_path, plan),
+        TaskPlanFormat::Text => render_goal_plan_text_output(label_name, label_value, plan),
         TaskPlanFormat::Yaml => serde_yaml::to_string(plan)
             .expect("serializing task plan output to YAML should succeed"),
         TaskPlanFormat::Json => serde_json::to_string_pretty(plan)
@@ -837,21 +950,58 @@ fn render_goal_plan_output(
     Ok(output)
 }
 
-fn render_goal_plan_text_output(request_path: &Path, plan: &JsonTaskPlanOutput) -> String {
+fn render_goal_plan_text_output(
+    label_name: &str,
+    label_value: &str,
+    plan: &JsonTaskPlanOutput,
+) -> String {
     let mut output = String::new();
     use std::fmt::Write as _;
 
-    writeln!(&mut output, "request: {}", request_path.display()).expect("write to string");
+    writeln!(&mut output, "{label_name}: {label_value}").expect("write to string");
     writeln!(&mut output, "version: {}", plan.version).expect("write to string");
     writeln!(&mut output, "kind: {}", plan.kind).expect("write to string");
+    writeln!(&mut output, "source mode: {}", plan.source.mode).expect("write to string");
     writeln!(&mut output, "classification: {}", plan.classification).expect("write to string");
     writeln!(&mut output, "source confidence: {}", plan.source.confidence)
         .expect("write to string");
+    if let Some(range) = &plan.source.range {
+        writeln!(&mut output, "source range: {range}").expect("write to string");
+    }
+    if let Some(evidence) = &plan.source.evidence {
+        writeln!(&mut output, "source evidence:").expect("write to string");
+        writeln!(&mut output, "  changed files:").expect("write to string");
+        if evidence.changed_files.is_empty() {
+            writeln!(&mut output, "    - none").expect("write to string");
+        } else {
+            for file in &evidence.changed_files {
+                writeln!(&mut output, "    - {file}").expect("write to string");
+            }
+        }
+        print_source_evidence_section(
+            &mut output,
+            "traced requirements",
+            &evidence.traced_requirements,
+        );
+        print_source_evidence_section(&mut output, "traced features", &evidence.traced_features);
+        print_source_evidence_section(&mut output, "traced policies", &evidence.traced_policies);
+        print_source_evidence_section(
+            &mut output,
+            "traced philosophies",
+            &evidence.traced_philosophies,
+        );
+    }
     writeln!(&mut output).expect("write to string");
     writeln!(&mut output, "goal:").expect("write to string");
     writeln!(&mut output, "  id: {}", plan.goal.id).expect("write to string");
     writeln!(&mut output, "  title: {}", plan.goal.title).expect("write to string");
     writeln!(&mut output, "  statement: {}", plan.goal.statement).expect("write to string");
+    writeln!(
+        &mut output,
+        "  inferred: {}",
+        if plan.goal.inferred { "yes" } else { "no" }
+    )
+    .expect("write to string");
     writeln!(&mut output, "  non-goals:").expect("write to string");
     for item in &plan.goal.non_goals {
         writeln!(&mut output, "    - {item}").expect("write to string");
@@ -957,6 +1107,767 @@ fn render_goal_plan_text_output(request_path: &Path, plan: &JsonTaskPlanOutput) 
     }
 
     output
+}
+
+fn print_source_evidence_section(output: &mut String, heading: &str, items: &[String]) {
+    use std::fmt::Write as _;
+
+    writeln!(output, "  {heading}:").expect("write to string");
+    if items.is_empty() {
+        writeln!(output, "    - none").expect("write to string");
+        return;
+    }
+
+    for item in items {
+        writeln!(output, "    - {item}").expect("write to string");
+    }
+}
+
+fn build_diff_inferred_goal_plan(
+    workspace: &crate::workspace::Workspace,
+    range: &str,
+    changed_files: &[PathBuf],
+    output_path: Option<&Path>,
+) -> Result<JsonTaskPlanOutput> {
+    let lookup = WorkspaceLookup::new(workspace);
+    let inference = infer_diff_plan(workspace, &lookup, range, changed_files)?;
+    let persistent_items = collect_task_plan_persistent_items(&lookup, &inference.scope)?;
+    let spec_update_reasons = determine_spec_update_reasons(&inference.scope, &persistent_items);
+    let spec_updates_required = !spec_update_reasons.is_empty() || inference.confidence != "high";
+    let test_plan = collect_task_plan_tests(&lookup, &persistent_items, &inference.scope)?;
+    let mut test_plan = test_plan;
+    test_plan.selection_mode = "affected".to_string();
+    let goal_title = build_inferred_goal_title(&inference.scope, changed_files, &lookup);
+    let goal_statement = build_inferred_goal_statement(
+        &inference.scope,
+        changed_files,
+        &persistent_items,
+        inference.confidence,
+    );
+
+    Ok(JsonTaskPlanOutput {
+        version: GOAL_PLAN_VERSION,
+        kind: "syu.goal_plan".to_string(),
+        request_path: range.to_string(),
+        request: format!("git diff {range}"),
+        classification: inference
+            .scope
+            .classification
+            .classification
+            .label()
+            .to_string(),
+        source: JsonTaskPlanSource {
+            mode: "diff_inferred".to_string(),
+            request_artifact: None,
+            classification: None,
+            range: Some(range.to_string()),
+            confidence: inference.confidence.to_string(),
+            evidence: Some(inference.source),
+        },
+        goal: JsonTaskPlanGoal {
+            id: "GOAL-INFERRED-001".to_string(),
+            title: goal_title,
+            statement: goal_statement,
+            non_goals: build_inferred_goal_non_goals(inference.confidence),
+            inferred: true,
+        },
+        spec_mapping: JsonTaskPlanSpecMapping {
+            persistent_items,
+            spec_updates_required,
+            spec_update_reasons,
+        },
+        implementation_plan: JsonTaskPlanImplementationPlan {
+            confidence: inference.confidence.to_string(),
+            scope: JsonTaskPlanScope {
+                include: inference.scope_entries,
+                exclude: vec!["docs/generated/**".to_string(), "target/**".to_string()],
+            },
+        },
+        test_plan,
+        coverage: JsonTaskPlanCoverage {
+            mode: "changed_lines".to_string(),
+            threshold: 100,
+        },
+        completion: JsonTaskPlanCompletion {
+            must_pass: inferred_goal_plan_completion_checks(range, output_path),
+        },
+        warnings: inference.warnings,
+    })
+}
+
+fn infer_diff_plan(
+    workspace: &crate::workspace::Workspace,
+    lookup: &WorkspaceLookup<'_>,
+    range: &str,
+    changed_files: &[PathBuf],
+) -> Result<DiffInferenceOutcome> {
+    let mut changed_file_strings = Vec::new();
+    let mut scope_entries = Vec::new();
+    let mut direct_items = BTreeMap::<String, SearchResult>::new();
+    let mut unowned_files = Vec::new();
+    let mut ambiguous_files = Vec::new();
+    let mut spec_files = Vec::new();
+
+    for file in changed_files {
+        let file_label = path_label(file);
+        changed_file_strings.push(file_label.clone());
+
+        let matches = collect_inferred_file_matches(workspace, lookup, file)?;
+        if matches.is_spec_file {
+            spec_files.push(file_label.clone());
+        }
+        if matches.is_unowned {
+            unowned_files.push(file_label.clone());
+        }
+        if matches.is_ambiguous {
+            ambiguous_files.push(file_label.clone());
+        }
+
+        scope_entries.push(matches.scope_entry);
+        for item in matches.direct_items {
+            direct_items.insert(item.id.clone(), item);
+        }
+    }
+
+    changed_file_strings.sort();
+    changed_file_strings.dedup();
+    scope_entries.sort_by(|left, right| left.file.cmp(&right.file));
+    scope_entries.dedup_by(|left, right| left.file == right.file && left.symbols == right.symbols);
+    unowned_files.sort();
+    unowned_files.dedup();
+    ambiguous_files.sort();
+    ambiguous_files.dedup();
+    spec_files.sort();
+    spec_files.dedup();
+
+    let direct_items = direct_items.into_values().collect::<Vec<_>>();
+    let related_items = collect_related_inference_items(lookup, &direct_items);
+    let related_and_direct = merge_inference_items(&direct_items, &related_items);
+    let classification = ClassificationOutcome {
+        classification: infer_requirement_action(&direct_items, &related_items),
+        reasons: build_inference_reasons(
+            &changed_file_strings,
+            &unowned_files,
+            &ambiguous_files,
+            &spec_files,
+            &direct_items,
+            &related_items,
+        ),
+        explicit_items: direct_items.clone(),
+        related_items: related_items.clone(),
+        request: format!("git diff {range}"),
+        context: RequestArtifactContext::default(),
+    };
+
+    let requirements =
+        collect_scoped_results(&direct_items, &related_and_direct, "requirement", 50);
+    let policies = collect_scoped_results(&direct_items, &related_and_direct, "policy", 50);
+    let philosophies = collect_scoped_results(&direct_items, &related_and_direct, "philosophy", 50);
+    let features = collect_feature_candidates(
+        lookup,
+        &direct_items,
+        &related_and_direct,
+        classification.classification,
+        50,
+    );
+
+    let scope = ScopeOutcome {
+        classification,
+        signals: ScopeSignals {
+            policy_discussion: !policies.is_empty(),
+            philosophy_discussion: !philosophies.is_empty(),
+            planned_feature_updates: features.iter().any(|feature| feature.planned_state_update)
+                || !spec_files.is_empty(),
+        },
+        requirements,
+        features,
+        policies,
+        philosophies,
+        notes: build_inference_notes(&unowned_files, &ambiguous_files, &spec_files),
+    };
+
+    let confidence = confidence_for_diff_inference(
+        &changed_file_strings,
+        &unowned_files,
+        &ambiguous_files,
+        &spec_files,
+        &scope,
+    );
+
+    let warnings =
+        build_inference_warnings(confidence, &unowned_files, &ambiguous_files, &spec_files);
+    let source = JsonTaskPlanSourceEvidence {
+        changed_files: changed_file_strings.clone(),
+        traced_requirements: collect_ids_by_kind(&scope.requirements),
+        traced_features: collect_feature_ids(&scope.features),
+        traced_policies: collect_ids_by_kind(&scope.policies),
+        traced_philosophies: collect_ids_by_kind(&scope.philosophies),
+    };
+
+    Ok(DiffInferenceOutcome {
+        scope,
+        source,
+        confidence,
+        warnings,
+        scope_entries,
+    })
+}
+
+#[derive(Debug)]
+struct InferredFileMatches {
+    direct_items: Vec<SearchResult>,
+    scope_entry: JsonTaskPlanScopeEntry,
+    is_spec_file: bool,
+    is_unowned: bool,
+    is_ambiguous: bool,
+}
+
+#[derive(Debug)]
+struct TracedItemMatch {
+    item: SearchResult,
+    symbols: BTreeSet<String>,
+}
+
+fn collect_inferred_file_matches(
+    workspace: &crate::workspace::Workspace,
+    lookup: &WorkspaceLookup<'_>,
+    file: &Path,
+) -> Result<InferredFileMatches> {
+    let file_label = path_label(file);
+    let mut direct_items = BTreeMap::<String, SearchResult>::new();
+    let mut symbols = BTreeSet::<String>::new();
+
+    for item in collect_spec_items_for_path(lookup, &file_label)? {
+        direct_items.insert(item.id.clone(), item);
+    }
+
+    for traced in collect_traced_items_for_path(workspace, file) {
+        symbols.extend(traced.symbols.iter().cloned());
+        direct_items.insert(traced.item.id.clone(), traced.item);
+    }
+
+    let is_spec_file = matches!(
+        file_label.as_str(),
+        label if label.starts_with("docs/syu/philosophy/")
+            || label.starts_with("docs/syu/policies/")
+            || label.starts_with("docs/syu/requirements/")
+            || label.starts_with("docs/syu/features/")
+    );
+    let direct_count = direct_items.len();
+    let is_unowned = direct_count == 0;
+    let is_ambiguous = direct_count > 1 && !is_shared_utility_path(file);
+
+    Ok(InferredFileMatches {
+        direct_items: direct_items.into_values().collect(),
+        scope_entry: JsonTaskPlanScopeEntry {
+            file: file_label,
+            symbols: symbols.into_iter().collect(),
+        },
+        is_spec_file,
+        is_unowned,
+        is_ambiguous,
+    })
+}
+
+fn collect_spec_items_for_path(
+    lookup: &WorkspaceLookup<'_>,
+    file_label: &str,
+) -> Result<Vec<SearchResult>> {
+    let mut items = Vec::new();
+    for kind in [
+        LookupKind::Philosophy,
+        LookupKind::Policy,
+        LookupKind::Requirement,
+        LookupKind::Feature,
+    ] {
+        for item in lookup.entries_with_document_paths(kind)? {
+            if item.document_path.as_deref() == Some(file_label) {
+                items.push(SearchResult {
+                    id: item.id,
+                    kind: kind.label(),
+                    title: item.title,
+                });
+            }
+        }
+    }
+
+    Ok(items)
+}
+
+fn collect_traced_items_for_path(
+    workspace: &crate::workspace::Workspace,
+    file: &Path,
+) -> Vec<TracedItemMatch> {
+    let normalized_file = normalize_relative_path(file);
+    let mut items = BTreeMap::<String, TracedItemMatch>::new();
+
+    for requirement in &workspace.requirements {
+        for references in requirement.tests.values() {
+            for reference in references {
+                if normalize_relative_path(&reference.file) != normalized_file {
+                    continue;
+                }
+                let entry =
+                    items
+                        .entry(requirement.id.clone())
+                        .or_insert_with(|| TracedItemMatch {
+                            item: SearchResult {
+                                id: requirement.id.clone(),
+                                kind: "requirement",
+                                title: requirement.title.clone(),
+                            },
+                            symbols: BTreeSet::new(),
+                        });
+                entry.symbols.extend(reference.symbols.iter().cloned());
+            }
+        }
+    }
+
+    for feature in &workspace.features {
+        for references in feature.implementations.values() {
+            for reference in references {
+                if normalize_relative_path(&reference.file) != normalized_file {
+                    continue;
+                }
+                let entry = items
+                    .entry(feature.id.clone())
+                    .or_insert_with(|| TracedItemMatch {
+                        item: SearchResult {
+                            id: feature.id.clone(),
+                            kind: "feature",
+                            title: feature.title.clone(),
+                        },
+                        symbols: BTreeSet::new(),
+                    });
+                entry.symbols.extend(reference.symbols.iter().cloned());
+            }
+        }
+    }
+
+    items.into_values().collect()
+}
+
+fn collect_related_inference_items(
+    lookup: &WorkspaceLookup<'_>,
+    direct_items: &[SearchResult],
+) -> Vec<SearchResult> {
+    let mut requirements = BTreeMap::<String, SearchResult>::new();
+    let mut features = BTreeMap::<String, SearchResult>::new();
+    let mut policies = BTreeMap::<String, SearchResult>::new();
+    let mut philosophies = BTreeMap::<String, SearchResult>::new();
+
+    for item in direct_items {
+        match item.kind {
+            "requirement" => {
+                insert_inference_item(&mut requirements, item);
+                if let Some(requirement) = lookup.requirement(&item.id) {
+                    for feature_id in &requirement.linked_features {
+                        insert_inference_lookup_item(
+                            &mut features,
+                            lookup,
+                            LookupKind::Feature,
+                            feature_id,
+                        );
+                    }
+                    collect_inference_requirement_context(
+                        lookup,
+                        requirement,
+                        &mut policies,
+                        &mut philosophies,
+                    );
+                }
+            }
+            "feature" => {
+                insert_inference_item(&mut features, item);
+                if let Some(feature) = lookup.feature(&item.id) {
+                    for requirement_id in &feature.linked_requirements {
+                        insert_inference_lookup_item(
+                            &mut requirements,
+                            lookup,
+                            LookupKind::Requirement,
+                            requirement_id,
+                        );
+                        if let Some(requirement) = lookup.requirement(requirement_id) {
+                            collect_inference_requirement_context(
+                                lookup,
+                                requirement,
+                                &mut policies,
+                                &mut philosophies,
+                            );
+                        }
+                    }
+                }
+            }
+            "policy" => {
+                insert_inference_item(&mut policies, item);
+                if let Some(policy) = lookup.policy(&item.id) {
+                    for philosophy_id in &policy.linked_philosophies {
+                        insert_inference_lookup_item(
+                            &mut philosophies,
+                            lookup,
+                            LookupKind::Philosophy,
+                            philosophy_id,
+                        );
+                    }
+                }
+            }
+            "philosophy" => {
+                insert_inference_item(&mut philosophies, item);
+            }
+            _ => {}
+        }
+    }
+
+    let mut items = requirements
+        .into_values()
+        .chain(features.into_values())
+        .chain(policies.into_values())
+        .chain(philosophies.into_values())
+        .collect::<Vec<_>>();
+    items.sort_by(|a, b| a.id.cmp(&b.id));
+    items
+}
+
+fn insert_inference_item(map: &mut BTreeMap<String, SearchResult>, item: &SearchResult) {
+    map.entry(item.id.clone()).or_insert_with(|| item.clone());
+}
+
+fn insert_inference_lookup_item(
+    map: &mut BTreeMap<String, SearchResult>,
+    lookup: &WorkspaceLookup<'_>,
+    kind: LookupKind,
+    id: &str,
+) {
+    if let Some(title) = lookup.title_for(kind, id) {
+        map.entry(id.to_string()).or_insert_with(|| SearchResult {
+            id: id.to_string(),
+            kind: kind.label(),
+            title: title.to_string(),
+        });
+    }
+}
+
+fn collect_inference_requirement_context(
+    lookup: &WorkspaceLookup<'_>,
+    requirement: &crate::model::Requirement,
+    policies: &mut BTreeMap<String, SearchResult>,
+    philosophies: &mut BTreeMap<String, SearchResult>,
+) {
+    for policy_id in &requirement.linked_policies {
+        insert_inference_lookup_item(policies, lookup, LookupKind::Policy, policy_id);
+        if let Some(policy) = lookup.policy(policy_id) {
+            for philosophy_id in &policy.linked_philosophies {
+                insert_inference_lookup_item(
+                    philosophies,
+                    lookup,
+                    LookupKind::Philosophy,
+                    philosophy_id,
+                );
+            }
+        }
+    }
+}
+
+fn merge_inference_items(left: &[SearchResult], right: &[SearchResult]) -> Vec<SearchResult> {
+    let mut items = BTreeMap::<String, SearchResult>::new();
+    for item in left.iter().chain(right.iter()) {
+        items.insert(item.id.clone(), item.clone());
+    }
+    items.into_values().collect()
+}
+
+fn infer_requirement_action(
+    direct_items: &[SearchResult],
+    related_items: &[SearchResult],
+) -> RequirementAction {
+    if direct_items.is_empty() && related_items.is_empty() {
+        RequirementAction::Create
+    } else {
+        RequirementAction::Change
+    }
+}
+
+fn build_inferred_goal_title(
+    scope: &ScopeOutcome,
+    changed_files: &[PathBuf],
+    lookup: &WorkspaceLookup<'_>,
+) -> String {
+    if let Some(feature) = scope.features.first() {
+        return format!("Extend {}", feature.title);
+    }
+    if let Some(requirement) = scope.requirements.first() {
+        return format!("Update {}", requirement.title);
+    }
+    if let Some(policy) = scope.policies.first() {
+        return format!("Update {}", policy.title);
+    }
+    if let Some(philosophy) = scope.philosophies.first() {
+        return format!("Update {}", philosophy.title);
+    }
+    if let Some(file) = changed_files.first() {
+        let file_label = path_label(file);
+        if let Ok(Some(title)) = infer_title_from_file_path(lookup, &file_label) {
+            return format!("Update {}", title);
+        }
+        return format!("Review diff for {}", file_label);
+    }
+
+    "Review inferred diff".to_string()
+}
+
+fn infer_title_from_file_path(
+    lookup: &WorkspaceLookup<'_>,
+    file_label: &str,
+) -> Result<Option<String>> {
+    for kind in [
+        LookupKind::Philosophy,
+        LookupKind::Policy,
+        LookupKind::Requirement,
+        LookupKind::Feature,
+    ] {
+        for item in lookup.entries_with_document_paths(kind)? {
+            if item.document_path.as_deref() == Some(file_label) {
+                return Ok(Some(item.title));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn build_inferred_goal_statement(
+    scope: &ScopeOutcome,
+    changed_files: &[PathBuf],
+    persistent_items: &JsonTaskPlanPersistentItems,
+    confidence: &'static str,
+) -> String {
+    let file_summary = changed_files
+        .iter()
+        .map(|path| path_label(path.as_path()))
+        .take(5)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let item_summary = summarize_persistent_item_ids(persistent_items);
+
+    if confidence == "low" {
+        format!(
+            "The diff appears to touch {} but the ownership evidence is weak enough that the plan should be reviewed before it is treated as certain.",
+            if item_summary.is_empty() {
+                file_summary
+            } else {
+                format!("{item_summary} and {file_summary}")
+            }
+        )
+    } else {
+        format!(
+            "The diff appears to update {}{}.",
+            if item_summary.is_empty() {
+                file_summary
+            } else {
+                item_summary
+            },
+            if scope.notes.is_empty() {
+                String::new()
+            } else {
+                format!(" with {}", scope.notes.join("; "))
+            }
+        )
+    }
+}
+
+fn summarize_persistent_item_ids(items: &JsonTaskPlanPersistentItems) -> String {
+    let mut ids = Vec::new();
+    ids.extend(items.philosophies.iter().map(|item| item.id.as_str()));
+    ids.extend(items.policies.iter().map(|item| item.id.as_str()));
+    ids.extend(items.requirements.iter().map(|item| item.id.as_str()));
+    ids.extend(items.features.iter().map(|item| item.id.as_str()));
+    ids.join(", ")
+}
+
+fn build_inferred_goal_non_goals(confidence: &'static str) -> Vec<String> {
+    let mut non_goals = vec![
+        "Do not modify persistent spec files.".to_string(),
+        "Do not promote the inferred goal plan into a permanent spec layer.".to_string(),
+    ];
+    if confidence == "low" {
+        non_goals.push(
+            "Do not treat ambiguous or unowned files as settled scope without review.".to_string(),
+        );
+    }
+    non_goals
+}
+
+fn build_inference_reasons(
+    changed_files: &[String],
+    unowned_files: &[String],
+    ambiguous_files: &[String],
+    spec_files: &[String],
+    direct_items: &[SearchResult],
+    related_items: &[SearchResult],
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if !direct_items.is_empty() {
+        reasons.push(format!(
+            "direct trace ownership found for {}",
+            direct_items
+                .iter()
+                .map(|item| format!("{} {}", item.kind, item.id))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !related_items.is_empty() {
+        reasons.push(format!(
+            "related graph context expands to {}",
+            related_items
+                .iter()
+                .map(|item| format!("{} {}", item.kind, item.id))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !unowned_files.is_empty() {
+        reasons.push(format!(
+            "unowned files reduce confidence: {}",
+            unowned_files.join(", ")
+        ));
+    }
+    if !ambiguous_files.is_empty() {
+        reasons.push(format!(
+            "ambiguous ownership reduces confidence: {}",
+            ambiguous_files.join(", ")
+        ));
+    }
+    if !spec_files.is_empty() {
+        reasons.push(format!(
+            "spec files changed directly: {}",
+            spec_files.join(", ")
+        ));
+    }
+    if reasons.is_empty() {
+        reasons.push(format!(
+            "changed files were analyzed from {}",
+            changed_files.join(", ")
+        ));
+    }
+
+    reasons
+}
+
+fn build_inference_notes(
+    unowned_files: &[String],
+    ambiguous_files: &[String],
+    spec_files: &[String],
+) -> Vec<String> {
+    let mut notes = Vec::new();
+    if !unowned_files.is_empty() {
+        notes.push(format!(
+            "no trace ownership was found for {}",
+            unowned_files.join(", ")
+        ));
+    }
+    if !ambiguous_files.is_empty() {
+        notes.push(format!(
+            "ambiguous ownership needs review for {}",
+            ambiguous_files.join(", ")
+        ));
+    }
+    if !spec_files.is_empty() {
+        notes.push(format!(
+            "spec files were included in the diff: {}",
+            spec_files.join(", ")
+        ));
+    }
+    notes
+}
+
+fn build_inference_warnings(
+    confidence: &'static str,
+    unowned_files: &[String],
+    ambiguous_files: &[String],
+    spec_files: &[String],
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if confidence == "low" {
+        if !unowned_files.is_empty() {
+            warnings.push(format!(
+                "Low confidence: no trace ownership was found for {}.",
+                unowned_files.join(", ")
+            ));
+        }
+        if !ambiguous_files.is_empty() {
+            warnings.push(format!(
+                "Low confidence: ambiguous ownership remains for {}.",
+                ambiguous_files.join(", ")
+            ));
+        }
+    } else if confidence == "medium" {
+        if !spec_files.is_empty() {
+            warnings.push(format!(
+                "Medium confidence: spec files changed directly in {}.",
+                spec_files.join(", ")
+            ));
+        }
+        if !ambiguous_files.is_empty() {
+            warnings.push(format!(
+                "Medium confidence: shared or ambiguous ownership was inferred for {}.",
+                ambiguous_files.join(", ")
+            ));
+        }
+    }
+    warnings
+}
+
+fn confidence_for_diff_inference(
+    changed_files: &[String],
+    unowned_files: &[String],
+    ambiguous_files: &[String],
+    spec_files: &[String],
+    scope: &ScopeOutcome,
+) -> &'static str {
+    if !unowned_files.is_empty() {
+        return "low";
+    }
+    if !spec_files.is_empty()
+        || changed_files.len() > 1
+        || changed_files
+            .iter()
+            .any(|file| is_shared_utility_path(Path::new(file)))
+    {
+        return "medium";
+    }
+    if !ambiguous_files.is_empty()
+        && !scope
+            .features
+            .iter()
+            .any(|feature| feature.status.eq_ignore_ascii_case("planned"))
+    {
+        return "low";
+    }
+    "high"
+}
+
+fn is_shared_utility_path(path: &Path) -> bool {
+    let rendered = path_label(path).to_lowercase();
+    rendered.contains("shared")
+        || rendered.contains("common")
+        || rendered.contains("util")
+        || rendered.contains("helper")
+        || rendered.contains("generated")
+}
+
+fn collect_ids_by_kind(items: &[SearchResult]) -> Vec<String> {
+    let mut ids = items.iter().map(|item| item.id.clone()).collect::<Vec<_>>();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn collect_feature_ids(items: &[ScopeFeatureCandidate]) -> Vec<String> {
+    let mut ids = items.iter().map(|item| item.id.clone()).collect::<Vec<_>>();
+    ids.sort();
+    ids.dedup();
+    ids
 }
 
 fn print_plan_item_section(output: &mut String, heading: &str, items: &[JsonTaskPlanItem]) {
@@ -1950,6 +2861,43 @@ fn check_goal_plan(
                         .to_string(),
                 ),
             )),
+        }
+
+        if artifact.goal.inferred != true {
+            issues.push(Issue::warning(
+                "GOAL-TASK-PLAN-012",
+                "goal.inferred",
+                None,
+                "diff-inferred plan goal does not mark itself as inferred",
+                Some(
+                    "Set goal.inferred to true so readers can tell the plan was derived from a diff."
+                        .to_string(),
+                ),
+            ));
+        }
+
+        match artifact.source.evidence.as_ref() {
+            Some(evidence) if evidence.changed_files.is_empty() => issues.push(Issue::error(
+                "GOAL-TASK-PLAN-013",
+                "source.evidence.changed_files",
+                None,
+                "diff-inferred plan does not record any changed files",
+                Some(
+                    "Add the diff's changed files to source.evidence.changed_files so the inferred plan is explainable."
+                        .to_string(),
+                ),
+            )),
+            None => issues.push(Issue::error(
+                "GOAL-TASK-PLAN-013",
+                "source.evidence",
+                None,
+                "diff-inferred plan does not record evidence",
+                Some(
+                    "Add source.evidence with changed files and traced IDs so reviewers can validate the inference."
+                        .to_string(),
+                ),
+            )),
+            _ => {}
         }
     }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -2863,7 +2863,7 @@ fn check_goal_plan(
             )),
         }
 
-        if artifact.goal.inferred != true {
+        if !artifact.goal.inferred {
             issues.push(Issue::warning(
                 "GOAL-TASK-PLAN-012",
                 "goal.inferred",
@@ -4113,8 +4113,13 @@ mod tests {
                 .any(|entry| entry.file.contains("src/command/task.rs"))
         );
 
-        let text =
-            render_goal_plan_output(&request, &plan, TaskPlanFormat::Text).expect("text render");
+        let text = render_goal_plan_output(
+            "request",
+            &request.display().to_string(),
+            &plan,
+            TaskPlanFormat::Text,
+        )
+        .expect("text render");
         assert!(text.contains("kind: syu.goal_plan"));
         assert!(text.contains("goal:"));
         assert!(text.contains("implementation plan:"));
@@ -4122,12 +4127,22 @@ mod tests {
         assert!(text.contains("coverage: changed_lines (threshold 100)"));
         assert!(text.contains("syu task check .syu/tasks/current.yaml --range origin/main...HEAD"));
 
-        let yaml =
-            render_goal_plan_output(&request, &plan, TaskPlanFormat::Yaml).expect("yaml render");
+        let yaml = render_goal_plan_output(
+            "request",
+            &request.display().to_string(),
+            &plan,
+            TaskPlanFormat::Yaml,
+        )
+        .expect("yaml render");
         assert!(yaml.contains("kind: syu.goal_plan"));
 
-        let json =
-            render_goal_plan_output(&request, &plan, TaskPlanFormat::Json).expect("json render");
+        let json = render_goal_plan_output(
+            "request",
+            &request.display().to_string(),
+            &plan,
+            TaskPlanFormat::Json,
+        )
+        .expect("json render");
         assert!(json.contains("\"kind\": \"syu.goal_plan\""));
 
         let output_path = tempdir.path().join(".syu/tasks/current.yaml");

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -798,6 +798,9 @@ pub fn run_task_infer_command(args: &TaskInferArgs) -> Result<i32> {
     }
 
     let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
+    if changed_files.is_empty() {
+        bail!("--range `{range}` does not include any changed files");
+    }
     let plan =
         build_diff_inferred_goal_plan(&workspace, range, &changed_files, args.output.as_deref())?;
     let rendered = render_goal_plan_output("range", range, &plan, args.format)?;
@@ -1133,7 +1136,7 @@ fn build_diff_inferred_goal_plan(
     let inference = infer_diff_plan(workspace, &lookup, range, changed_files)?;
     let persistent_items = collect_task_plan_persistent_items(&lookup, &inference.scope)?;
     let spec_update_reasons = determine_spec_update_reasons(&inference.scope, &persistent_items);
-    let spec_updates_required = !spec_update_reasons.is_empty() || inference.confidence != "high";
+    let spec_updates_required = !spec_update_reasons.is_empty();
     let test_plan = collect_task_plan_tests(&lookup, &persistent_items, &inference.scope)?;
     let mut test_plan = test_plan;
     test_plan.selection_mode = "affected".to_string();

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -146,7 +146,7 @@ fn goal_plan_yaml(
     confidence: &str,
 ) -> String {
     format!(
-        "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: {confidence}\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - {linked_requirement}\n    features:\n      - {linked_feature}\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: {test_file}\n        symbols:\n          - {test_symbol}\n  suggested_tests: {{}}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n"
+        "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: {confidence}\n  evidence:\n    changed_files:\n      - src/command/task.rs\n    traced_requirements:\n      - {linked_requirement}\n    traced_features:\n      - {linked_feature}\n    traced_policies:\n      - POL-001\n    traced_philosophies:\n      - PHIL-001\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  inferred: true\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - {linked_requirement}\n    features:\n      - {linked_feature}\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: {test_file}\n        symbols:\n          - {test_symbol}\n  suggested_tests: {{}}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n"
     )
 }
 
@@ -174,6 +174,126 @@ fn prepare_git_workspace(root: &Path, test_symbol: &str) {
     commit_all(root, "base");
     let base = git_output(root, &["rev-parse", "HEAD"]);
     git(root, &["update-ref", "refs/remotes/origin/main", &base]);
+}
+
+fn write_infer_workspace(root: &Path) {
+    fs::write(
+        root.join("syu.yaml"),
+        "version: 1\nspec:\n  root: docs/syu\n",
+    )
+    .expect("workspace config");
+    fs::create_dir_all(root.join("docs/syu/philosophy")).expect("philosophy dir");
+    fs::create_dir_all(root.join("docs/syu/policies")).expect("policy dir");
+    fs::create_dir_all(root.join("docs/syu/requirements/core")).expect("requirements dir");
+    fs::create_dir_all(root.join("docs/syu/features/core")).expect("features dir");
+    fs::create_dir_all(root.join("src")).expect("src dir");
+    fs::create_dir_all(root.join("tests")).expect("tests dir");
+    fs::create_dir_all(root.join("notes")).expect("notes dir");
+
+    fs::write(
+        root.join("docs/syu/philosophy/foundation.yaml"),
+        "category: Philosophy\nversion: 1\nlanguage: en\nphilosophies:\n  - id: PHIL-INF-001\n    title: Keep diff inference explicit\n    product_design_principle: Inferred plans should cite the files that led to them.\n    coding_guideline: Prefer evidence over guesswork.\n    linked_policies:\n      - POL-INF-001\n",
+    )
+    .expect("philosophy doc");
+    fs::write(
+        root.join("docs/syu/policies/policies.yaml"),
+        "category: Policies\nversion: 1\nlanguage: en\npolicies:\n  - id: POL-INF-001\n    title: Diff inference must stay explainable\n    summary: Inferred Goal Plans should record evidence and confidence.\n    description: The infer command should preserve the changed files and traced IDs that shaped the result.\n    linked_philosophies:\n      - PHIL-INF-001\n    linked_requirements:\n      - REQ-INF-CLEAN\n      - REQ-INF-SHARED\n      - REQ-INF-AMBIG-A\n      - REQ-INF-AMBIG-B\n",
+    )
+    .expect("policy doc");
+
+    fs::write(
+        root.join("docs/syu/requirements/core/clean.yaml"),
+        "category: Core Requirements\nprefix: REQ-INF\nrequirements:\n  - id: REQ-INF-CLEAN\n    title: Infer a clean single-feature diff\n    description: The infer command should resolve one clear feature implementation into a provisional plan.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-INF-001\n    linked_features:\n      - FEAT-INF-CLEAN\n    tests:\n      rust:\n        - file: tests/clean_requirement.rs\n          symbols:\n            - clean_requirement_test\n",
+    )
+    .expect("clean requirement doc");
+    fs::write(
+        root.join("docs/syu/requirements/core/shared.yaml"),
+        "category: Core Requirements\nprefix: REQ-INF\nrequirements:\n  - id: REQ-INF-SHARED\n    title: Infer a shared utility diff\n    description: The infer command should stay explainable when the changed file looks like shared utility code.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-INF-001\n    linked_features:\n      - FEAT-INF-SHARED\n    tests:\n      rust:\n        - file: tests/shared_requirement.rs\n          symbols:\n            - shared_requirement_test\n",
+    )
+    .expect("shared requirement doc");
+    fs::write(
+        root.join("docs/syu/requirements/core/ambiguous-a.yaml"),
+        "category: Core Requirements\nprefix: REQ-INF\nrequirements:\n  - id: REQ-INF-AMBIG-A\n    title: Infer one side of an ambiguous diff\n    description: One feature owner should not claim the entire file when another feature also owns it.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-INF-001\n    linked_features:\n      - FEAT-INF-AMBIG-A\n    tests:\n      rust:\n        - file: tests/ambiguous_a_requirement.rs\n          symbols:\n            - ambiguous_a_requirement_test\n",
+    )
+    .expect("ambiguous requirement A doc");
+    fs::write(
+        root.join("docs/syu/requirements/core/ambiguous-b.yaml"),
+        "category: Core Requirements\nprefix: REQ-INF\nrequirements:\n  - id: REQ-INF-AMBIG-B\n    title: Infer the other side of an ambiguous diff\n    description: Another feature owner should keep the plan low confidence when the file is shared.\n    priority: medium\n    status: implemented\n    linked_policies:\n      - POL-INF-001\n    linked_features:\n      - FEAT-INF-AMBIG-B\n    tests:\n      rust:\n        - file: tests/ambiguous_b_requirement.rs\n          symbols:\n            - ambiguous_b_requirement_test\n",
+    )
+    .expect("ambiguous requirement B doc");
+
+    fs::write(
+        root.join("docs/syu/features/features.yaml"),
+        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: inference\n    file: core/clean.yaml\n  - kind: inference\n    file: core/shared.yaml\n  - kind: inference\n    file: core/ambiguous-a.yaml\n  - kind: inference\n    file: core/ambiguous-b.yaml\n",
+    )
+    .expect("feature registry");
+    fs::write(
+        root.join("docs/syu/features/core/clean.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-CLEAN\n    title: Clean single-feature inference\n    summary: One feature implementation should infer cleanly.\n    status: implemented\n    linked_requirements:\n      - REQ-INF-CLEAN\n    implementations:\n      rust:\n        - file: src/clean.rs\n          symbols:\n            - clean_feature\n",
+    )
+    .expect("clean feature doc");
+    fs::write(
+        root.join("docs/syu/features/core/shared.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-SHARED\n    title: Shared utility inference\n    summary: A shared utility file should still infer a provisional plan, but with lower confidence than a single-purpose feature.\n    status: implemented\n    linked_requirements:\n      - REQ-INF-SHARED\n    implementations:\n      rust:\n        - file: src/shared_util.rs\n          symbols:\n            - shared_helper\n",
+    )
+    .expect("shared feature doc");
+    fs::write(
+        root.join("docs/syu/features/core/ambiguous-a.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-AMBIG-A\n    title: Ambiguous owner A\n    summary: The same file is also owned by another feature.\n    status: implemented\n    linked_requirements:\n      - REQ-INF-AMBIG-A\n    implementations:\n      rust:\n        - file: src/ambiguous.rs\n          symbols:\n            - ambiguous_feature_a\n",
+    )
+    .expect("ambiguous feature A doc");
+    fs::write(
+        root.join("docs/syu/features/core/ambiguous-b.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-AMBIG-B\n    title: Ambiguous owner B\n    summary: The same file is also owned by another feature.\n    status: implemented\n    linked_requirements:\n      - REQ-INF-AMBIG-B\n    implementations:\n      rust:\n        - file: src/ambiguous.rs\n          symbols:\n            - ambiguous_feature_b\n",
+    )
+    .expect("ambiguous feature B doc");
+
+    fs::write(root.join("src/clean.rs"), "pub fn clean_feature() {}\n").expect("clean source");
+    fs::write(
+        root.join("src/shared_util.rs"),
+        "pub fn shared_helper() {}\n",
+    )
+    .expect("shared utility source");
+    fs::write(
+        root.join("src/ambiguous.rs"),
+        "pub fn ambiguous_feature_a() {}\npub fn ambiguous_feature_b() {}\n",
+    )
+    .expect("ambiguous source");
+
+    fs::write(
+        root.join("tests/clean_requirement.rs"),
+        "fn clean_requirement_test() {}\n",
+    )
+    .expect("clean test");
+    fs::write(
+        root.join("tests/shared_requirement.rs"),
+        "fn shared_requirement_test() {}\n",
+    )
+    .expect("shared test");
+    fs::write(
+        root.join("tests/ambiguous_a_requirement.rs"),
+        "fn ambiguous_a_requirement_test() {}\n",
+    )
+    .expect("ambiguous A test");
+    fs::write(
+        root.join("tests/ambiguous_b_requirement.rs"),
+        "fn ambiguous_b_requirement_test() {}\n",
+    )
+    .expect("ambiguous B test");
+
+    init_git_repo(root);
+    commit_all(root, "base");
+    let base = git_output(root, &["rev-parse", "HEAD"]);
+    git(root, &["update-ref", "refs/remotes/origin/main", &base]);
+}
+
+fn run_task_infer(root: &Path, extra_args: &[&str]) -> std::process::Output {
+    let mut command = std::process::Command::cargo_bin("syu").expect("binary should build");
+    command.current_dir(root);
+    let mut args = vec!["task", "infer", "--range", "origin/main...HEAD"];
+    args.extend_from_slice(extra_args);
+    command.args(args);
+    command.output().expect("command should run")
 }
 
 #[test]
@@ -596,6 +716,162 @@ fn task_scaffold_rejects_delete_requests() {
     assert!(!output.status.success(), "delete scaffold should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("only supports request artifacts"));
+}
+
+#[test]
+fn task_infer_reports_high_confidence_for_a_clean_single_feature_diff() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("src/clean.rs"),
+        "pub fn clean_feature() {}\n// cleaned diff\n",
+    )
+    .expect("updated clean source");
+    commit_all(tempdir.path(), "update clean feature");
+
+    let output = run_task_infer(tempdir.path(), &[]);
+    assert!(output.status.success(), "task infer should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("mode: diff_inferred"));
+    assert!(stdout.contains("confidence: high"));
+    assert!(stdout.contains("inferred: true"));
+    assert!(stdout.contains("changed_files"));
+    assert!(stdout.contains("src/clean.rs"));
+    assert!(stdout.contains("FEAT-INF-CLEAN"));
+    assert!(stdout.contains("REQ-INF-CLEAN"));
+}
+
+#[test]
+fn task_infer_reports_medium_confidence_for_shared_utility_diffs() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("src/shared_util.rs"),
+        "pub fn shared_helper() {}\n// shared diff\n",
+    )
+    .expect("updated shared utility source");
+    commit_all(tempdir.path(), "update shared utility");
+
+    let output = run_task_infer(tempdir.path(), &[]);
+    assert!(output.status.success(), "task infer should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("confidence: medium"));
+    assert!(stdout.contains("src/shared_util.rs"));
+    assert!(stdout.contains("FEAT-INF-SHARED"));
+}
+
+#[test]
+fn task_infer_reports_low_confidence_for_unmapped_files() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(tempdir.path().join("notes/random.txt"), "unmapped change\n").expect("note");
+    commit_all(tempdir.path(), "add unmapped file");
+
+    let output = run_task_infer(tempdir.path(), &["--format", "json"]);
+    assert!(output.status.success(), "task infer should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"confidence\": \"low\""));
+    assert!(stdout.contains("\"changed_files\": ["));
+    assert!(stdout.contains("notes/random.txt"));
+    assert!(stdout.contains("no trace ownership was found"));
+}
+
+#[test]
+fn task_infer_reports_low_confidence_for_ambiguous_ownership() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("src/ambiguous.rs"),
+        "pub fn ambiguous_feature_a() {}\npub fn ambiguous_feature_b() {}\n// ambiguous diff\n",
+    )
+    .expect("updated ambiguous source");
+    commit_all(tempdir.path(), "update ambiguous file");
+
+    let output = run_task_infer(tempdir.path(), &["--format", "json"]);
+    assert!(output.status.success(), "task infer should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"confidence\": \"low\""));
+    assert!(stdout.contains("\"FEAT-INF-AMBIG-A\""));
+    assert!(stdout.contains("\"FEAT-INF-AMBIG-B\""));
+    assert!(stdout.contains("ambiguous ownership"));
+}
+
+#[test]
+fn task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("docs/syu/features/core/clean.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-CLEAN\n    title: Clean single-feature inference\n    summary: Updated feature spec only.\n    status: implemented\n    linked_requirements:\n      - REQ-INF-CLEAN\n    implementations:\n      rust:\n        - file: src/clean.rs\n          symbols:\n            - clean_feature\n",
+    )
+    .expect("updated clean feature doc");
+    commit_all(tempdir.path(), "update spec only");
+
+    let spec_only = run_task_infer(tempdir.path(), &[]);
+    assert!(spec_only.status.success(), "task infer should succeed");
+    let spec_stdout = String::from_utf8_lossy(&spec_only.stdout);
+    assert!(spec_stdout.contains("confidence: medium"));
+    assert!(spec_stdout.contains("docs/syu/features/core/clean.yaml"));
+
+    fs::write(
+        tempdir.path().join("src/clean.rs"),
+        "pub fn clean_feature() {}\n// mixed diff\n",
+    )
+    .expect("updated clean source");
+    commit_all(tempdir.path(), "update implementation too");
+
+    let mixed = run_task_infer(tempdir.path(), &[]);
+    assert!(mixed.status.success(), "task infer should succeed");
+    let mixed_stdout = String::from_utf8_lossy(&mixed.stdout);
+    assert!(mixed_stdout.contains("confidence: medium"));
+    assert!(mixed_stdout.contains("docs/syu/features/core/clean.yaml"));
+    assert!(mixed_stdout.contains("src/clean.rs"));
+}
+
+#[test]
+fn task_infer_is_deterministic_for_json_and_yaml_outputs() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("src/clean.rs"),
+        "pub fn clean_feature() {}\n// determinism diff\n",
+    )
+    .expect("updated clean source");
+    commit_all(tempdir.path(), "update clean feature for determinism");
+
+    let json_one = run_task_infer(tempdir.path(), &["--format", "json"]);
+    let json_two = run_task_infer(tempdir.path(), &["--format", "json"]);
+    assert!(json_one.status.success(), "first JSON infer should succeed");
+    assert!(
+        json_two.status.success(),
+        "second JSON infer should succeed"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&json_one.stdout),
+        String::from_utf8_lossy(&json_two.stdout)
+    );
+
+    let yaml_one = run_task_infer(tempdir.path(), &["--format", "yaml"]);
+    let yaml_two = run_task_infer(tempdir.path(), &["--format", "yaml"]);
+    assert!(yaml_one.status.success(), "first YAML infer should succeed");
+    assert!(
+        yaml_two.status.success(),
+        "second YAML infer should succeed"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&yaml_one.stdout),
+        String::from_utf8_lossy(&yaml_two.stdout)
+    );
 }
 
 #[test]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -744,6 +744,21 @@ fn task_infer_reports_high_confidence_for_a_clean_single_feature_diff() {
 }
 
 #[test]
+fn task_infer_rejects_empty_diffs() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    let output = run_task_infer(tempdir.path(), &[]);
+    assert!(
+        !output.status.success(),
+        "task infer should fail for empty diffs"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("does not include any changed files"));
+}
+
+#[test]
 fn task_infer_reports_medium_confidence_for_shared_utility_diffs() {
     let tempdir = tempdir().expect("tempdir");
     write_infer_workspace(tempdir.path());
@@ -762,6 +777,41 @@ fn task_infer_reports_medium_confidence_for_shared_utility_diffs() {
     assert!(stdout.contains("confidence: medium"));
     assert!(stdout.contains("src/shared_util.rs"));
     assert!(stdout.contains("FEAT-INF-SHARED"));
+}
+
+#[test]
+fn task_infer_keeps_spec_updates_optional_for_medium_confidence_planned_features() {
+    let tempdir = tempdir().expect("tempdir");
+    write_infer_workspace(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("docs/syu/features/core/shared.yaml"),
+        "category: Core Features\nversion: 1\nfeatures:\n  - id: FEAT-INF-SHARED\n    title: Shared utility inference\n    summary: A shared utility file should still infer a provisional plan, but with lower confidence than a single-purpose feature.\n    status: planned\n    linked_requirements:\n      - REQ-INF-SHARED\n    implementations:\n      rust:\n        - file: src/shared_util.rs\n          symbols:\n            - shared_helper\n",
+    )
+    .expect("updated shared feature doc");
+    commit_all(tempdir.path(), "plan shared utility feature");
+    let planned_base = git_output(tempdir.path(), &["rev-parse", "HEAD"]);
+    git(
+        tempdir.path(),
+        &["update-ref", "refs/remotes/origin/main", &planned_base],
+    );
+
+    fs::write(
+        tempdir.path().join("src/shared_util.rs"),
+        "pub fn shared_helper() {}\n// shared diff\n",
+    )
+    .expect("updated shared utility source");
+    commit_all(tempdir.path(), "update planned shared utility");
+
+    let output = run_task_infer(tempdir.path(), &[]);
+    assert!(output.status.success(), "task infer should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("confidence: medium"));
+    assert!(
+        stdout.contains("spec_updates_required: false"),
+        "stdout was:\n{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Added `syu task infer` to derive provisional Goal Plans from a git diff.
- Extended Goal Plan serialization and validation for diff-inferred evidence, confidence, and inferred goals.
- Documented the new workflow in the command card and planning guides.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test task_command task_infer_ -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test task_command goal_plan_ -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test --test task_command`

Closes #704
