### PR TITLE
Extract reusable domain and task models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,8 @@ dependencies = [
  "serde_yaml",
  "syn",
  "syu-core",
+ "syu-domain",
+ "syu-task-model",
  "tempfile",
  "tokio",
  "tower",
@@ -1016,6 +1018,25 @@ version = "0.0.1-alpha.8"
 dependencies = [
  "serde",
  "serde_yaml",
+]
+
+[[package]]
+name = "syu-domain"
+version = "0.0.1-alpha.8"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "syu-task-model"
+version = "0.0.1-alpha.8"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syu-domain",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace]
+members = [
+    ".",
+    "crates/syu-domain",
+    "crates/syu-task-model",
+]
+
 [package]
 name = "syu"
 version = "0.0.1-alpha.8"
@@ -21,6 +28,8 @@ regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34"
+syu-domain = { path = "crates/syu-domain" }
+syu-task-model = { path = "crates/syu-task-model" }
 syu-core = { path = "crates/syu-core" }
 syn = { version = "2.0.117", features = ["full"] }
 tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread", "signal"] }

--- a/crates/syu-domain/Cargo.toml
+++ b/crates/syu-domain/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "syu-domain"
+version = "0.0.1-alpha.8"
+edition = "2024"
+description = "Reusable domain models for syu"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0.150"
+serde_yaml = "0.9.34"

--- a/crates/syu-domain/src/lib.rs
+++ b/crates/syu-domain/src/lib.rs
@@ -1,0 +1,272 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpecKind {
+    Philosophy,
+    Policy,
+    Requirement,
+    Feature,
+}
+
+impl SpecKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Philosophy => "philosophy",
+            Self::Policy => "policy",
+            Self::Requirement => "requirement",
+            Self::Feature => "feature",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SpecId(pub String);
+
+impl From<String> for SpecId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SpecId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl fmt::Display for SpecId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for SpecId {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkspaceRoot(pub PathBuf);
+
+impl From<PathBuf> for WorkspaceRoot {
+    fn from(value: PathBuf) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&Path> for WorkspaceRoot {
+    fn from(value: &Path) -> Self {
+        Self(value.to_path_buf())
+    }
+}
+
+impl AsRef<Path> for WorkspaceRoot {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl fmt::Display for WorkspaceRoot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GitRange(pub String);
+
+impl From<String> for GitRange {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for GitRange {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl AsRef<str> for GitRange {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for GitRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LanguageName(pub String);
+
+impl From<String> for LanguageName {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for LanguageName {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl AsRef<str> for LanguageName {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for LanguageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Issue {
+    pub code: String,
+    pub severity: Severity,
+    pub subject: String,
+    pub location: Option<String>,
+    pub message: String,
+    pub suggestion: Option<String>,
+}
+
+impl Issue {
+    pub fn error(
+        code: impl Into<String>,
+        subject: impl Into<String>,
+        location: Option<String>,
+        message: impl Into<String>,
+        suggestion: Option<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity: Severity::Error,
+            subject: subject.into(),
+            location,
+            message: message.into(),
+            suggestion,
+        }
+    }
+
+    pub fn warning(
+        code: impl Into<String>,
+        subject: impl Into<String>,
+        location: Option<String>,
+        message: impl Into<String>,
+        suggestion: Option<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity: Severity::Warning,
+            subject: subject.into(),
+            location,
+            message: message.into(),
+            suggestion,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceReference {
+    pub file: PathBuf,
+    #[serde(default, alias = "tests", alias = "functions")]
+    pub symbols: Vec<String>,
+    #[serde(default, alias = "docs", alias = "docstrings")]
+    pub doc_contains: Vec<String>,
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GitRange, Issue, LanguageName, Severity, SpecId, SpecKind, TraceReference, WorkspaceRoot,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn issue_constructors_set_expected_severity() {
+        let error = Issue::error("e", "subject", Some("loc".to_string()), "message", None);
+        let warning = Issue::warning("w", "subject", None, "message", Some("fix".to_string()));
+
+        assert_eq!(error.severity, Severity::Error);
+        assert_eq!(warning.severity, Severity::Warning);
+        assert_eq!(warning.suggestion.as_deref(), Some("fix"));
+    }
+
+    #[test]
+    fn trace_reference_roundtrips_through_yaml_and_json() {
+        let reference = TraceReference {
+            file: PathBuf::from("tests/task.rs"),
+            symbols: vec!["smoke".to_string()],
+            doc_contains: vec!["goal plan".to_string()],
+            method: Some("get".to_string()),
+            path: Some("/tasks".to_string()),
+        };
+
+        let yaml = serde_yaml::to_string(&reference).expect("yaml");
+        let from_yaml: TraceReference = serde_yaml::from_str(&yaml).expect("yaml parse");
+        assert_eq!(reference, from_yaml);
+
+        let json = serde_json::to_string(&reference).expect("json");
+        let from_json: TraceReference = serde_json::from_str(&json).expect("json parse");
+        assert_eq!(reference, from_json);
+    }
+
+    #[test]
+    fn wrapper_types_serialize_as_strings() {
+        let spec_id = SpecId::from("REQ-001");
+        let workspace_root = WorkspaceRoot::from(PathBuf::from("/repo"));
+        let git_range = GitRange::from("origin/main...HEAD");
+        let language = LanguageName::from("rust");
+
+        assert_eq!(
+            serde_json::to_string(&spec_id).expect("json"),
+            "\"REQ-001\""
+        );
+        assert_eq!(
+            serde_json::to_string(&workspace_root).expect("json"),
+            "\"/repo\""
+        );
+        assert_eq!(
+            serde_json::to_string(&git_range).expect("json"),
+            "\"origin/main...HEAD\""
+        );
+        assert_eq!(serde_json::to_string(&language).expect("json"), "\"rust\"");
+    }
+
+    #[test]
+    fn spec_kind_labels_are_stable() {
+        assert_eq!(SpecKind::Philosophy.label(), "philosophy");
+        assert_eq!(SpecKind::Policy.label(), "policy");
+        assert_eq!(SpecKind::Requirement.label(), "requirement");
+        assert_eq!(SpecKind::Feature.label(), "feature");
+    }
+}

--- a/crates/syu-task-model/Cargo.toml
+++ b/crates/syu-task-model/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "syu-task-model"
+version = "0.0.1-alpha.8"
+edition = "2024"
+description = "Reusable task planning models for syu"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+syu-domain = { path = "../syu-domain" }
+
+[dev-dependencies]
+serde_json = "1.0.150"
+serde_yaml = "0.9.34"

--- a/crates/syu-task-model/src/lib.rs
+++ b/crates/syu-task-model/src/lib.rs
@@ -1,0 +1,626 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub use syu_domain::{GitRange, LanguageName, SpecId, SpecKind, WorkspaceRoot};
+use syu_domain::{Issue, Severity, TraceReference};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SearchResult {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestClassification {
+    Create,
+    Change,
+    Delete,
+}
+
+impl RequestClassification {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Create => "requirement_create",
+            Self::Change => "requirement_change",
+            Self::Delete => "requirement_delete",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestArtifact {
+    pub version: u32,
+    pub request: String,
+    #[serde(default)]
+    pub context: RequestArtifactContext,
+}
+
+impl RequestArtifact {
+    pub fn analysis_text(&self) -> String {
+        let mut text = String::new();
+        text.push_str(&self.request);
+        if let Some(affected_area) = &self.context.affected_area {
+            text.push('\n');
+            text.push_str(affected_area);
+        }
+        for constraint in &self.context.repository_constraints {
+            text.push('\n');
+            text.push_str(constraint);
+        }
+        for id in &self.context.linked_ids {
+            text.push('\n');
+            text.push_str(id);
+        }
+        text
+    }
+
+    pub fn explicit_ids(&self) -> Vec<String> {
+        let mut ids = self.context.linked_ids.clone();
+        ids.extend(extract_spec_ids(&self.request));
+        if let Some(affected_area) = &self.context.affected_area {
+            ids.extend(extract_spec_ids(affected_area));
+        }
+        ids.sort();
+        ids.dedup();
+        ids
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestArtifactContext {
+    #[serde(default)]
+    pub affected_area: Option<String>,
+    #[serde(default)]
+    pub repository_constraints: Vec<String>,
+    #[serde(default)]
+    pub linked_ids: Vec<String>,
+}
+
+fn extract_spec_ids(text: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+            current.push(ch);
+        } else if !current.is_empty() {
+            if is_spec_id(&current) {
+                ids.push(current.clone());
+            }
+            current.clear();
+        }
+    }
+    if !current.is_empty() && is_spec_id(&current) {
+        ids.push(current);
+    }
+    ids
+}
+
+fn is_spec_id(value: &str) -> bool {
+    value.starts_with("PHIL-")
+        || value.starts_with("POL-")
+        || value.starts_with("REQ-")
+        || value.starts_with("FEAT-")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanArtifact {
+    pub version: u32,
+    pub kind: String,
+    #[serde(default)]
+    pub request_path: Option<String>,
+    #[serde(default)]
+    pub request: Option<String>,
+    #[serde(default)]
+    pub classification: Option<String>,
+    #[serde(default)]
+    pub source: GoalPlanSource,
+    pub goal: GoalPlanGoal,
+    #[serde(default)]
+    pub spec_mapping: GoalPlanSpecMapping,
+    pub implementation_plan: GoalPlanImplementationPlan,
+    pub test_plan: GoalPlanTestPlan,
+    pub coverage: GoalPlanCoverage,
+    pub completion: GoalPlanCompletion,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanSourceEvidence {
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(default)]
+    pub traced_requirements: Vec<String>,
+    #[serde(default)]
+    pub traced_features: Vec<String>,
+    #[serde(default)]
+    pub traced_policies: Vec<String>,
+    #[serde(default)]
+    pub traced_philosophies: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanSource {
+    pub mode: GoalPlanSourceMode,
+    #[serde(default)]
+    pub request_artifact: Option<String>,
+    #[serde(default)]
+    pub classification: Option<String>,
+    #[serde(default)]
+    pub range: Option<String>,
+    #[serde(default)]
+    pub confidence: Option<GoalPlanConfidence>,
+    #[serde(default)]
+    pub evidence: Option<GoalPlanSourceEvidence>,
+}
+
+impl Default for GoalPlanSource {
+    fn default() -> Self {
+        Self {
+            mode: GoalPlanSourceMode::RequestDriven,
+            request_artifact: None,
+            classification: None,
+            range: None,
+            confidence: None,
+            evidence: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPlanSourceMode {
+    #[default]
+    #[serde(rename = "request_driven")]
+    RequestDriven,
+    #[serde(rename = "diff_inferred")]
+    DiffInferred,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPlanConfidence {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanGoal {
+    pub id: String,
+    pub title: String,
+    pub statement: String,
+    #[serde(default)]
+    pub non_goals: Vec<String>,
+    #[serde(default)]
+    pub inferred: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanSpecMapping {
+    #[serde(default)]
+    pub persistent_items: GoalPlanPersistentItems,
+    #[serde(default)]
+    pub spec_updates: GoalPlanSpecUpdates,
+    #[serde(default)]
+    pub spec_updates_required: bool,
+    #[serde(default)]
+    pub spec_update_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanPersistentItems {
+    #[serde(default)]
+    pub philosophies: Vec<GoalPlanPersistentItem>,
+    #[serde(default)]
+    pub policies: Vec<GoalPlanPersistentItem>,
+    #[serde(default)]
+    pub requirements: Vec<GoalPlanPersistentItem>,
+    #[serde(default)]
+    pub features: Vec<GoalPlanPersistentItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GoalPlanPersistentItem {
+    Id(String),
+    Item(GoalPlanPersistentItemDetails),
+}
+
+impl GoalPlanPersistentItem {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Id(id) => id,
+            Self::Item(item) => &item.id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanPersistentItemDetails {
+    pub id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub document_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanSpecUpdates {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub expected_updates: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanImplementationPlan {
+    #[serde(default)]
+    pub confidence: Option<GoalPlanConfidence>,
+    pub scope: GoalPlanScope,
+    #[serde(default)]
+    pub steps: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanScope {
+    #[serde(default)]
+    pub include: Vec<GoalPlanScopeInclude>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GoalPlanScopeInclude {
+    Pattern(String),
+    Entry(GoalPlanScopeIncludeDetails),
+}
+
+impl GoalPlanScopeInclude {
+    pub fn pattern(&self) -> &str {
+        match self {
+            Self::Pattern(pattern) => pattern,
+            Self::Entry(entry) => &entry.file,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanScopeIncludeDetails {
+    pub file: String,
+    #[serde(default)]
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanTestPlan {
+    pub selection_mode: GoalPlanSelectionMode,
+    #[serde(default)]
+    pub confidence: Option<GoalPlanConfidence>,
+    #[serde(default)]
+    pub required_tests: BTreeMap<String, Vec<TraceReference>>,
+    #[serde(default)]
+    pub suggested_tests: BTreeMap<String, Vec<TraceReference>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPlanSelectionMode {
+    #[default]
+    #[serde(rename = "minimal")]
+    Minimal,
+    #[serde(rename = "affected")]
+    Affected,
+    #[serde(rename = "full")]
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanCoverage {
+    pub mode: GoalPlanCoverageMode,
+    pub threshold: u32,
+    #[serde(default)]
+    pub include: Vec<String>,
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalPlanCoverageMode {
+    #[default]
+    #[serde(rename = "changed_lines")]
+    ChangedLines,
+    #[serde(rename = "affected")]
+    Affected,
+    #[serde(rename = "full")]
+    Full,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanCompletion {
+    #[serde(default)]
+    pub must_pass: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalPlanCheckReport {
+    pub plan_path: String,
+    pub range: String,
+    pub changed_files: Vec<String>,
+    pub issues: Vec<Issue>,
+}
+
+impl GoalPlanCheckReport {
+    pub fn passed(&self) -> bool {
+        self.issues
+            .iter()
+            .all(|issue| issue.severity != Severity::Error)
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Warning)
+            .count()
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.issues
+            .iter()
+            .filter(|issue| issue.severity == Severity::Error)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScopeSignals {
+    pub policy_discussion: bool,
+    pub philosophy_discussion: bool,
+    pub planned_feature_updates: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScopeFeatureCandidate {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+    pub linked_requirements: Vec<String>,
+    pub planned_state_update: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClassificationOutcome {
+    pub classification: RequestClassification,
+    pub reasons: Vec<String>,
+    pub explicit_items: Vec<SearchResult>,
+    pub related_items: Vec<SearchResult>,
+    pub request: String,
+    pub context: RequestArtifactContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScopeOutcome {
+    pub classification: ClassificationOutcome,
+    pub signals: ScopeSignals,
+    pub requirements: Vec<SearchResult>,
+    pub features: Vec<ScopeFeatureCandidate>,
+    pub policies: Vec<SearchResult>,
+    pub philosophies: Vec<SearchResult>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScaffoldUpdate {
+    pub kind: ScaffoldUpdateKind,
+    pub action: ScaffoldAction,
+    pub path: String,
+    pub id: Option<String>,
+    pub contents: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScaffoldUpdateKind {
+    Requirement,
+    Feature,
+    FeatureRegistry,
+}
+
+impl ScaffoldUpdateKind {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Requirement => "requirement",
+            Self::Feature => "feature",
+            Self::FeatureRegistry => "feature registry",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScaffoldAction {
+    Create,
+    Update,
+    Append,
+}
+
+impl ScaffoldAction {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Update => "update",
+            Self::Append => "append",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScaffoldPlan {
+    pub updates: Vec<ScaffoldUpdate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskTestSelectionPlan {
+    pub goal_id: String,
+    pub goal_title: String,
+    pub selection_mode: String,
+    pub commands: Vec<TaskTestSelectionCommand>,
+    pub escalation: TaskTestSelectionEscalation,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskTestSelectionCommand {
+    pub language: String,
+    pub command: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskTestSelectionEscalation {
+    pub level: String,
+    pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_artifact_yaml() -> &'static str {
+        "version: 1\nrequest: Update FEAT-001 and REQ-001\ncontext:\n  affected_area: core\n  repository_constraints:\n    - keep text and JSON output\n  linked_ids:\n    - REQ-001\n"
+    }
+
+    fn goal_plan_yaml() -> &'static str {
+        "version: 1\nkind: syu.goal_plan\nrequest_path: request.yaml\nrequest: Update FEAT-001 and REQ-001\nclassification: requirement_change\nsource:\n  mode: diff_inferred\n  request_artifact: request.yaml\n  classification: requirement_change\n  range: origin/main...HEAD\n  confidence: high\n  evidence:\n    changed_files:\n      - src/command/task.rs\n    traced_requirements:\n      - REQ-001\ngoal:\n  id: GOAL-001\n  title: Keep planning explicit\n  statement: Capture implementation intent without creating a fifth persistent spec layer.\n  inferred: true\n  non_goals:\n    - Add persistent task specs under spec.root\nspec_mapping:\n  persistent_items:\n    philosophies:\n      - PHIL-001\n    policies:\n      - POL-001\n    requirements:\n      - REQ-001\n    features:\n      - FEAT-001\n  spec_updates:\n    required: false\n    expected_updates: []\n  spec_updates_required: false\nimplementation_plan:\n  confidence: high\n  scope:\n    include:\n      - src/command/task.rs\n    exclude:\n      - docs/syu/**\n  steps:\n    - add a Goal Plan model\ntest_plan:\n  selection_mode: affected\n  confidence: high\n  required_tests:\n    rust:\n      - file: tests/task_command.rs\n        symbols:\n          - task_plan_generates_goal_from_request\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\n  include:\n    - src/command/task.rs\n  exclude: []\ncompletion:\n  must_pass:\n    - syu validate .\n"
+    }
+
+    #[test]
+    fn request_artifact_yaml_roundtrip() {
+        let artifact: RequestArtifact = serde_yaml::from_str(request_artifact_yaml())
+            .expect("request artifact should deserialize");
+        assert_eq!(artifact.version, 1);
+        assert_eq!(artifact.context.affected_area.as_deref(), Some("core"));
+
+        let yaml = serde_yaml::to_string(&artifact).expect("request artifact yaml");
+        let roundtrip: RequestArtifact =
+            serde_yaml::from_str(&yaml).expect("request artifact should roundtrip through yaml");
+        assert_eq!(artifact, roundtrip);
+
+        let json = serde_json::to_string_pretty(&artifact).expect("request artifact json");
+        let roundtrip_json: RequestArtifact =
+            serde_json::from_str(&json).expect("request artifact should roundtrip through json");
+        assert_eq!(artifact, roundtrip_json);
+    }
+
+    #[test]
+    fn goal_plan_yaml_roundtrip() {
+        let artifact: GoalPlanArtifact =
+            serde_yaml::from_str(goal_plan_yaml()).expect("goal plan should deserialize");
+        assert_eq!(artifact.kind, "syu.goal_plan");
+        assert!(matches!(
+            artifact.source.mode,
+            GoalPlanSourceMode::DiffInferred
+        ));
+        assert_eq!(artifact.goal.id, "GOAL-001");
+
+        let yaml = serde_yaml::to_string(&artifact).expect("goal plan yaml");
+        let roundtrip: GoalPlanArtifact =
+            serde_yaml::from_str(&yaml).expect("goal plan should roundtrip through yaml");
+        assert_eq!(artifact, roundtrip);
+
+        let json = serde_json::to_string_pretty(&artifact).expect("goal plan json");
+        let roundtrip_json: GoalPlanArtifact =
+            serde_json::from_str(&json).expect("goal plan should roundtrip through json");
+        assert_eq!(artifact, roundtrip_json);
+    }
+
+    #[test]
+    fn rejects_unknown_fields_at_artifact_boundaries() {
+        let err =
+            serde_yaml::from_str::<RequestArtifact>("version: 1\nrequest: Example\nextra: nope\n")
+                .expect_err("unknown request artifact field should fail");
+        assert!(err.to_string().contains("extra"));
+
+        let err = serde_yaml::from_str::<GoalPlanArtifact>(
+            "version: 1\nkind: syu.goal_plan\nunexpected: nope\nsource:\n  mode: request_driven\ngoal:\n  id: GOAL-001\n  title: Example\n  statement: Example\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: minimal\n  required_tests: {}\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect_err("unknown goal plan field should fail");
+        assert!(err.to_string().contains("unexpected"));
+    }
+
+    #[test]
+    fn supports_request_driven_and_diff_inferred_sources() {
+        let request_driven: GoalPlanArtifact = serde_yaml::from_str(
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\ngoal:\n  id: GOAL-001\n  title: Example\n  statement: Example\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: minimal\n  required_tests: {}\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect("request-driven plan should parse");
+        assert!(matches!(
+            request_driven.source.mode,
+            GoalPlanSourceMode::RequestDriven
+        ));
+
+        let diff_inferred: GoalPlanArtifact = serde_yaml::from_str(
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: diff_inferred\n  range: origin/main...HEAD\n  confidence: medium\n  evidence:\n    changed_files:\n      - src/command/task.rs\ngoal:\n  id: GOAL-001\n  title: Example\n  statement: Example\n  inferred: true\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: minimal\n  required_tests: {}\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect("diff-inferred plan should parse");
+        assert!(matches!(
+            diff_inferred.source.mode,
+            GoalPlanSourceMode::DiffInferred
+        ));
+        assert_eq!(
+            diff_inferred.source.range.as_deref(),
+            Some("origin/main...HEAD")
+        );
+        assert_eq!(
+            diff_inferred.source.confidence,
+            Some(GoalPlanConfidence::Medium)
+        );
+    }
+
+    #[test]
+    fn empty_required_test_symbols_are_preserved_for_validation_layers() {
+        let artifact: GoalPlanArtifact = serde_yaml::from_str(
+            "version: 1\nkind: syu.goal_plan\nsource:\n  mode: request_driven\ngoal:\n  id: GOAL-001\n  title: Example\n  statement: Example\nimplementation_plan:\n  scope:\n    include: []\n    exclude: []\n  steps: []\ntest_plan:\n  selection_mode: affected\n  required_tests:\n    rust:\n      - file: tests/task_command.rs\n        symbols: []\n  suggested_tests: {}\ncoverage:\n  mode: changed_lines\n  threshold: 100\ncompletion:\n  must_pass: []\n",
+        )
+        .expect("goal plan with empty symbols should parse");
+
+        let symbols = &artifact
+            .test_plan
+            .required_tests
+            .get("rust")
+            .expect("language should be present")[0]
+            .symbols;
+        assert!(symbols.is_empty());
+    }
+}

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Result, bail};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use serde::Serialize;
+#[allow(unused_imports)]
 use syu_task_model::{
     ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanCompletion,
     GoalPlanConfidence, GoalPlanCoverage, GoalPlanCoverageMode, GoalPlanGoal,

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -16,7 +16,19 @@ use std::{
 use anyhow::{Context, Result, bail};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use syu_task_model::{
+    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanCompletion,
+    GoalPlanConfidence, GoalPlanCoverage, GoalPlanCoverageMode, GoalPlanGoal,
+    GoalPlanImplementationPlan, GoalPlanPersistentItem, GoalPlanPersistentItemDetails,
+    GoalPlanPersistentItems, GoalPlanScope, GoalPlanScopeInclude, GoalPlanScopeIncludeDetails,
+    GoalPlanSelectionMode, GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSourceMode,
+    GoalPlanSpecMapping, GoalPlanSpecUpdates, GoalPlanTestPlan, RequestArtifact,
+    RequestArtifactContext, RequestClassification as RequirementAction, ScaffoldAction,
+    ScaffoldPlan, ScaffoldUpdate, ScaffoldUpdateKind, ScopeFeatureCandidate, ScopeOutcome,
+    ScopeSignals, SearchResult as TaskSearchResult, TaskTestSelectionCommand,
+    TaskTestSelectionEscalation, TaskTestSelectionPlan,
+};
 
 use crate::{
     cli::{
@@ -26,7 +38,7 @@ use crate::{
     },
     coverage::normalize_relative_path,
     language::adapter_for_language,
-    model::{Issue, Severity},
+    model::Issue,
     workspace::load_workspace,
 };
 
@@ -37,320 +49,14 @@ use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
 const REQUEST_ARTIFACT_VERSION: u32 = 1;
 const GOAL_PLAN_VERSION: u32 = 1;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum RequirementAction {
-    Create,
-    Change,
-    Delete,
-}
-
-impl RequirementAction {
-    const fn label(self) -> &'static str {
-        match self {
-            Self::Create => "requirement_create",
-            Self::Change => "requirement_change",
-            Self::Delete => "requirement_delete",
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct RequestArtifact {
-    version: u32,
-    request: String,
-    #[serde(default)]
-    context: RequestArtifactContext,
-}
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanArtifact {
-    version: u32,
-    kind: String,
-    #[serde(default)]
-    request_path: Option<String>,
-    #[serde(default)]
-    request: Option<String>,
-    #[serde(default)]
-    classification: Option<String>,
-    #[serde(default)]
-    source: GoalPlanSource,
-    goal: GoalPlanGoal,
-    #[serde(default)]
-    spec_mapping: GoalPlanSpecMapping,
-    implementation_plan: GoalPlanImplementationPlan,
-    test_plan: GoalPlanTestPlan,
-    coverage: GoalPlanCoverage,
-    completion: GoalPlanCompletion,
-    #[serde(default)]
-    warnings: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone, Default)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanSourceEvidence {
-    #[serde(default)]
-    changed_files: Vec<String>,
-    #[serde(default)]
-    traced_requirements: Vec<String>,
-    #[serde(default)]
-    traced_features: Vec<String>,
-    #[serde(default)]
-    traced_policies: Vec<String>,
-    #[serde(default)]
-    traced_philosophies: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanSource {
-    mode: GoalPlanSourceMode,
-    #[serde(default)]
-    request_artifact: Option<String>,
-    #[serde(default)]
-    classification: Option<String>,
-    #[serde(default)]
-    range: Option<String>,
-    #[serde(default)]
-    confidence: Option<GoalPlanConfidence>,
-    #[serde(default)]
-    evidence: Option<GoalPlanSourceEvidence>,
-}
-
-impl Default for GoalPlanSource {
-    fn default() -> Self {
-        Self {
-            mode: GoalPlanSourceMode::RequestDriven,
-            request_artifact: None,
-            classification: None,
-            range: None,
-            confidence: None,
-            evidence: None,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-enum GoalPlanSourceMode {
-    #[default]
-    #[serde(rename = "request_driven")]
-    RequestDriven,
-    #[serde(rename = "diff_inferred")]
-    DiffInferred,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum GoalPlanConfidence {
-    High,
-    Medium,
-    Low,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanGoal {
-    id: String,
-    title: String,
-    statement: String,
-    #[serde(default)]
-    non_goals: Vec<String>,
-    #[serde(default)]
-    inferred: bool,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanSpecMapping {
-    #[serde(default)]
-    persistent_items: GoalPlanPersistentItems,
-    #[serde(default)]
-    spec_updates: GoalPlanSpecUpdates,
-    #[serde(default)]
-    spec_updates_required: bool,
-    #[serde(default)]
-    spec_update_reasons: Vec<String>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanPersistentItems {
-    #[serde(default)]
-    philosophies: Vec<GoalPlanPersistentItem>,
-    #[serde(default)]
-    policies: Vec<GoalPlanPersistentItem>,
-    #[serde(default)]
-    requirements: Vec<GoalPlanPersistentItem>,
-    #[serde(default)]
-    features: Vec<GoalPlanPersistentItem>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(untagged)]
-enum GoalPlanPersistentItem {
-    Id(String),
-    Item(GoalPlanPersistentItemDetails),
-}
-
-impl GoalPlanPersistentItem {
-    fn id(&self) -> &str {
-        match self {
-            GoalPlanPersistentItem::Id(id) => id,
-            GoalPlanPersistentItem::Item(item) => &item.id,
-        }
-    }
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanPersistentItemDetails {
-    id: String,
-    #[serde(default)]
-    title: Option<String>,
-    #[serde(default)]
-    document_path: Option<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(untagged)]
-enum GoalPlanScopeInclude {
-    Pattern(String),
-    Entry(GoalPlanScopeIncludeDetails),
-}
-
-impl GoalPlanScopeInclude {
-    fn pattern(&self) -> &str {
-        match self {
-            GoalPlanScopeInclude::Pattern(pattern) => pattern,
-            GoalPlanScopeInclude::Entry(entry) => &entry.file,
-        }
-    }
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanScopeIncludeDetails {
-    file: String,
-    #[serde(default)]
-    symbols: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanSpecUpdates {
-    #[serde(default)]
-    required: bool,
-    #[serde(default)]
-    expected_updates: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanImplementationPlan {
-    #[serde(default)]
-    confidence: Option<GoalPlanConfidence>,
-    scope: GoalPlanScope,
-    #[serde(default)]
-    steps: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanScope {
-    #[serde(default)]
-    include: Vec<GoalPlanScopeInclude>,
-    #[serde(default)]
-    exclude: Vec<String>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanTestPlan {
-    selection_mode: GoalPlanSelectionMode,
-    #[serde(default)]
-    confidence: Option<GoalPlanConfidence>,
-    #[serde(default)]
-    required_tests: BTreeMap<String, Vec<crate::model::TraceReference>>,
-    #[serde(default)]
-    suggested_tests: BTreeMap<String, Vec<crate::model::TraceReference>>,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-enum GoalPlanSelectionMode {
-    #[default]
-    #[serde(rename = "minimal")]
-    Minimal,
-    #[serde(rename = "affected")]
-    Affected,
-    #[serde(rename = "full")]
-    Full,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanCoverage {
-    mode: GoalPlanCoverageMode,
-    threshold: u32,
-    #[serde(default)]
-    include: Vec<String>,
-    #[serde(default)]
-    exclude: Vec<String>,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-enum GoalPlanCoverageMode {
-    #[default]
-    #[serde(rename = "changed_lines")]
-    ChangedLines,
-    #[serde(rename = "affected")]
-    Affected,
-    #[serde(rename = "full")]
-    Full,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize, Default, Clone)]
-#[serde(deny_unknown_fields)]
-struct GoalPlanCompletion {
-    #[serde(default)]
-    must_pass: Vec<String>,
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
-struct RequestArtifactContext {
-    #[serde(default)]
-    affected_area: Option<String>,
-    #[serde(default)]
-    repository_constraints: Vec<String>,
-    #[serde(default)]
-    linked_ids: Vec<String>,
-}
-
 #[derive(Debug, Serialize)]
 struct JsonTaskClassifyOutput {
     request_path: String,
     request: String,
     classification: String,
     reasons: Vec<String>,
-    explicit_items: Vec<SearchResult>,
-    related_items: Vec<SearchResult>,
+    explicit_items: Vec<TaskSearchResult>,
+    related_items: Vec<TaskSearchResult>,
     context: JsonRequestArtifactContext,
 }
 
@@ -361,10 +67,10 @@ struct JsonTaskScopeOutput {
     classification: String,
     reasons: Vec<String>,
     signals: JsonScopeSignals,
-    requirements: Vec<SearchResult>,
+    requirements: Vec<TaskSearchResult>,
     features: Vec<ScopeFeatureCandidate>,
-    policies: Vec<SearchResult>,
-    philosophies: Vec<SearchResult>,
+    policies: Vec<TaskSearchResult>,
+    philosophies: Vec<TaskSearchResult>,
     context: JsonRequestArtifactContext,
 }
 
@@ -550,79 +256,6 @@ struct JsonScopeSignals {
     philosophy_discussion: bool,
     planned_feature_updates: bool,
 }
-
-#[derive(Debug)]
-struct GoalPlanCheckReport {
-    plan_path: String,
-    range: String,
-    changed_files: Vec<String>,
-    issues: Vec<Issue>,
-}
-
-impl GoalPlanCheckReport {
-    fn passed(&self) -> bool {
-        self.issues
-            .iter()
-            .all(|issue| issue.severity != Severity::Error)
-    }
-
-    fn warning_count(&self) -> usize {
-        self.issues
-            .iter()
-            .filter(|issue| issue.severity == Severity::Warning)
-            .count()
-    }
-
-    fn error_count(&self) -> usize {
-        self.issues
-            .iter()
-            .filter(|issue| issue.severity == Severity::Error)
-            .count()
-    }
-}
-
-#[derive(Debug)]
-struct ScopeOutcome {
-    classification: ClassificationOutcome,
-    signals: ScopeSignals,
-    requirements: Vec<SearchResult>,
-    features: Vec<ScopeFeatureCandidate>,
-    policies: Vec<SearchResult>,
-    philosophies: Vec<SearchResult>,
-    notes: Vec<String>,
-}
-
-#[derive(Debug)]
-struct ClassificationOutcome {
-    classification: RequirementAction,
-    reasons: Vec<String>,
-    explicit_items: Vec<SearchResult>,
-    related_items: Vec<SearchResult>,
-    request: String,
-    context: RequestArtifactContext,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ScopeSignals {
-    policy_discussion: bool,
-    philosophy_discussion: bool,
-    planned_feature_updates: bool,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ScopeFeatureCandidate {
-    id: String,
-    title: String,
-    status: String,
-    linked_requirements: Vec<String>,
-    planned_state_update: bool,
-}
-
-#[derive(Debug)]
-struct ScaffoldPlan {
-    updates: Vec<ScaffoldUpdate>,
-}
-
 #[derive(Debug)]
 struct DiffInferenceOutcome {
     scope: ScopeOutcome,
@@ -632,77 +265,11 @@ struct DiffInferenceOutcome {
     warnings: Vec<String>,
 }
 
-#[derive(Debug)]
-struct TaskTestSelectionPlan {
-    goal_id: String,
-    goal_title: String,
-    selection_mode: String,
-    commands: Vec<TaskTestSelectionCommand>,
-    escalation: TaskTestSelectionEscalation,
-    warnings: Vec<String>,
-}
-
-#[derive(Debug)]
-struct TaskTestSelectionCommand {
-    language: String,
-    command: String,
-    reason: String,
-}
-
-#[derive(Debug)]
-struct TaskTestSelectionEscalation {
-    level: String,
-    reason: String,
-}
-
 #[derive(Debug, Default)]
 struct TaskTestSelectionEntry {
     symbols: BTreeSet<String>,
     reasons: BTreeSet<String>,
     whole_file: bool,
-}
-
-#[derive(Debug)]
-struct ScaffoldUpdate {
-    kind: ScaffoldUpdateKind,
-    action: ScaffoldAction,
-    path: String,
-    id: Option<String>,
-    contents: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScaffoldUpdateKind {
-    Requirement,
-    Feature,
-    FeatureRegistry,
-}
-
-impl ScaffoldUpdateKind {
-    const fn label(self) -> &'static str {
-        match self {
-            Self::Requirement => "requirement",
-            Self::Feature => "feature",
-            Self::FeatureRegistry => "feature registry",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScaffoldAction {
-    Create,
-    Update,
-    Append,
-}
-
-impl ScaffoldAction {
-    const fn label(self) -> &'static str {
-        match self {
-            Self::Create => "create",
-            Self::Update => "update",
-            Self::Append => "append",
-        }
-    }
 }
 
 pub fn run_task_command(args: &TaskArgs) -> Result<i32> {
@@ -1848,6 +1415,8 @@ fn infer_diff_plan(
     let direct_items = direct_items.into_values().collect::<Vec<_>>();
     let related_items = collect_related_inference_items(lookup, &direct_items);
     let related_and_direct = merge_inference_items(&direct_items, &related_items);
+    let direct_task_items = to_task_search_results(&direct_items);
+    let related_task_items = to_task_search_results(&related_items);
     let classification = ClassificationOutcome {
         classification: infer_requirement_action(&direct_items, &related_items),
         reasons: build_inference_reasons(
@@ -1858,16 +1427,30 @@ fn infer_diff_plan(
             &direct_items,
             &related_items,
         ),
-        explicit_items: direct_items.clone(),
-        related_items: related_items.clone(),
+        explicit_items: direct_task_items,
+        related_items: related_task_items,
         request: format!("git diff {range}"),
         context: RequestArtifactContext::default(),
     };
 
-    let requirements =
-        collect_scoped_results(&direct_items, &related_and_direct, "requirement", 50);
-    let policies = collect_scoped_results(&direct_items, &related_and_direct, "policy", 50);
-    let philosophies = collect_scoped_results(&direct_items, &related_and_direct, "philosophy", 50);
+    let requirements = to_task_search_results(&collect_scoped_results(
+        &direct_items,
+        &related_and_direct,
+        "requirement",
+        50,
+    ));
+    let policies = to_task_search_results(&collect_scoped_results(
+        &direct_items,
+        &related_and_direct,
+        "policy",
+        50,
+    ));
+    let philosophies = to_task_search_results(&collect_scoped_results(
+        &direct_items,
+        &related_and_direct,
+        "philosophy",
+        50,
+    ));
     let features = collect_feature_candidates(
         lookup,
         &direct_items,
@@ -2461,8 +2044,11 @@ fn is_shared_utility_path(path: &Path) -> bool {
         || rendered.contains("generated")
 }
 
-fn collect_ids_by_kind(items: &[SearchResult]) -> Vec<String> {
-    let mut ids = items.iter().map(|item| item.id.clone()).collect::<Vec<_>>();
+fn collect_ids_by_kind<T: SearchResultView>(items: &[T]) -> Vec<String> {
+    let mut ids = items
+        .iter()
+        .map(|item| item.id().to_string())
+        .collect::<Vec<_>>();
     ids.sort();
     ids.dedup();
     ids
@@ -2533,7 +2119,7 @@ fn collect_task_plan_persistent_items(
             title: result.title.clone(),
             document_path: lookup.document_path_for_id(&result.id)?,
         };
-        match result.kind {
+        match result.kind.as_str() {
             "philosophy" => items.philosophies.push(item),
             "policy" => items.policies.push(item),
             "requirement" => items.requirements.push(item),
@@ -2856,6 +2442,8 @@ fn classify_request(
     let mut related_items = collect_related_items(&lookup, &artifact.request);
     merge_related_items(&mut related_items, lookup.search(&analysis_text, None));
     related_items.truncate(5);
+    let explicit_task_items = to_task_search_results(&explicit_items);
+    let related_task_items = to_task_search_results(&related_items);
 
     let mut reasons = Vec::new();
     if delete_hits > 0 {
@@ -2927,8 +2515,8 @@ fn classify_request(
     Ok(ClassificationOutcome {
         classification,
         reasons,
-        explicit_items,
-        related_items,
+        explicit_items: explicit_task_items,
+        related_items: related_task_items,
         request: artifact.request.clone(),
         context: artifact.context.clone(),
     })
@@ -2946,9 +2534,24 @@ fn scope_request(
     let explicit_items = collect_explicit_items(&lookup, &explicit_ids);
     let search_results = lookup.search(&analysis_text, None);
 
-    let requirements = collect_scoped_results(&explicit_items, &search_results, "requirement", 5);
-    let policies = collect_scoped_results(&explicit_items, &search_results, "policy", 5);
-    let philosophies = collect_scoped_results(&explicit_items, &search_results, "philosophy", 5);
+    let requirements = to_task_search_results(&collect_scoped_results(
+        &explicit_items,
+        &search_results,
+        "requirement",
+        5,
+    ));
+    let policies = to_task_search_results(&collect_scoped_results(
+        &explicit_items,
+        &search_results,
+        "policy",
+        5,
+    ));
+    let philosophies = to_task_search_results(&collect_scoped_results(
+        &explicit_items,
+        &search_results,
+        "philosophy",
+        5,
+    ));
     let features = collect_feature_candidates(
         &lookup,
         &explicit_items,
@@ -3113,37 +2716,6 @@ fn build_scaffold_plan(
     Ok(ScaffoldPlan { updates })
 }
 
-impl RequestArtifact {
-    fn analysis_text(&self) -> String {
-        let mut text = String::new();
-        text.push_str(&self.request);
-        if let Some(affected_area) = &self.context.affected_area {
-            text.push('\n');
-            text.push_str(affected_area);
-        }
-        for constraint in &self.context.repository_constraints {
-            text.push('\n');
-            text.push_str(constraint);
-        }
-        for id in &self.context.linked_ids {
-            text.push('\n');
-            text.push_str(id);
-        }
-        text
-    }
-
-    fn explicit_ids(&self) -> Vec<String> {
-        let mut ids = self.context.linked_ids.clone();
-        ids.extend(extract_spec_ids(&self.request));
-        if let Some(affected_area) = &self.context.affected_area {
-            ids.extend(extract_spec_ids(affected_area));
-        }
-        ids.sort();
-        ids.dedup();
-        ids
-    }
-}
-
 fn collect_explicit_items(lookup: &WorkspaceLookup<'_>, ids: &[String]) -> Vec<SearchResult> {
     let mut items = BTreeMap::<String, SearchResult>::new();
     for id in ids {
@@ -3245,6 +2817,18 @@ fn item_to_search_result(item: WorkspaceEntity<'_>) -> SearchResult {
             title: item.title.clone(),
         },
     }
+}
+
+fn to_task_search_result(item: &SearchResult) -> TaskSearchResult {
+    TaskSearchResult {
+        id: item.id.clone(),
+        kind: item.kind.to_string(),
+        title: item.title.clone(),
+    }
+}
+
+fn to_task_search_results(items: &[SearchResult]) -> Vec<TaskSearchResult> {
+    items.iter().map(to_task_search_result).collect()
 }
 
 fn print_classify_text_output(request_path: &Path, outcome: &ClassificationOutcome) {
@@ -3822,7 +3406,41 @@ fn is_production_path(path: &Path) -> bool {
         || matches!(rendered.as_str(), "build.rs" | "Cargo.toml" | "Cargo.lock")
 }
 
-fn print_items(heading: &str, items: &[SearchResult]) {
+trait SearchResultView {
+    fn id(&self) -> &str;
+    fn kind(&self) -> &str;
+    fn title(&self) -> &str;
+}
+
+impl SearchResultView for SearchResult {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn kind(&self) -> &str {
+        self.kind
+    }
+
+    fn title(&self) -> &str {
+        self.title.as_str()
+    }
+}
+
+impl SearchResultView for TaskSearchResult {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn kind(&self) -> &str {
+        self.kind.as_str()
+    }
+
+    fn title(&self) -> &str {
+        self.title.as_str()
+    }
+}
+
+fn print_items<T: SearchResultView>(heading: &str, items: &[T]) {
     println!("{heading}:");
     if items.is_empty() {
         println!("- none");
@@ -3830,7 +3448,7 @@ fn print_items(heading: &str, items: &[SearchResult]) {
     }
 
     for item in items {
-        println!("- {}\t{}\t{}", item.id, item.kind, item.title);
+        println!("- {}\t{}\t{}", item.id(), item.kind(), item.title());
     }
 }
 
@@ -4221,16 +3839,6 @@ fn describe_keyword_hits(text: &str, keywords: &[&str]) -> String {
         .filter(|keyword| text.contains(keyword))
         .collect::<Vec<_>>()
         .join(", ")
-}
-
-fn extract_spec_ids(text: &str) -> Vec<String> {
-    static SPEC_ID_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
-    let re = SPEC_ID_RE.get_or_init(|| {
-        Regex::new(r"\b(?:PHIL|POL|REQ|FEAT)-[A-Z0-9][A-Z0-9-]*\b")
-            .expect("spec id regex should compile")
-    });
-
-    re.find_iter(text).map(|m| m.as_str().to_string()).collect()
 }
 
 #[cfg(test)]

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -17,17 +17,12 @@ use anyhow::{Context, Result, bail};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use serde::Serialize;
-#[allow(unused_imports)]
 use syu_task_model::{
-    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanCompletion,
-    GoalPlanConfidence, GoalPlanCoverage, GoalPlanCoverageMode, GoalPlanGoal,
-    GoalPlanImplementationPlan, GoalPlanPersistentItem, GoalPlanPersistentItemDetails,
-    GoalPlanPersistentItems, GoalPlanScope, GoalPlanScopeInclude, GoalPlanScopeIncludeDetails,
-    GoalPlanSelectionMode, GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSourceMode,
-    GoalPlanSpecMapping, GoalPlanSpecUpdates, GoalPlanTestPlan, RequestArtifact,
-    RequestArtifactContext, RequestClassification as RequirementAction, ScaffoldAction,
-    ScaffoldPlan, ScaffoldUpdate, ScaffoldUpdateKind, ScopeFeatureCandidate, ScopeOutcome,
-    ScopeSignals, SearchResult as TaskSearchResult, TaskTestSelectionCommand,
+    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanConfidence,
+    GoalPlanScope, GoalPlanScopeInclude, GoalPlanSelectionMode, GoalPlanSourceMode,
+    RequestArtifact, RequestArtifactContext, RequestClassification as RequirementAction,
+    ScaffoldAction, ScaffoldPlan, ScaffoldUpdate, ScaffoldUpdateKind, ScopeFeatureCandidate,
+    ScopeOutcome, ScopeSignals, SearchResult as TaskSearchResult, TaskTestSelectionCommand,
     TaskTestSelectionEscalation, TaskTestSelectionPlan,
 };
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -3853,15 +3853,18 @@ mod tests {
         TaskPlanFormat, TaskScaffoldArgs, TaskScopeArgs, TaskTestSelectArgs,
     };
     use crate::model::TraceReference;
-
-    use super::{
+    use syu_task_model::{
         ClassificationOutcome, GoalPlanArtifact, GoalPlanCompletion, GoalPlanConfidence,
         GoalPlanCoverage, GoalPlanCoverageMode, GoalPlanGoal, GoalPlanImplementationPlan,
         GoalPlanPersistentItem, GoalPlanPersistentItemDetails, GoalPlanPersistentItems,
         GoalPlanScope, GoalPlanScopeInclude, GoalPlanScopeIncludeDetails, GoalPlanSelectionMode,
-        GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSpecMapping, GoalPlanSpecUpdates,
-        GoalPlanTestPlan, RequirementAction, SearchResult, WorkspaceLookup, build_goal_plan,
-        build_scaffold_plan, check_goal_plan, classify_request, collect_feature_candidates,
+        GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSourceMode, GoalPlanSpecMapping,
+        GoalPlanSpecUpdates, GoalPlanTestPlan,
+    };
+
+    use super::{
+        RequirementAction, SearchResult, WorkspaceLookup, build_goal_plan, build_scaffold_plan,
+        check_goal_plan, classify_request, collect_feature_candidates,
         collect_linked_requirement_tests, load_goal_plan_artifact, load_request_artifact,
         render_goal_plan_output, resolve_task_plan_output_path, run_task_command, scope_request,
     };
@@ -4130,7 +4133,7 @@ mod tests {
                 classification: Some("request_driven".to_string()),
                 warnings: vec!["inferred from request text".to_string()],
                 source: GoalPlanSource {
-                    mode: super::GoalPlanSourceMode::DiffInferred,
+                    mode: GoalPlanSourceMode::DiffInferred,
                     request_artifact: Some("request.yaml".to_string()),
                     classification: Some("request_driven".to_string()),
                     range: Some("origin/main...HEAD".to_string()),

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,10 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::rules::ReferencedRule;
 
+pub use syu_domain::{
+    GitRange, Issue, LanguageName, Severity, SpecId, SpecKind, TraceReference, WorkspaceRoot,
+};
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PhilosophyDocument {
@@ -109,20 +113,6 @@ pub struct Feature {
     pub implementations: BTreeMap<String, Vec<TraceReference>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct TraceReference {
-    pub file: PathBuf,
-    #[serde(default, alias = "tests", alias = "functions")]
-    pub symbols: Vec<String>,
-    #[serde(default, alias = "docs", alias = "docstrings")]
-    pub doc_contains: Vec<String>,
-    #[serde(default)]
-    pub method: Option<String>,
-    #[serde(default)]
-    pub path: Option<String>,
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct OwnershipManifest {
@@ -192,59 +182,6 @@ impl CheckResult {
         self.issues
             .iter()
             .all(|issue| issue.severity != Severity::Error)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Severity {
-    Error,
-    Warning,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct Issue {
-    pub code: String,
-    pub severity: Severity,
-    pub subject: String,
-    pub location: Option<String>,
-    pub message: String,
-    pub suggestion: Option<String>,
-}
-
-impl Issue {
-    pub fn error(
-        code: impl Into<String>,
-        subject: impl Into<String>,
-        location: Option<String>,
-        message: impl Into<String>,
-        suggestion: Option<String>,
-    ) -> Self {
-        Self {
-            code: code.into(),
-            severity: Severity::Error,
-            subject: subject.into(),
-            location,
-            message: message.into(),
-            suggestion,
-        }
-    }
-
-    pub fn warning(
-        code: impl Into<String>,
-        subject: impl Into<String>,
-        location: Option<String>,
-        message: impl Into<String>,
-        suggestion: Option<String>,
-    ) -> Self {
-        Self {
-            code: code.into(),
-            severity: Severity::Warning,
-            subject: subject.into(),
-            location,
-            message: message.into(),
-            suggestion,
-        }
     }
 }
 


### PR DESCRIPTION
Summary:
- Converted the repo into a workspace and added `syu-domain` plus `syu-task-model` crates.
- Moved shared domain types and task artifact schemas out of `src/command/task.rs`.
- Kept CLI behavior intact while preserving YAML/JSON roundtrips and validation boundaries.

Validation:
- `cargo test -p syu-domain`
- `cargo test -p syu-task-model`
- `cargo test --test task_command`

Closes #733
