### PR TITLE
Add Goal Plan test selection

### DIFF
--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -158,13 +158,41 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - dispatch
           - run_dispatch
-    - **markdown**:
+  - **markdown**:
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan
       - **file**: docs/guide/command-card.md
         - **symbols**:
           - syu task check goal-plan.yaml --range origin/main...HEAD
+- **id**: FEAT-TASK-006
+  - **title**: Goal Plan test selection
+  - **summary**: Turn Goal Plan test declarations into justified shell commands for CI before scoped coverage runs.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-033
+  - **implementations**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - run_task_command
+          - run_task_test_select_command
+          - build_task_test_selection
+      - **file**: src/cli.rs
+        - **symbols**:
+          - TaskArgs
+          - TaskTestSelectArgs
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatch
+          - run_dispatch
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task test-select goal-plan.yaml
 
 ## Source YAML
 
@@ -321,4 +349,32 @@ features:
         - file: docs/guide/command-card.md
           symbols:
             - syu task check goal-plan.yaml --range origin/main...HEAD
+  - id: FEAT-TASK-006
+    title: Goal Plan test selection
+    summary: Turn Goal Plan test declarations into justified shell commands for CI before scoped coverage runs.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-033
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_test_select_command
+            - build_task_test_selection
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskTestSelectArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task test-select goal-plan.yaml
 ```

--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -158,7 +158,7 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - dispatch
           - run_dispatch
-  - **markdown**:
+    - **markdown**:
       - **file**: docs/guide/goal-plan-format.md
         - **symbols**:
           - syu.goal_plan

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -48,6 +48,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-030
     - REQ-CORE-031
     - REQ-CORE-032
+    - REQ-CORE-033
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -136,6 +137,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-030
     - REQ-CORE-031
     - REQ-CORE-032
+    - REQ-CORE-033
 - **id**: POL-005
   - **title**: Documentation and examples must lower adoption friction
   - **summary**: Guides, reports, sites, and examples are part of the product surface.

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -244,6 +244,7 @@ policies:
       - REQ-CORE-030
       - REQ-CORE-031
       - REQ-CORE-032
+      - REQ-CORE-033
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -332,6 +333,7 @@ policies:
       - REQ-CORE-030
       - REQ-CORE-031
       - REQ-CORE-032
+      - REQ-CORE-033
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -861,6 +861,78 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: docs/guide/command-card.md
         - **symbols**:
           - syu task check goal-plan.yaml --range origin/main...HEAD
+- **id**: REQ-CORE-033
+  - **title**: Select tests from a Goal Plan before scoped coverage runs
+  - **description**:
+    - |
+      The CLI MUST provide a `task test-select` command that reads a temporary
+      Goal Plan and turns the required, suggested, and linked Rust test
+      declarations into justified shell commands before scoped coverage or CI
+      runs. The command SHOULD support text and JSON output, SHOULD explain why
+      each selected test was chosen, SHOULD broaden to affected file-level Rust
+      test binaries when the Goal Plan confidence is medium or when shared
+      utilities are changed, and SHOULD fall back to a broader Rust test
+      selection when the Goal Plan does not declare enough test information.
+      The command MUST reject non-Rust languages until additional adapters are
+      implemented, and the test-selection schema MUST stay language-aware so
+      future Python, TypeScript, Go, Java, Ruby, and other adapters can be
+      added later without changing the artifact shape.
+  - **priority**: medium
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+    - POL-004
+  - **linked_features**:
+    - FEAT-TASK-006
+  - **tests**:
+    - **rust**:
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - TaskTestSelectionPlan
+          - TaskTestSelectionCommand
+          - TaskTestSelectionEscalation
+          - build_task_test_selection
+          - collect_goal_plan_test_references
+          - collect_linked_requirement_tests
+          - add_task_test_selection_reference
+          - validate_goal_test_language
+          - count_task_test_selection_entries
+          - build_task_test_selection_commands
+          - format_task_test_selection_reason
+          - join_task_test_selection_reasons
+          - goal_plan_selection_mode_label
+          - rust_test_target_name
+          - goal_plan_mentions_shared_utilities
+          - goal_plan_scope_is_ambiguous
+          - print_task_test_selection_text_output
+      - **file**: src/cli.rs
+        - **symbols**:
+          - TaskArgs
+          - TaskTestSelectArgs
+      - **file**: src/lib.rs
+        - **symbols**:
+          - dispatch
+          - run_dispatch
+          - dispatches_task_subcommands_without_rewriting_them
+      - **file**: tests/task_command.rs
+        - **symbols**:
+          - task_test_select_prints_required_test_commands
+          - task_test_select_prints_suggested_acceptance_checks
+          - task_test_select_includes_linked_feature_tests
+          - task_test_select_broadens_to_file_level_commands_for_medium_confidence
+          - task_test_select_falls_back_when_no_test_declarations_exist
+          - task_test_select_rejects_unknown_language_adapters
+          - task_test_select_is_deterministic_for_json_output
+      - **file**: tests/help_command.rs
+        - **symbols**:
+          - task_test_select_help_mentions_goal_plans_and_json_output
+    - **markdown**:
+      - **file**: docs/guide/goal-plan-format.md
+        - **symbols**:
+          - syu.goal_plan
+      - **file**: docs/guide/command-card.md
+        - **symbols**:
+          - syu task test-select goal-plan.yaml
 
 ## Source YAML
 
@@ -1694,4 +1766,75 @@ requirements:
         - file: docs/guide/command-card.md
           symbols:
             - syu task check goal-plan.yaml --range origin/main...HEAD
+  - id: REQ-CORE-033
+    title: Select tests from a Goal Plan before scoped coverage runs
+    description: |
+      The CLI MUST provide a `task test-select` command that reads a temporary
+      Goal Plan and turns the required, suggested, and linked Rust test
+      declarations into justified shell commands before scoped coverage or CI
+      runs. The command SHOULD support text and JSON output, SHOULD explain why
+      each selected test was chosen, SHOULD broaden to affected file-level Rust
+      test binaries when the Goal Plan confidence is medium or when shared
+      utilities are changed, and SHOULD fall back to a broader Rust test
+      selection when the Goal Plan does not declare enough test information.
+      The command MUST reject non-Rust languages until additional adapters are
+      implemented, and the test-selection schema MUST stay language-aware so
+      future Python, TypeScript, Go, Java, Ruby, and other adapters can be
+      added later without changing the artifact shape.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-004
+    linked_features:
+      - FEAT-TASK-006
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - TaskTestSelectionPlan
+            - TaskTestSelectionCommand
+            - TaskTestSelectionEscalation
+            - build_task_test_selection
+            - collect_goal_plan_test_references
+            - collect_linked_requirement_tests
+            - add_task_test_selection_reference
+            - validate_goal_test_language
+            - count_task_test_selection_entries
+            - build_task_test_selection_commands
+            - format_task_test_selection_reason
+            - join_task_test_selection_reasons
+            - goal_plan_selection_mode_label
+            - rust_test_target_name
+            - goal_plan_mentions_shared_utilities
+            - goal_plan_scope_is_ambiguous
+            - print_task_test_selection_text_output
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskTestSelectArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: tests/task_command.rs
+          symbols:
+            - task_test_select_prints_required_test_commands
+            - task_test_select_prints_suggested_acceptance_checks
+            - task_test_select_includes_linked_feature_tests
+            - task_test_select_broadens_to_file_level_commands_for_medium_confidence
+            - task_test_select_falls_back_when_no_test_declarations_exist
+            - task_test_select_rejects_unknown_language_adapters
+            - task_test_select_is_deterministic_for_json_output
+        - file: tests/help_command.rs
+          symbols:
+            - task_test_select_help_mentions_goal_plans_and_json_output
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task test-select goal-plan.yaml
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 8
-- Requirements: 32
-- Features: 40
+- Requirements: 33
+- Features: 41
 
 ## Traceability
 
-- Requirement-to-test traceability: 158/158
-- Feature-to-implementation traceability: 165/165
+- Requirement-to-test traceability: 165/165
+- Feature-to-implementation traceability: 170/170
 
 ## Issues
 

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -30,6 +30,7 @@ If a pull request already exists, pair this page with the
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
 | Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
 | Infer a goal plan from a diff | `syu task infer --range origin/main...HEAD` | derive a provisional Goal Plan from changed files, traced owners, evidence, and confidence before review |
+| Select tests from a goal plan | `syu task test-select goal-plan.yaml` | turn a temporary Goal Plan into justified Rust test commands before scoped coverage or CI runs |
 | Check a temporary goal plan | `syu task check goal-plan.yaml --range origin/main...HEAD` | validate a temporary Goal Plan against the changed files, linked spec IDs, required tests, and completion commands before review |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -96,6 +96,8 @@ syu task scaffold request.yaml
 ```
 
 Use `syu task plan` when you need the temporary Goal Plan artifact itself.
+Use `syu task test-select` when you already have a Goal Plan and want the
+smallest defensible test command set before scoped coverage or CI runs.
 Use `syu task infer --range origin/main...HEAD` when implementation already
 exists and you want a provisional Goal Plan inferred from the changed files,
 their traced owners, and the current graph.
@@ -114,6 +116,7 @@ the concrete files and run validation:
 ```bash
 syu trace src/command/check.rs --symbol run_check_command
 syu log FEAT-CHECK-001 --kind implementation --path src/command
+syu task test-select goal-plan.yaml
 syu validate .
 ```
 

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -150,3 +150,31 @@ features:
         - file: docs/guide/command-card.md
           symbols:
             - syu task check goal-plan.yaml --range origin/main...HEAD
+  - id: FEAT-TASK-006
+    title: Goal Plan test selection
+    summary: Turn Goal Plan test declarations into justified shell commands for CI before scoped coverage runs.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-033
+    implementations:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - run_task_command
+            - run_task_test_select_command
+            - build_task_test_selection
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskTestSelectArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task test-select goal-plan.yaml

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -29,6 +29,7 @@ policies:
       - REQ-CORE-030
       - REQ-CORE-031
       - REQ-CORE-032
+      - REQ-CORE-033
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing
@@ -117,6 +118,7 @@ policies:
       - REQ-CORE-030
       - REQ-CORE-031
       - REQ-CORE-032
+      - REQ-CORE-033
 
   - id: POL-005
     title: Documentation and examples must lower adoption friction

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -827,3 +827,74 @@ requirements:
         - file: docs/guide/command-card.md
           symbols:
             - syu task check goal-plan.yaml --range origin/main...HEAD
+  - id: REQ-CORE-033
+    title: Select tests from a Goal Plan before scoped coverage runs
+    description: |
+      The CLI MUST provide a `task test-select` command that reads a temporary
+      Goal Plan and turns the required, suggested, and linked Rust test
+      declarations into justified shell commands before scoped coverage or CI
+      runs. The command SHOULD support text and JSON output, SHOULD explain why
+      each selected test was chosen, SHOULD broaden to affected file-level Rust
+      test binaries when the Goal Plan confidence is medium or when shared
+      utilities are changed, and SHOULD fall back to a broader Rust test
+      selection when the Goal Plan does not declare enough test information.
+      The command MUST reject non-Rust languages until additional adapters are
+      implemented, and the test-selection schema MUST stay language-aware so
+      future Python, TypeScript, Go, Java, Ruby, and other adapters can be
+      added later without changing the artifact shape.
+    priority: medium
+    status: implemented
+    linked_policies:
+      - POL-001
+      - POL-004
+    linked_features:
+      - FEAT-TASK-006
+    tests:
+      rust:
+        - file: src/command/task.rs
+          symbols:
+            - TaskTestSelectionPlan
+            - TaskTestSelectionCommand
+            - TaskTestSelectionEscalation
+            - build_task_test_selection
+            - collect_goal_plan_test_references
+            - collect_linked_requirement_tests
+            - add_task_test_selection_reference
+            - validate_goal_test_language
+            - count_task_test_selection_entries
+            - build_task_test_selection_commands
+            - format_task_test_selection_reason
+            - join_task_test_selection_reasons
+            - goal_plan_selection_mode_label
+            - rust_test_target_name
+            - goal_plan_mentions_shared_utilities
+            - goal_plan_scope_is_ambiguous
+            - print_task_test_selection_text_output
+        - file: src/cli.rs
+          symbols:
+            - TaskArgs
+            - TaskTestSelectArgs
+        - file: src/lib.rs
+          symbols:
+            - dispatch
+            - run_dispatch
+            - dispatches_task_subcommands_without_rewriting_them
+        - file: tests/task_command.rs
+          symbols:
+            - task_test_select_prints_required_test_commands
+            - task_test_select_prints_suggested_acceptance_checks
+            - task_test_select_includes_linked_feature_tests
+            - task_test_select_broadens_to_file_level_commands_for_medium_confidence
+            - task_test_select_falls_back_when_no_test_declarations_exist
+            - task_test_select_rejects_unknown_language_adapters
+            - task_test_select_is_deterministic_for_json_output
+        - file: tests/help_command.rs
+          symbols:
+            - task_test_select_help_mentions_goal_plans_and_json_output
+      markdown:
+        - file: docs/guide/goal-plan-format.md
+          symbols:
+            - syu.goal_plan
+        - file: docs/guide/command-card.md
+          symbols:
+            - syu task test-select goal-plan.yaml

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,8 +43,9 @@ New here?
   8. syu task scope request.yaml      map a request artifact onto the current spec graph
   9. syu task scaffold request.yaml   preview planned requirement and feature updates from a request artifact
  10. syu task plan request.yaml      generate a temporary Goal Plan from a request artifact
- 11. syu task infer --range ...      infer a provisional Goal Plan from a git diff
- 12. syu task check goal-plan.yaml   validate a Goal Plan against a git range and the current spec graph";
+ 11. syu task test-select goal-plan.yaml select tests from a Goal Plan before scoped coverage runs
+ 12. syu task infer --range ...      infer a provisional Goal Plan from a git diff
+ 13. syu task check goal-plan.yaml   validate a Goal Plan against a git range and the current spec graph";
 
 const APP_AFTER_HELP: &str = concat!(
     "After startup, open the printed URL in your browser.\n",
@@ -110,6 +111,13 @@ Examples:
 
 Use this when a scoped request is ready to become a temporary Goal Plan that stays outside the persistent spec tree while still mapping the request to existing philosophy, policy, requirement, and feature items.";
 
+const TASK_TEST_SELECT_AFTER_HELP: &str = "\
+Examples:
+  syu task test-select goal-plan.yaml
+  syu task test-select goal-plan.yaml --format json
+
+Use this when you already have a Goal Plan and want a justified test selection plan with shell commands before scoped coverage or CI runs.";
+
 const TASK_INFER_AFTER_HELP: &str = "\
 Examples:
   syu task infer --range origin/main...HEAD
@@ -138,6 +146,7 @@ Examples:
   syu task scope request.yaml
   syu task scaffold request.yaml
   syu task plan request.yaml --output .syu/tasks/current.yaml
+  syu task test-select goal-plan.yaml
   syu task infer --range origin/main...HEAD --output target/syu/inferred-goal.yaml
   syu task check .syu/tasks/current.yaml --range origin/main...HEAD
   syu task check target/syu/inferred-goal.yaml --range origin/main...HEAD --format json";
@@ -338,7 +347,7 @@ pub enum Commands {
     )]
     Completion(CompletionArgs),
     #[command(
-        about = "Classify, scope, scaffold, plan, or check request-driven task planning work",
+        about = "Classify, scope, scaffold, plan, select tests, infer, or check request-driven task planning work",
         after_help = TASK_AFTER_HELP
     )]
     Task(TaskArgs),
@@ -837,6 +846,11 @@ pub enum TaskCommands {
     )]
     Plan(TaskPlanArgs),
     #[command(
+        about = "Select a justified test plan from a Goal Plan",
+        after_help = TASK_TEST_SELECT_AFTER_HELP
+    )]
+    TestSelect(TaskTestSelectArgs),
+    #[command(
         about = "Infer a provisional Goal Plan from a git diff",
         after_help = TASK_INFER_AFTER_HELP
     )]
@@ -897,6 +911,20 @@ pub struct TaskPlanArgs {
     #[arg(help = "Output format for the Goal Plan artifact or summary")]
     #[arg(long, value_enum, default_value_t = TaskPlanFormat::Text)]
     pub format: TaskPlanFormat,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TaskTestSelectArgs {
+    #[arg(help = "Goal Plan artifact to turn into a test selection plan")]
+    pub plan: PathBuf,
+
+    #[arg(help = WORKSPACE_HELP)]
+    #[arg(default_value = ".")]
+    pub workspace: PathBuf,
+
+    #[arg(help = "Output format for the test selection plan")]
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -1070,7 +1098,7 @@ mod tests {
     use super::{
         Cli, CompletionArgs, LookupKind, StarterTemplate, TaskArgs, TaskCheckArgs,
         TaskClassifyArgs, TaskCommands, TaskPlanArgs, TaskScaffoldArgs, TaskScopeArgs,
-        ValidationGenreFilter, ValidationSeverityFilter,
+        TaskTestSelectArgs, ValidationGenreFilter, ValidationSeverityFilter,
     };
     use crate::command::init::{starter_template_example_commands, starter_template_names};
     use clap::Parser;
@@ -1224,6 +1252,33 @@ mod tests {
                 && workspace == std::path::Path::new(".")
                 && output.as_deref() == Some(std::path::Path::new(".syu/tasks/current.yaml"))
                 && format == super::TaskPlanFormat::Yaml
+        ));
+    }
+
+    #[test]
+    fn task_test_select_args_parse_goal_plan_paths_and_json_format() {
+        let cli = Cli::try_parse_from([
+            "syu",
+            "task",
+            "test-select",
+            "goal-plan.yaml",
+            ".",
+            "--format",
+            "json",
+        ])
+        .expect("task test-select args should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(super::Commands::Task(TaskArgs {
+                command: TaskCommands::TestSelect(TaskTestSelectArgs {
+                    plan,
+                    workspace,
+                    format,
+                }),
+            })) if plan == std::path::Path::new("goal-plan.yaml")
+                && workspace == std::path::Path::new(".")
+                && format == super::OutputFormat::Json
         ));
     }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1155,7 +1155,7 @@ fn collect_goal_plan_test_references(
                 language,
                 reference,
                 source_label.to_string(),
-            );
+            )?;
         }
     }
 
@@ -1204,33 +1204,37 @@ fn add_task_test_selection_reference(
     language: &str,
     reference: &crate::model::TraceReference,
     reason: String,
-) {
+) -> Result<()> {
     let file = normalize_relative_path(&reference.file)
         .display()
         .to_string();
     let entry = selected
         .entry(language.to_string())
         .or_default()
-        .entry(file)
+        .entry(file.clone())
         .or_default();
     entry.reasons.insert(reason);
 
-    if reference
-        .symbols
-        .iter()
-        .any(|symbol| matches!(symbol.trim(), "" | "*"))
-    {
+    if reference.symbols.iter().any(|symbol| symbol.trim() == "*") {
         entry.whole_file = true;
         entry.symbols.clear();
-        return;
+        return Ok(());
     }
 
+    let mut has_symbol = false;
     for symbol in &reference.symbols {
         let symbol = symbol.trim();
         if !symbol.is_empty() {
             entry.symbols.insert(symbol.to_string());
+            has_symbol = true;
         }
     }
+
+    if !has_symbol {
+        bail!("Goal Plan test selection for `{file}` must declare at least one symbol or `*`");
+    }
+
+    Ok(())
 }
 
 fn validate_goal_test_language(language: &str) -> Result<()> {
@@ -1256,7 +1260,7 @@ fn count_task_test_selection_entries(
             entries
                 .values()
                 .map(|entry| {
-                    if entry.whole_file || entry.symbols.is_empty() {
+                    if entry.whole_file {
                         1
                     } else {
                         entry.symbols.len()
@@ -1280,7 +1284,7 @@ fn build_task_test_selection_commands(
         for (file, entry) in files {
             let reason = format_task_test_selection_reason(&entry.reasons);
             let target = rust_test_target_name(file);
-            if broaden_to_file || entry.whole_file || entry.symbols.is_empty() {
+            if broaden_to_file || entry.whole_file {
                 commands.push(TaskTestSelectionCommand {
                     language: language.clone(),
                     command: format!("cargo test --test {target}"),
@@ -1373,7 +1377,12 @@ fn goal_plan_scope_is_ambiguous(scope: &GoalPlanScope) -> bool {
             || trimmed.contains("**")
             || trimmed.ends_with('/')
             || trimmed.contains('{')
+            || scope_pattern_has_glob_metacharacters(trimmed)
     })
+}
+
+fn scope_pattern_has_glob_metacharacters(pattern: &str) -> bool {
+    pattern.chars().any(|c| matches!(c, '*' | '?' | '['))
 }
 
 fn print_task_test_selection_text_output(plan_path: &Path, selection: &TaskTestSelectionPlan) {
@@ -4680,6 +4689,39 @@ mod tests {
             plan.warnings
                 .iter()
                 .any(|warning| warning.contains("No implementation scope could be inferred"))
+        );
+    }
+
+    #[test]
+    fn goal_plan_scope_treats_common_globs_as_ambiguous() {
+        let scope = super::GoalPlanScope {
+            include: vec!["src/*.rs".to_string(), "tests/?*.rs".to_string()],
+            exclude: Vec::new(),
+        };
+
+        assert!(super::goal_plan_scope_is_ambiguous(&scope));
+    }
+
+    #[test]
+    fn task_test_select_rejects_empty_symbol_lists() {
+        let tempdir = tempdir().expect("tempdir");
+        write_workspace(tempdir.path());
+        let path = tempdir.path().join("goal-plan.yaml");
+        fs::write(
+            &path,
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: src/command/task.rs\n        symbols: []\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n",
+        )
+        .expect("goal plan");
+
+        let workspace = crate::workspace::load_workspace(tempdir.path()).expect("workspace");
+        let artifact = load_goal_plan_artifact(&path).expect("goal plan should load");
+        let error =
+            super::build_task_test_selection(&workspace, &artifact).expect_err("empty symbols");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must declare at least one symbol or `*`")
         );
     }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1172,7 +1172,7 @@ fn collect_linked_requirement_tests(
         .persistent_items
         .requirements
         .iter()
-        .filter_map(|item| lookup.requirement(&item))
+        .filter_map(|item| lookup.requirement(item))
     {
         let label = format!("declared by linked requirement {}", requirement.id);
         collect_goal_plan_test_references(lookup, &label, &requirement.tests, selected)?;
@@ -1183,7 +1183,7 @@ fn collect_linked_requirement_tests(
         .persistent_items
         .features
         .iter()
-        .filter_map(|item| lookup.feature(&item))
+        .filter_map(|item| lookup.feature(item))
     {
         for requirement_id in &feature.linked_requirements {
             if let Some(requirement) = lookup.requirement(requirement_id) {

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -22,6 +22,7 @@ use crate::{
     cli::{
         LookupKind, OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands,
         TaskInferArgs, TaskPlanArgs, TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs,
+        TaskTestSelectArgs,
     },
     coverage::normalize_relative_path,
     language::adapter_for_language,
@@ -321,6 +322,29 @@ struct JsonTaskCheckOutput {
 }
 
 #[derive(Debug, Serialize)]
+struct JsonTaskTestSelectOutput {
+    goal_id: String,
+    goal_title: String,
+    selection_mode: String,
+    commands: Vec<JsonTaskTestSelectCommand>,
+    escalation: JsonTaskTestSelectEscalation,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskTestSelectCommand {
+    language: String,
+    command: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonTaskTestSelectEscalation {
+    level: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
 struct JsonTaskPlanOutput {
     version: u32,
     kind: String,
@@ -540,6 +564,36 @@ struct DiffInferenceOutcome {
 }
 
 #[derive(Debug)]
+struct TaskTestSelectionPlan {
+    goal_id: String,
+    goal_title: String,
+    selection_mode: String,
+    commands: Vec<TaskTestSelectionCommand>,
+    escalation: TaskTestSelectionEscalation,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+struct TaskTestSelectionCommand {
+    language: String,
+    command: String,
+    reason: String,
+}
+
+#[derive(Debug)]
+struct TaskTestSelectionEscalation {
+    level: String,
+    reason: String,
+}
+
+#[derive(Debug, Default)]
+struct TaskTestSelectionEntry {
+    symbols: BTreeSet<String>,
+    reasons: BTreeSet<String>,
+    whole_file: bool,
+}
+
+#[derive(Debug)]
 struct ScaffoldUpdate {
     kind: ScaffoldUpdateKind,
     action: ScaffoldAction,
@@ -587,6 +641,7 @@ pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
         TaskCommands::Classify(classify) => run_task_classify_command(classify),
         TaskCommands::Scope(scope) => run_task_scope_command(scope),
         TaskCommands::Plan(plan) => run_task_plan_command(plan),
+        TaskCommands::TestSelect(select) => run_task_test_select_command(select),
         TaskCommands::Infer(infer) => run_task_infer_command(infer),
         TaskCommands::Scaffold(scaffold) => run_task_scaffold_command(scaffold),
         TaskCommands::Check(check) => run_task_check_command(check),
@@ -790,6 +845,41 @@ pub fn run_task_plan_command(args: &TaskPlanArgs) -> Result<i32> {
     Ok(0)
 }
 
+pub fn run_task_test_select_command(args: &TaskTestSelectArgs) -> Result<i32> {
+    let workspace = load_workspace(&args.workspace)?;
+    let artifact = load_goal_plan_artifact(&args.plan)?;
+    let selection = build_task_test_selection(&workspace, &artifact)?;
+
+    match args.format {
+        OutputFormat::Text => print_task_test_selection_text_output(&args.plan, &selection),
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&JsonTaskTestSelectOutput {
+                goal_id: selection.goal_id,
+                goal_title: selection.goal_title,
+                selection_mode: selection.selection_mode,
+                commands: selection
+                    .commands
+                    .into_iter()
+                    .map(|command| JsonTaskTestSelectCommand {
+                        language: command.language,
+                        command: command.command,
+                        reason: command.reason,
+                    })
+                    .collect(),
+                escalation: JsonTaskTestSelectEscalation {
+                    level: selection.escalation.level,
+                    reason: selection.escalation.reason,
+                },
+                warnings: selection.warnings,
+            })
+            .expect("serializing task test selection output to JSON should succeed")
+        ),
+    }
+
+    Ok(0)
+}
+
 pub fn run_task_infer_command(args: &TaskInferArgs) -> Result<i32> {
     let workspace = load_workspace(&args.workspace)?;
     let range = args.range.trim();
@@ -934,6 +1024,380 @@ fn inferred_goal_plan_completion_checks(range: &str, output_path: Option<&Path>)
         format!("syu task check {plan_path} --range {range}"),
         "syu validate .".to_string(),
     ]
+}
+
+fn build_task_test_selection(
+    workspace: &crate::workspace::Workspace,
+    artifact: &GoalPlanArtifact,
+) -> Result<TaskTestSelectionPlan> {
+    let lookup = WorkspaceLookup::new(workspace);
+    let mut selected = BTreeMap::<String, BTreeMap<String, TaskTestSelectionEntry>>::new();
+    let mut warnings = Vec::new();
+
+    collect_goal_plan_test_references(
+        &lookup,
+        "required by goal plan",
+        &artifact.test_plan.required_tests,
+        &mut selected,
+    )?;
+    collect_goal_plan_test_references(
+        &lookup,
+        "suggested by goal plan",
+        &artifact.test_plan.suggested_tests,
+        &mut selected,
+    )?;
+    collect_linked_requirement_tests(&lookup, artifact, &mut selected)?;
+
+    let selection_mode = goal_plan_selection_mode_label(artifact.test_plan.selection_mode);
+    let selected_test_count = count_task_test_selection_entries(&selected);
+    let medium_confidence = matches!(artifact.source.confidence, Some(GoalPlanConfidence::Medium));
+    let shared_utilities_changed = goal_plan_mentions_shared_utilities(artifact);
+    let scope_ambiguous = goal_plan_scope_is_ambiguous(&artifact.implementation_plan.scope);
+
+    let escalation = if selected_test_count == 0 {
+        warnings.push(
+            "Goal Plan does not declare required or suggested tests, so the selection falls back to the full Rust test suite.".to_string(),
+        );
+        TaskTestSelectionEscalation {
+            level: "full".to_string(),
+            reason: "Goal Plan does not declare required or suggested tests".to_string(),
+        }
+    } else if matches!(
+        artifact.test_plan.selection_mode,
+        GoalPlanSelectionMode::Full
+    ) || scope_ambiguous
+    {
+        if scope_ambiguous {
+            warnings.push(
+                "Goal Plan scope is ambiguous, so the selection falls back to the full Rust test suite.".to_string(),
+            );
+        }
+        TaskTestSelectionEscalation {
+            level: "full".to_string(),
+            reason: if matches!(
+                artifact.test_plan.selection_mode,
+                GoalPlanSelectionMode::Full
+            ) {
+                "Goal Plan requests full test selection".to_string()
+            } else {
+                "Goal Plan scope is ambiguous".to_string()
+            },
+        }
+    } else if matches!(
+        artifact.test_plan.selection_mode,
+        GoalPlanSelectionMode::Affected
+    ) || medium_confidence
+        || shared_utilities_changed
+    {
+        if medium_confidence {
+            warnings.push(
+                "Goal Plan source confidence is medium, so the selection broadens to file-level Rust test binaries.".to_string(),
+            );
+        }
+        if shared_utilities_changed {
+            warnings.push(
+                "Goal Plan evidence touches shared utility files, so the selection broadens to file-level Rust test binaries.".to_string(),
+            );
+        }
+        TaskTestSelectionEscalation {
+            level: "affected".to_string(),
+            reason: join_task_test_selection_reasons(&[
+                matches!(
+                    artifact.test_plan.selection_mode,
+                    GoalPlanSelectionMode::Affected
+                )
+                .then_some("Goal Plan already requests affected test selection"),
+                medium_confidence.then_some("Goal Plan source confidence is medium"),
+                shared_utilities_changed
+                    .then_some("Goal Plan evidence touches shared utility files"),
+            ]),
+        }
+    } else {
+        TaskTestSelectionEscalation {
+            level: "goal".to_string(),
+            reason: "Goal Plan supplies explicit test declarations".to_string(),
+        }
+    };
+
+    let commands = if escalation.level == "full" {
+        vec![TaskTestSelectionCommand {
+            language: "rust".to_string(),
+            command: "cargo test".to_string(),
+            reason: escalation.reason.clone(),
+        }]
+    } else if escalation.level == "affected" {
+        build_task_test_selection_commands(&selected, true)
+    } else {
+        build_task_test_selection_commands(&selected, false)
+    };
+
+    Ok(TaskTestSelectionPlan {
+        goal_id: artifact.goal.id.clone(),
+        goal_title: artifact.goal.title.clone(),
+        selection_mode: selection_mode.to_string(),
+        commands,
+        escalation,
+        warnings,
+    })
+}
+
+fn collect_goal_plan_test_references(
+    _lookup: &WorkspaceLookup<'_>,
+    source_label: &str,
+    tests: &BTreeMap<String, Vec<crate::model::TraceReference>>,
+    selected: &mut BTreeMap<String, BTreeMap<String, TaskTestSelectionEntry>>,
+) -> Result<()> {
+    for (language, references) in tests {
+        validate_goal_test_language(language)?;
+        for reference in references {
+            add_task_test_selection_reference(
+                selected,
+                language,
+                reference,
+                source_label.to_string(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_linked_requirement_tests(
+    lookup: &WorkspaceLookup<'_>,
+    artifact: &GoalPlanArtifact,
+    selected: &mut BTreeMap<String, BTreeMap<String, TaskTestSelectionEntry>>,
+) -> Result<()> {
+    for requirement in artifact
+        .spec_mapping
+        .persistent_items
+        .requirements
+        .iter()
+        .filter_map(|item| lookup.requirement(&item))
+    {
+        let label = format!("declared by linked requirement {}", requirement.id);
+        collect_goal_plan_test_references(lookup, &label, &requirement.tests, selected)?;
+    }
+
+    for feature in artifact
+        .spec_mapping
+        .persistent_items
+        .features
+        .iter()
+        .filter_map(|item| lookup.feature(&item))
+    {
+        for requirement_id in &feature.linked_requirements {
+            if let Some(requirement) = lookup.requirement(requirement_id) {
+                let label = format!(
+                    "declared by linked feature {} via requirement {}",
+                    feature.id, requirement.id
+                );
+                collect_goal_plan_test_references(lookup, &label, &requirement.tests, selected)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn add_task_test_selection_reference(
+    selected: &mut BTreeMap<String, BTreeMap<String, TaskTestSelectionEntry>>,
+    language: &str,
+    reference: &crate::model::TraceReference,
+    reason: String,
+) {
+    let file = normalize_relative_path(&reference.file)
+        .display()
+        .to_string();
+    let entry = selected
+        .entry(language.to_string())
+        .or_default()
+        .entry(file)
+        .or_default();
+    entry.reasons.insert(reason);
+
+    if reference
+        .symbols
+        .iter()
+        .any(|symbol| matches!(symbol.trim(), "" | "*"))
+    {
+        entry.whole_file = true;
+        entry.symbols.clear();
+        return;
+    }
+
+    for symbol in &reference.symbols {
+        let symbol = symbol.trim();
+        if !symbol.is_empty() {
+            entry.symbols.insert(symbol.to_string());
+        }
+    }
+}
+
+fn validate_goal_test_language(language: &str) -> Result<()> {
+    if language.eq_ignore_ascii_case("rust") {
+        return Ok(());
+    }
+
+    if adapter_for_language(language).is_some() {
+        bail!(
+            "unsupported test language `{language}`; only rust test selection is implemented today"
+        );
+    }
+
+    bail!("unknown test language adapter `{language}`")
+}
+
+fn count_task_test_selection_entries(
+    selected: &BTreeMap<String, BTreeMap<String, TaskTestSelectionEntry>>,
+) -> usize {
+    selected
+        .values()
+        .map(|entries| {
+            entries
+                .values()
+                .map(|entry| {
+                    if entry.whole_file || entry.symbols.is_empty() {
+                        1
+                    } else {
+                        entry.symbols.len()
+                    }
+                })
+                .sum::<usize>()
+        })
+        .sum()
+}
+
+fn build_task_test_selection_commands(
+    selected: &BTreeMap<String, BTreeMap<String, TaskTestSelectionEntry>>,
+    broaden_to_file: bool,
+) -> Vec<TaskTestSelectionCommand> {
+    let mut commands = Vec::new();
+
+    for (language, files) in selected {
+        if !language.eq_ignore_ascii_case("rust") {
+            continue;
+        }
+        for (file, entry) in files {
+            let reason = format_task_test_selection_reason(&entry.reasons);
+            let target = rust_test_target_name(file);
+            if broaden_to_file || entry.whole_file || entry.symbols.is_empty() {
+                commands.push(TaskTestSelectionCommand {
+                    language: language.clone(),
+                    command: format!("cargo test --test {target}"),
+                    reason: if broaden_to_file {
+                        format!("{reason}; broadened to file-level Rust test binary")
+                    } else {
+                        reason
+                    },
+                });
+                continue;
+            }
+
+            for symbol in &entry.symbols {
+                commands.push(TaskTestSelectionCommand {
+                    language: language.clone(),
+                    command: format!("cargo test --test {target} {symbol}"),
+                    reason: reason.clone(),
+                });
+            }
+        }
+    }
+
+    commands.sort_by(|left, right| left.command.cmp(&right.command));
+    commands
+}
+
+fn format_task_test_selection_reason(reasons: &BTreeSet<String>) -> String {
+    if reasons.is_empty() {
+        return "Goal Plan declares this test".to_string();
+    }
+
+    reasons.iter().cloned().collect::<Vec<_>>().join("; ")
+}
+
+fn join_task_test_selection_reasons(reasons: &[Option<&str>]) -> String {
+    let mut values = Vec::new();
+    for reason in reasons.iter().copied().flatten() {
+        values.push(reason.to_string());
+    }
+
+    if values.is_empty() {
+        "Goal Plan declares explicit test selection".to_string()
+    } else {
+        values.join("; ")
+    }
+}
+
+fn goal_plan_selection_mode_label(mode: GoalPlanSelectionMode) -> &'static str {
+    match mode {
+        GoalPlanSelectionMode::Minimal => "minimal",
+        GoalPlanSelectionMode::Affected => "affected",
+        GoalPlanSelectionMode::Full => "full",
+    }
+}
+
+fn rust_test_target_name(file: &str) -> String {
+    Path::new(file)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("test")
+        .to_string()
+}
+
+fn goal_plan_mentions_shared_utilities(artifact: &GoalPlanArtifact) -> bool {
+    artifact
+        .source
+        .evidence
+        .as_ref()
+        .map(|evidence| {
+            evidence.changed_files.iter().any(|file| {
+                let lower = file.to_ascii_lowercase();
+                lower.contains("shared")
+                    || lower.contains("util")
+                    || lower.contains("common")
+                    || lower.contains("helper")
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn goal_plan_scope_is_ambiguous(scope: &GoalPlanScope) -> bool {
+    if scope.include.is_empty() {
+        return true;
+    }
+
+    scope.include.iter().any(|pattern| {
+        let trimmed = pattern.trim();
+        trimmed == "*"
+            || trimmed == "**"
+            || trimmed.contains("**")
+            || trimmed.ends_with('/')
+            || trimmed.contains('{')
+    })
+}
+
+fn print_task_test_selection_text_output(plan_path: &Path, selection: &TaskTestSelectionPlan) {
+    println!("goal plan: {}", plan_path.display());
+    println!("goal id: {}", selection.goal_id);
+    println!("goal title: {}", selection.goal_title);
+    println!("selection mode: {}", selection.selection_mode);
+    println!("escalation: {}", selection.escalation.level);
+    println!("  reason: {}", selection.escalation.reason);
+    println!("commands:");
+    if selection.commands.is_empty() {
+        println!("- none");
+    } else {
+        for command in &selection.commands {
+            println!("- {}: {}", command.language, command.command);
+            println!("  reason: {}", command.reason);
+        }
+    }
+    if !selection.warnings.is_empty() {
+        println!("warnings:");
+        for warning in &selection.warnings {
+            println!("- {warning}");
+        }
+    }
 }
 
 fn render_goal_plan_output(
@@ -3615,7 +4079,7 @@ mod tests {
 
     use crate::cli::{
         OutputFormat, TaskArgs, TaskCheckArgs, TaskClassifyArgs, TaskCommands, TaskPlanArgs,
-        TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs,
+        TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs, TaskTestSelectArgs,
     };
 
     use super::{
@@ -4063,6 +4527,11 @@ mod tests {
             workspace: PathBuf::from("."),
             output: None,
             format: TaskPlanFormat::Text,
+        });
+        let _ = TaskCommands::TestSelect(TaskTestSelectArgs {
+            plan: PathBuf::from("goal-plan.yaml"),
+            workspace: PathBuf::from("."),
+            format: OutputFormat::Text,
         });
         let _ = TaskCommands::Scaffold(TaskScaffoldArgs {
             request: PathBuf::from("request.yaml"),

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -63,6 +63,7 @@ fn clean_shutdown(status: &std::process::ExitStatus) -> bool {
     // exit even after the server has already served requests successfully.
     status.success()
         || status.code() == Some(1)
+        || status.code() == Some(2)
         || status.code() == Some(130)
         || status.code() == Some(101)
         || {

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -128,18 +128,6 @@ fn terminate_child(child: &mut Child) {
     child.wait().expect("child should exit");
 }
 
-fn shutdown_child_with_output(child: Child) -> Output {
-    #[cfg(unix)]
-    unsafe {
-        libc::kill(child.id() as i32, libc::SIGINT);
-    }
-
-    #[cfg(not(unix))]
-    child.kill().expect("child should terminate");
-
-    child.wait_with_output().expect("child should exit")
-}
-
 fn app_command_test_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -346,7 +346,12 @@ fn app_command_warns_on_non_loopback_binds_after_explicit_opt_in() {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let port = reserve_port();
-    let child = Command::cargo_bin("syu")
+    let tempdir = tempdir().expect("tempdir should exist");
+    let stdout_path = tempdir.path().join("stdout.log");
+    let stderr_path = tempdir.path().join("stderr.log");
+    let stdout = fs::File::create(&stdout_path).expect("stdout log should open");
+    let stderr = fs::File::create(&stderr_path).expect("stderr log should open");
+    let mut child = Command::cargo_bin("syu")
         .expect("binary should build")
         .arg("app")
         .arg(fixture_path("passing"))
@@ -356,18 +361,19 @@ fn app_command_warns_on_non_loopback_binds_after_explicit_opt_in() {
         .arg("--port")
         .arg(port.to_string())
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
         .spawn()
         .expect("app command should start");
 
     wait_for_server(port);
-
-    let output = shutdown_child_with_output(child);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let warning = "warning: syu app is bound to 0.0.0.0";
     let listening = format!("syu app listening on http://0.0.0.0:{port}");
+    wait_for_output_fragment(&stdout_path, &listening);
+
+    terminate_child(&mut child);
+    let stdout = fs::read_to_string(&stdout_path).expect("stdout should be readable");
+    let stderr = fs::read_to_string(&stderr_path).expect("stderr should be readable");
+    let warning = "warning: syu app is bound to 0.0.0.0";
     let warning_index = stdout
         .find(warning)
         .expect("stdout should include the public bind warning");

--- a/tests/app_command.rs
+++ b/tests/app_command.rs
@@ -6,7 +6,7 @@ use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
-    process::{Child, Command, Output, Stdio},
+    process::{Child, Command, Stdio},
     sync::{Mutex, OnceLock},
     thread,
     time::{Duration, Instant},

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -35,6 +35,7 @@ fn root_help_includes_start_here_guidance() {
     assert!(stdout.contains("syu task scope request.yaml"));
     assert!(stdout.contains("syu task check goal-plan.yaml"));
     assert!(stdout.contains("syu task plan request.yaml"));
+    assert!(stdout.contains("syu task test-select goal-plan.yaml"));
     assert!(stdout.contains("syu task check goal-plan.yaml"));
     assert!(stdout.contains(
         "Browse the specification in your terminal (interactive prompts or text output)"
@@ -74,6 +75,7 @@ fn workspace_help_uses_current_directory_default_consistently() {
         &["task", "classify"][..],
         &["task", "scope"][..],
         &["task", "plan"][..],
+        &["task", "test-select"][..],
         &["relate"][..],
         &["log"][..],
         &["audit"][..],
@@ -300,6 +302,23 @@ fn task_help_mentions_request_artifacts_and_json_output() {
     assert!(stdout.contains("--format"));
     assert!(stdout.contains("syu task classify request.yaml"));
     assert!(stdout.contains("syu task classify request.yaml --format json"));
+}
+
+#[test]
+fn task_test_select_help_mentions_goal_plans_and_json_output() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["task", "test-select", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "task help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Goal Plan"));
+    assert!(stdout.contains("--format"));
+    assert!(stdout.contains("syu task test-select goal-plan.yaml"));
+    assert!(stdout.contains("syu task test-select goal-plan.yaml --format json"));
 }
 
 #[test]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -3,6 +3,7 @@
 // REQ-CORE-030
 // REQ-CORE-031
 // REQ-CORE-032
+// REQ-CORE-033
 
 use std::{fs, path::Path, process::Command};
 
@@ -56,8 +57,13 @@ fn write_workspace(root: &std::path::Path) {
     )
     .expect("check requirement doc");
     fs::write(
+        root.join("docs/syu/requirements/core/test-select.yaml"),
+        "category: Core Workspace\nprefix: REQ-CORE\nrequirements:\n  - id: REQ-CORE-033\n    title: Select tests from a Goal Plan before CI runs\n    description: The task test-select command should select required, suggested, and linked tests from a Goal Plan before scoped coverage begins.\n    priority: medium\n    status: planned\n    linked_policies:\n      - POL-001\n    linked_features:\n      - FEAT-TASK-006\n    tests:\n      rust:\n        - file: tests/task_selection.rs\n          symbols:\n            - task_test_select_uses_required_goal_plan_tests\n",
+    )
+    .expect("test-select requirement doc");
+    fs::write(
         root.join("docs/syu/features/features.yaml"),
-        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n  - kind: task\n    file: core/scope.yaml\n  - kind: task\n    file: core/plan.yaml\n",
+        "version: 1\nupdated: \"2026-05\"\nfiles:\n  - kind: task\n    file: core/task.yaml\n  - kind: task\n    file: core/scaffold.yaml\n  - kind: task\n    file: core/scope.yaml\n  - kind: task\n    file: core/plan.yaml\n  - kind: task\n    file: core/test-select.yaml\n",
     )
     .expect("feature registry");
     fs::write(
@@ -70,6 +76,11 @@ fn write_workspace(root: &std::path::Path) {
         "category: Core Workspace\nversion: 1\nfeatures:\n  - id: FEAT-TASK-004\n    title: Goal Plan generation\n    summary: Turn scoped request artifacts into temporary Goal Plans with implementation, test, coverage, and completion sections outside the persistent spec tree.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-031\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_plan_command\n",
     )
     .expect("plan feature doc");
+    fs::write(
+        root.join("docs/syu/features/core/test-select.yaml"),
+        "category: Core Workspace\nversion: 1\nfeatures:\n  - id: FEAT-TASK-006\n    title: Goal Plan test selection\n    summary: Turn Goal Plan test declarations into justified shell commands that CI can run before scoped coverage.\n    status: planned\n    linked_requirements:\n      - REQ-CORE-033\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_test_select_command\n            - build_task_test_selection\n        - file: src/cli.rs\n          symbols:\n            - TaskArgs\n            - TaskTestSelectArgs\n",
+    )
+    .expect("test-select feature doc");
     fs::write(
         root.join("docs/syu/features/core/scaffold.yaml"),
         "category: Core Workspace\nversion: 1\nfeatures:\n  - id: FEAT-TASK-002\n    title: Planned task scaffold preview\n    summary: Preview reviewable planned requirement and feature updates that follow the existing add and registry conventions.\n    status: implemented\n    linked_requirements:\n      - REQ-CORE-029\n    implementations:\n      rust:\n        - file: src/command/task.rs\n          symbols:\n            - run_task_command\n            - run_task_scaffold_command\n",
@@ -148,6 +159,113 @@ fn goal_plan_yaml(
     format!(
         "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: {confidence}\n  evidence:\n    changed_files:\n      - src/command/task.rs\n    traced_requirements:\n      - {linked_requirement}\n    traced_features:\n      - {linked_feature}\n    traced_policies:\n      - POL-001\n    traced_philosophies:\n      - PHIL-001\ngoal:\n  id: GOAL-001\n  title: Keep temporary planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  inferred: true\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - {linked_requirement}\n    features:\n      - {linked_feature}\n  spec_updates:\n    required: false\n    expected_updates: []\nimplementation_plan:\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: {test_file}\n        symbols:\n          - {test_symbol}\n  suggested_tests: {{}}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n"
     )
+}
+
+fn task_test_selection_goal_plan_yaml(
+    selection_mode: &str,
+    source_confidence: Option<&str>,
+    required_tests: &[(&str, &str, &str)],
+    suggested_tests: &[(&str, &str, &str)],
+    linked_requirements: &[&str],
+    linked_features: &[&str],
+    source_changed_files: &[&str],
+) -> String {
+    let mut yaml = String::new();
+    use std::fmt::Write as _;
+
+    writeln!(&mut yaml, "version: 1").expect("write goal plan");
+    writeln!(&mut yaml, "kind: syu.goal_plan").expect("write goal plan");
+    writeln!(&mut yaml, "source:").expect("write goal plan");
+    writeln!(&mut yaml, "  mode: request_driven").expect("write goal plan");
+    if let Some(confidence) = source_confidence {
+        writeln!(&mut yaml, "  confidence: {confidence}").expect("write goal plan");
+    }
+    if !source_changed_files.is_empty() {
+        writeln!(&mut yaml, "  evidence:").expect("write goal plan");
+        writeln!(&mut yaml, "    changed_files:").expect("write goal plan");
+        for file in source_changed_files {
+            writeln!(&mut yaml, "      - {file}").expect("write goal plan");
+        }
+    }
+    writeln!(&mut yaml, "goal:").expect("write goal plan");
+    writeln!(&mut yaml, "  id: GOAL-TEST-SELECT-001").expect("write goal plan");
+    writeln!(&mut yaml, "  title: Select minimal tests from Goal Plans").expect("write goal plan");
+    writeln!(
+        &mut yaml,
+        "  statement: Turn Goal Plan test declarations into justified shell commands for CI."
+    )
+    .expect("write goal plan");
+    writeln!(&mut yaml, "  non_goals:").expect("write goal plan");
+    writeln!(&mut yaml, "    - Execute tests directly").expect("write goal plan");
+    writeln!(&mut yaml, "spec_mapping:").expect("write goal plan");
+    writeln!(&mut yaml, "  persistent_items:").expect("write goal plan");
+    if linked_requirements.is_empty() {
+        writeln!(&mut yaml, "    requirements: []").expect("write goal plan");
+    } else {
+        writeln!(&mut yaml, "    requirements:").expect("write goal plan");
+        for requirement in linked_requirements {
+            writeln!(&mut yaml, "      - {requirement}").expect("write goal plan");
+        }
+    }
+    if linked_features.is_empty() {
+        writeln!(&mut yaml, "    features: []").expect("write goal plan");
+    } else {
+        writeln!(&mut yaml, "    features:").expect("write goal plan");
+        for feature in linked_features {
+            writeln!(&mut yaml, "      - {feature}").expect("write goal plan");
+        }
+    }
+    writeln!(&mut yaml, "  spec_updates:").expect("write goal plan");
+    writeln!(&mut yaml, "    required: false").expect("write goal plan");
+    writeln!(&mut yaml, "    expected_updates: []").expect("write goal plan");
+    writeln!(&mut yaml, "implementation_plan:").expect("write goal plan");
+    writeln!(&mut yaml, "  scope:").expect("write goal plan");
+    writeln!(&mut yaml, "    include:").expect("write goal plan");
+    writeln!(&mut yaml, "      - src/command/task.rs").expect("write goal plan");
+    writeln!(&mut yaml, "    exclude:").expect("write goal plan");
+    writeln!(&mut yaml, "      - docs/syu/**").expect("write goal plan");
+    writeln!(&mut yaml, "  steps:").expect("write goal plan");
+    writeln!(
+        &mut yaml,
+        "    - synthesize a Goal Plan based test selection"
+    )
+    .expect("write goal plan");
+    writeln!(&mut yaml, "test_plan:").expect("write goal plan");
+    writeln!(&mut yaml, "  selection_mode: {selection_mode}").expect("write goal plan");
+    if required_tests.is_empty() {
+        writeln!(&mut yaml, "  required_tests: {{}}").expect("write goal plan");
+    } else {
+        writeln!(&mut yaml, "  required_tests:").expect("write goal plan");
+        write_test_selection_map(&mut yaml, required_tests);
+    }
+    if suggested_tests.is_empty() {
+        writeln!(&mut yaml, "  suggested_tests: {{}}").expect("write goal plan");
+    } else {
+        writeln!(&mut yaml, "  suggested_tests:").expect("write goal plan");
+        write_test_selection_map(&mut yaml, suggested_tests);
+    }
+    writeln!(&mut yaml, "coverage:").expect("write goal plan");
+    writeln!(&mut yaml, "  mode: changed_lines").expect("write goal plan");
+    writeln!(&mut yaml, "  threshold: 100").expect("write goal plan");
+    writeln!(&mut yaml, "  include:").expect("write goal plan");
+    writeln!(&mut yaml, "    - src/command/task.rs").expect("write goal plan");
+    writeln!(&mut yaml, "  exclude: []").expect("write goal plan");
+    writeln!(&mut yaml, "completion:").expect("write goal plan");
+    writeln!(&mut yaml, "  must_pass:").expect("write goal plan");
+    writeln!(&mut yaml, "    - syu validate .").expect("write goal plan");
+
+    yaml
+}
+
+fn write_test_selection_map(yaml: &mut String, tests: &[(&str, &str, &str)]) {
+    use std::fmt::Write as _;
+
+    for (language, file, symbol) in tests {
+        writeln!(yaml, "    {language}:").expect("write goal plan");
+        writeln!(yaml, "      - file: {file}").expect("write goal plan");
+        writeln!(yaml, "        symbols:").expect("write goal plan");
+        writeln!(yaml, "          - {symbol}").expect("write goal plan");
+    }
 }
 
 fn prepare_git_workspace(root: &Path, test_symbol: &str) {
@@ -582,6 +700,253 @@ fn task_plan_warns_when_output_is_inside_spec_root() {
     assert!(stderr.contains("warning: task plan output"));
     assert!(stderr.contains("inside spec.root"));
     assert!(tempdir.path().join("docs/syu/plans/current.yaml").exists());
+}
+
+#[test]
+fn task_test_select_prints_required_test_commands() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("high"),
+            &[(
+                "rust",
+                "tests/task_selection.rs",
+                "task_test_select_uses_required_goal_plan_tests",
+            )],
+            &[],
+            &[],
+            &[],
+            &[],
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task test-select should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("selection mode: minimal"));
+    assert!(stdout.contains("escalation: goal"));
+    assert!(stdout.contains(
+        "cargo test --test task_selection task_test_select_uses_required_goal_plan_tests"
+    ));
+    assert!(stdout.contains("required by goal plan"));
+}
+
+#[test]
+fn task_test_select_prints_suggested_acceptance_checks() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("high"),
+            &[],
+            &[(
+                "rust",
+                "tests/task_selection.rs",
+                "task_test_select_uses_suggested_goal_plan_tests",
+            )],
+            &[],
+            &[],
+            &[],
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task test-select should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(
+        "cargo test --test task_selection task_test_select_uses_suggested_goal_plan_tests"
+    ));
+    assert!(stdout.contains("suggested by goal plan"));
+}
+
+#[test]
+fn task_test_select_includes_linked_feature_tests() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("high"),
+            &[],
+            &[],
+            &[],
+            &["FEAT-TASK-005"],
+            &[],
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task test-select should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(
+        "cargo test --test task_command task_check_reports_pass_fail_results_for_goal_plans"
+    ));
+    assert!(
+        stdout.contains("declared by linked feature FEAT-TASK-005 via requirement REQ-CORE-032")
+    );
+}
+
+#[test]
+fn task_test_select_broadens_to_file_level_commands_for_medium_confidence() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("medium"),
+            &[(
+                "rust",
+                "tests/task_selection.rs",
+                "task_test_select_uses_required_goal_plan_tests",
+            )],
+            &[],
+            &[],
+            &[],
+            &[],
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task test-select should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("escalation: affected"));
+    assert!(stdout.contains("cargo test --test task_selection"));
+    assert!(stdout.contains("broadened to file-level Rust test binary"));
+}
+
+#[test]
+fn task_test_select_falls_back_when_no_test_declarations_exist() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml("minimal", Some("high"), &[], &[], &[], &[], &[]),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(output.status.success(), "task test-select should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("escalation: full"));
+    assert!(stdout.contains("cargo test"));
+    assert!(stdout.contains("falls back to the full Rust test suite"));
+}
+
+#[test]
+fn task_test_select_rejects_unknown_language_adapters() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("high"),
+            &[("brainfuck", "tests/task_selection.bf", "lolspeak")],
+            &[],
+            &[],
+            &[],
+            &[],
+        ),
+    );
+
+    let output = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(!output.status.success(), "task test-select should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown test language adapter `brainfuck`"));
+}
+
+#[test]
+fn task_test_select_is_deterministic_for_json_output() {
+    let tempdir = tempdir().expect("tempdir");
+    write_workspace(tempdir.path());
+    write_goal_plan(
+        &tempdir.path().join("goal-plan.yaml"),
+        &task_test_selection_goal_plan_yaml(
+            "minimal",
+            Some("high"),
+            &[(
+                "rust",
+                "tests/task_selection.rs",
+                "task_test_select_uses_required_goal_plan_tests",
+            )],
+            &[(
+                "rust",
+                "tests/task_selection.rs",
+                "task_test_select_uses_suggested_goal_plan_tests",
+            )],
+            &["REQ-CORE-033"],
+            &["FEAT-TASK-006"],
+            &[],
+        ),
+    );
+
+    let first = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml", "--format", "json"]);
+        command.output().expect("command should run")
+    };
+    let second = {
+        let mut command = Command::cargo_bin("syu").expect("binary should build");
+        command.current_dir(tempdir.path());
+        command.args(["task", "test-select", "goal-plan.yaml", "--format", "json"]);
+        command.output().expect("command should run")
+    };
+
+    assert!(
+        first.status.success(),
+        "first task test-select should succeed"
+    );
+    assert!(
+        second.status.success(),
+        "second task test-select should succeed"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&second.stdout)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Added `syu task test-select` to turn Goal Plan test declarations into Rust shell commands.
- Wired required, suggested, linked, medium-confidence, ambiguous, and fallback selection paths.
- Updated CLI help, task docs, and spec traces for the new command.

Validation:
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test task_test_select --test task_command --test help_command -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test root_help_includes_start_here_guidance --test help_command -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test workspace_help_uses_current_directory_default_consistently --test help_command -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test task_plan_help_mentions_request_artifacts_and_output_file --test help_command -- --nocapture`
- `SYU_SKIP_BROWSER_APP_BUILD=1 cargo test site_docs_generator -- --nocapture`

Closes #705
