### PR TITLE
Document the request-to-goal workflow and update issue/PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,20 @@ Use a GitHub closing keyword (`Closes #123`, `Fixes #123`, or `Resolves #123`) w
 
 If you list requirement or feature IDs here, include the same IDs in the PR title so the squash commit headline preserves them in `git log`.
 
+## Goal Plan
+
+- [ ] This PR was implemented from a request-generated Goal Plan.
+- [ ] This PR uses an inferred Goal Plan.
+- [ ] This PR intentionally requires broader/full validation.
+
+Goal Plan path or summary:
+
+Linked persistent spec IDs:
+
+Selected test scope:
+
+Coverage scope:
+
 ## Validation
 
 - [ ] `scripts/ci/quality-gates.sh`

--- a/docs/guide/command-card.md
+++ b/docs/guide/command-card.md
@@ -18,6 +18,13 @@ If a pull request already exists, pair this page with the
 | Check local readiness | `syu doctor .` | confirm the Rust, Node, and browser-app dependencies are ready before you scaffold or validate |
 | Scaffold a workspace | `syu init .` | create the default four-layer tree in the current directory |
 | Scaffold with another starter | `syu init . --template rust-only` | begin from a language-shaped or docs-first layout instead of the generic starter |
+| Classify a request | `syu task classify request.yaml` | decide whether the request is a create, change, or delete before planning starts |
+| Scope a request | `syu task scope request.yaml` | map the request onto the current philosophy, policy, requirement, and feature graph |
+| Scaffold planned updates | `syu task scaffold request.yaml` | preview the planned requirement and feature edits once the request is scoped |
+| Draft a temporary goal plan | `syu task plan request.yaml` | turn a scoped request into a temporary Goal Plan without adding a fifth persistent spec layer |
+| Select tests from a goal plan | `syu task test-select goal-plan.yaml` | turn a temporary Goal Plan into justified Rust test commands before scoped coverage or CI runs |
+| Infer a goal plan from a diff | `syu task infer --range origin/main...HEAD` | derive a provisional Goal Plan from changed files, traced owners, evidence, and confidence before review |
+| Check a temporary goal plan | `syu task check goal-plan.yaml --range origin/main...HEAD` | validate a temporary Goal Plan against the changed files, linked spec IDs, required tests, and completion commands before review |
 | Check the workspace | `syu validate .` | run the full graph, trace, and coverage validation pass |
 | Focus one validation view | `syu validate . --id FEAT-CHECK-001` | keep the visible output anchored on one requirement or feature after the normal validation run |
 | Focus trace failures first | `syu validate . --genre trace` | inspect trace-specific problems before reading the full validation output |
@@ -28,10 +35,6 @@ If a pull request already exists, pair this page with the
 | Review a PR range | `syu review --range origin/main...HEAD` | start with the affected philosophy, policy, requirement, and feature IDs, then drill into changed files with `show`, `relate`, or `log` |
 | Strictly review a PR range | `syu review --range origin/main...HEAD --strict --allowed-id FEAT-CHECK-001 --format json` | fail the range review on unowned, ambiguously owned, or out-of-scope changes while keeping structured findings for CI |
 | Guard a review range | `syu review --range origin/main...HEAD --allowed-id FEAT-CHECK-001` | block changes that step outside the named requirement or feature IDs and list the out-of-scope items |
-| Draft a temporary goal plan | `syu task scaffold request.yaml` | preview a bounded delivery artifact with goal, scope, tests, coverage, and completion checks without adding a fifth persistent spec layer |
-| Infer a goal plan from a diff | `syu task infer --range origin/main...HEAD` | derive a provisional Goal Plan from changed files, traced owners, evidence, and confidence before review |
-| Select tests from a goal plan | `syu task test-select goal-plan.yaml` | turn a temporary Goal Plan into justified Rust test commands before scoped coverage or CI runs |
-| Check a temporary goal plan | `syu task check goal-plan.yaml --range origin/main...HEAD` | validate a temporary Goal Plan against the changed files, linked spec IDs, required tests, and completion commands before review |
 | Jump from code to the owning spec | `syu trace src/command/check.rs --symbol run_check_command` | start in code and resolve the traced requirement and feature chain |
 | List items by layer | `syu list feature` | print list-shaped output instead of the browser-style explorer |
 | Search by keyword or ID | `syu search validation --kind feature` | find the right spec item before `show`, `relate`, or `log` |
@@ -92,6 +95,10 @@ syu report .
   checked-in starter and example matrix.
 - Use [goal plan format](./goal-plan-format.md) when you need a temporary
   delivery artifact instead of a persistent spec item.
+- For request-driven planning, the shortest useful sequence is
+  `classify -> scope -> scaffold -> plan -> implementation -> check`. Use `infer`
+  only when the implementation already exists and you need to reconstruct the
+  temporary Goal Plan from the diff.
 - Use [LSP guide](./lsp.md) when you are connecting `syu` to an editor client
   over stdio instead of using the checked-in VS Code extension directly.
 - Use [configuration](./configuration.md) when you need validation and runtime

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -94,6 +94,25 @@ Without features, requirements never connect to running software.
 repository can explain itself from ideals down to code and tests without being
 tied to a single implementation language.
 
+## Goal Plans
+
+Goal Plans are temporary delivery artifacts that sit outside the four
+persistent layers. They capture the request, scope, test selection, coverage
+expectation, and completion checks for one bounded piece of work.
+
+They may live in a task file, a PR body, an issue body, or a CI artifact, but
+they should not be stored under `spec.root` as if they were a fifth durable
+spec layer.
+
+Prefer request-driven planning when the request is still being shaped:
+classify it, scope it, scaffold the planned updates, and then turn it into a
+Goal Plan. Use diff-inferred planning only as a fallback when the code already
+changed and the plan has to be reconstructed from the diff.
+
+For pull requests, Goal Plans describe the smallest justified test and coverage
+scope. They do not replace the repository's full integration gates, which stay
+with merge queue and main-branch validation.
+
 ## Authoring guidelines
 
 ### Write philosophy for stability

--- a/docs/guide/goal-plan-format.md
+++ b/docs/guide/goal-plan-format.md
@@ -37,7 +37,7 @@ When the request still needs shaping, use the planning commands in order:
 3. `syu task scaffold request.yaml`
 4. `syu task plan request.yaml`
 5. implementation
-6. `syu task check goal-plan.yaml`
+6. `syu task check goal-plan.yaml --range origin/main...HEAD`
 
 That flow keeps the intake, the spec adjacency check, the reviewable preview,
 and the temporary Goal Plan separate from one another.

--- a/docs/guide/goal-plan-format.md
+++ b/docs/guide/goal-plan-format.md
@@ -6,12 +6,19 @@ Use this guide when a request has already been scoped and you need a temporary
 delivery artifact that stays outside the persistent spec tree. Goal Plans are
 planning artifacts, not another long-lived spec layer.
 
+The normal path is request-driven: classify the request, scope it against the
+current graph, scaffold the planned edits, and then turn that result into a
+Goal Plan. If implementation already happened, `syu task infer` can rebuild a
+provisional Goal Plan from the diff and the current traces.
+
 ## When to use it
 
 - A request already has a clear implementation goal, scope, and test plan.
 - You want a structured artifact that can live in a task file, PR body, issue
   body, CI artifact, or another temporary delivery location.
 - You need a reviewable artifact before the implementation starts.
+- You want the PR-scoped test selection and coverage expectation recorded
+  separately from the repository's full integration gates.
 
 ## When not to use it
 
@@ -20,6 +27,31 @@ planning artifacts, not another long-lived spec layer.
 - You want to add durable intent to philosophy, policy, requirement, or feature
   YAML.
 - The change is already a direct spec diff.
+
+## Request-driven flow
+
+When the request still needs shaping, use the planning commands in order:
+
+1. `syu task classify request.yaml`
+2. `syu task scope request.yaml`
+3. `syu task scaffold request.yaml`
+4. `syu task plan request.yaml`
+5. implementation
+6. `syu task check goal-plan.yaml`
+
+That flow keeps the intake, the spec adjacency check, the reviewable preview,
+and the temporary Goal Plan separate from one another.
+
+## Diff-inferred fallback
+
+If the implementation already exists and you need a provisional plan instead of
+request-driven planning, use:
+
+1. `syu task infer --range origin/main...HEAD`
+2. `syu task check goal-plan.yaml --range origin/main...HEAD`
+
+The inferred plan should record the changed files, traced owners, and
+confidence level that shaped the result, but it still remains temporary.
 
 ## Recommended shape
 
@@ -107,10 +139,17 @@ completion:
 - **test_plan**: records the test selection mode plus required and suggested
   checks, including file and symbol references when a plan needs explicit test
   coverage.
-- **coverage**: states the coverage expectation for the changed surface.
+- **coverage**: states the coverage expectation for the changed surface. This
+  is the PR-scoped coverage target, not the repository's full integration
+  validation.
 - **completion**: lists the checks that must pass before the work is complete.
 
 Goal Plans are intentionally temporary. They may live in `.syu/tasks/*.yaml`,
 `target/syu/*.json`, a GitHub issue or PR body, or a CI artifact. They do not
 need to live under `spec.root`, and `syu validate .` should not require them to
 exist.
+
+Scoped tests and scoped coverage are a preview of the PR's justified risk
+boundaries. The merge queue and the main branch still own the full integration
+gate, so a Goal Plan should never imply that `syu task test-select` or
+coverage selection replaces the repository-wide validation pass.

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -19,7 +19,7 @@ The preferred request-driven flow is:
 3. `syu task scaffold request.yaml`
 4. `syu task plan request.yaml`
 5. implementation
-6. `syu task check goal-plan.yaml`
+6. `syu task check goal-plan.yaml --range origin/main...HEAD`
 
 If the work already exists in a diff and you need to reconstruct the temporary
 artifact, use the fallback:

--- a/docs/guide/implementation-planning.md
+++ b/docs/guide/implementation-planning.md
@@ -12,6 +12,21 @@ format](./goal-plan-format.md).
 The goal plan format is temporary by design and should not become a fifth
 persistent spec layer.
 
+The preferred request-driven flow is:
+
+1. `syu task classify request.yaml`
+2. `syu task scope request.yaml`
+3. `syu task scaffold request.yaml`
+4. `syu task plan request.yaml`
+5. implementation
+6. `syu task check goal-plan.yaml`
+
+If the work already exists in a diff and you need to reconstruct the temporary
+artifact, use the fallback:
+
+1. `syu task infer --range origin/main...HEAD`
+2. `syu task check goal-plan.yaml --range origin/main...HEAD`
+
 ## When to use it
 
 - A request has enough detail to turn into planned requirements or features.
@@ -101,6 +116,10 @@ smallest defensible test command set before scoped coverage or CI runs.
 Use `syu task infer --range origin/main...HEAD` when implementation already
 exists and you want a provisional Goal Plan inferred from the changed files,
 their traced owners, and the current graph.
+
+That is the boundary between the request-driven flow and the diff-inferred
+fallback. The first path is the normal contributor path; the second is for
+reconstructing a plan from existing implementation.
 
 That is the step that should capture the implementation plan, test plan,
 coverage target, completion checks, and any warnings that still need review.

--- a/docs/guide/request-artifact-format.md
+++ b/docs/guide/request-artifact-format.md
@@ -57,3 +57,9 @@ follow from that decision. `syu task plan request.yaml` can then turn the
 scoped request into a temporary Goal Plan artifact that stays outside the
 persistent spec tree while still keeping the implementation, test, coverage,
 and completion work visible.
+
+When the request comes from an issue template, a maintainer can copy the
+problem statement into a request artifact, preserve the linked IDs and
+constraints, and then run the request-driven flow above. That keeps issue
+intake separate from temporary delivery planning without turning the request
+note into another persistent spec layer.

--- a/docs/guide/reviewer-workflow.md
+++ b/docs/guide/reviewer-workflow.md
@@ -261,6 +261,11 @@ assuming the PR description stayed complete after rebases or queue updates.
 `syu log --merge-base-ref origin/main` is the quickest way to ask for the
 history slice that matters since the review branch diverged from main.
 
+Use scoped Goal Plan tests and coverage to keep the PR reviewable, but treat
+the merge queue and main branch as the full integration gate. A PR can be
+small enough for focused validation and still require the repository-wide
+checks before it is considered landed.
+
 ## Merge-queue and long-lived branch review
 
 Use this variant when the branch has been rebased repeatedly, queued for merge,

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -486,6 +486,7 @@ fn repository_declares_documentation_guides() {
     let existing_repository = read_file("docs/guide/existing-repository.md");
     let implementation_planning = read_file("docs/guide/implementation-planning.md");
     let request_artifact_format = read_file("docs/guide/request-artifact-format.md");
+    let goal_plan_format = read_file("docs/guide/goal-plan-format.md");
     let node_workflow = read_file("docs/guide/node-workflow.md");
     let lsp_guide = read_file("docs/guide/lsp.md");
     let command_card = read_file("docs/guide/command-card.md");
@@ -740,6 +741,13 @@ fn repository_declares_documentation_guides() {
     assert!(vscode_guide.contains("hover is the first capability"));
     assert!(command_card.contains("[LSP guide](./lsp.md)"));
     assert!(command_card.contains("`syu lsp`"));
+    assert!(command_card.contains("syu task classify request.yaml"));
+    assert!(command_card.contains("syu task scope request.yaml"));
+    assert!(command_card.contains("syu task scaffold request.yaml"));
+    assert!(command_card.contains("syu task plan request.yaml"));
+    assert!(
+        command_card.contains("classify -> scope -> scaffold -> plan -> implementation -> check")
+    );
     assert!(lsp_guide.contains("JSON-RPC 2.0 over stdio"));
     assert!(lsp_guide.contains("textDocument/hover"));
     assert!(lsp_guide.contains("workspaceFolders"));
@@ -760,6 +768,8 @@ fn repository_declares_documentation_guides() {
     assert!(implementation_planning.contains("When to use it"));
     assert!(implementation_planning.contains("When not to use it"));
     assert!(implementation_planning.contains("create, expand, or delete"));
+    assert!(implementation_planning.contains("syu task classify request.yaml"));
+    assert!(implementation_planning.contains("syu task infer --range origin/main...HEAD"));
     let tutorial = read_file("docs/guide/tutorial.md");
     assert!(tutorial.contains("Want a different entry point?"));
     assert!(tutorial.contains("[getting started](./getting-started.md)"));
@@ -786,6 +796,12 @@ fn repository_declares_documentation_guides() {
     assert!(request_artifact_format.contains("linked_ids"));
     assert!(request_artifact_format.contains("request: >"));
     assert!(request_artifact_format.contains("Expand syu validate --fix"));
+    assert!(request_artifact_format.contains("problem statement into a request artifact"));
+    assert!(goal_plan_format.contains("The normal path is request-driven"));
+    assert!(goal_plan_format.contains("Diff-inferred fallback"));
+    assert!(goal_plan_format.contains("PR-scoped coverage target"));
+    assert!(goal_plan_format.contains("The merge queue and the main branch"));
+    assert!(goal_plan_format.contains("Goal Plans are intentionally temporary"));
     assert!(trace_adapter_support.contains("# Trace adapter capability matrix"));
     assert!(trace_adapter_support.contains("validate.require_symbol_trace_coverage"));
     assert!(trace_adapter_support.contains("TypeScript / JavaScript"));
@@ -817,6 +833,7 @@ fn repository_declares_documentation_guides() {
     assert!(merge_queue_playbook.contains("All comments must be resolved"));
     assert!(merge_queue_playbook.contains("gh pr merge 123 --auto --squash"));
     assert!(merge_queue_playbook.contains("gh-readonly-queue/main/pr-123-<sha>"));
+    assert!(reviewer_workflow.contains("full integration gate"));
     assert!(configuration.contains("validate.default_fix"));
     assert!(configuration.contains("--allow-remote"));
     assert!(configuration.contains("trace-adapter-support.md"));
@@ -1153,6 +1170,13 @@ fn repository_declares_contribution_workflow_assets() {
     assert!(squash_title_script.contains("GitHub squash merges use the PR title"));
     assert!(squash_title_script.contains("local git history traceable"));
     assert!(pr_template.contains("Linked issue or specification"));
+    assert!(pr_template.contains("Goal Plan"));
+    assert!(pr_template.contains("This PR was implemented from a request-generated Goal Plan."));
+    assert!(pr_template.contains("This PR uses an inferred Goal Plan."));
+    assert!(pr_template.contains("This PR intentionally requires broader/full validation."));
+    assert!(pr_template.contains("Goal Plan path or summary:"));
+    assert!(pr_template.contains("Selected test scope:"));
+    assert!(pr_template.contains("Coverage scope:"));
 
     assert!(pr_link_script.contains("FEAT-CONTRIB-002"));
     assert!(pr_link_script.contains("docs/syu/"));


### PR DESCRIPTION
Summary:
- Documented the request-to-goal workflow across the guide pages, including request-driven planning, diff-inferred fallback, scoped tests, coverage, and merge-queue responsibilities.
- Added a Goal Plan section to the PR template and aligned repository-quality assertions to the new contributor guidance.

Validation:
- `cargo test --test repository_quality`
- `cargo fmt --check`
- `git diff --check`

Closes #707
