### PR TITLE
Surface generated-docs freshness before queueing PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,9 @@ dependency installs, and Playwright browser readiness for this checkout.
    cargo run -- validate .
    ```
 
-   `scripts/ci/quality-gates.sh fast` keeps the local pre-push path short.
-   The full gate also checks that the committed `docs/generated/` artifacts
-   are fresh and generates the repository report:
+   `scripts/ci/quality-gates.sh fast` keeps the local pre-push path short and
+   now catches stale `docs/generated/` artifacts before you queue a push. The
+   full gate adds the repository report:
 
    ```bash
    scripts/ci/quality-gates.sh full

--- a/scripts/ci/quality-gates.sh
+++ b/scripts/ci/quality-gates.sh
@@ -13,6 +13,7 @@ run_quality_gates() {
   cargo fmt --all --check
   cargo clippy --all-targets --all-features -- -D warnings
   cargo run -- validate .
+  bash scripts/ci/check-generated-docs-freshness.sh
 
   case "$mode" in
     fast)
@@ -21,7 +22,6 @@ run_quality_gates() {
       ;;
     full)
       cargo test
-      bash scripts/ci/check-generated-docs-freshness.sh
 
       mkdir -p target/quality
       cargo run -- report . --output target/quality/syu-report.md >/dev/null


### PR DESCRIPTION
Summary:
- Run generated-doc freshness checks in the fast quality gate so stale `docs/generated/` output fails before pre-push or PR queueing.
- Update the contributor guide to match the new validation path.

Validation:
- `bash -n scripts/ci/quality-gates.sh`
- `bash -n scripts/ci/check-generated-docs-freshness.sh`
- `cargo test --test repository_quality repository_declares_precommit_and_quality_gates`
- `bash scripts/ci/check-generated-docs-freshness.sh`

Closes #723
