### PR TITLE
Add typed action layer for workspace workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syu-actions"
+version = "0.0.1-alpha.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "syu",
+ "syu-domain",
+ "syu-task-model",
+]
+
+[[package]]
 name = "syu-core"
 version = "0.0.1-alpha.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "crates/syu-actions",
     "crates/syu-domain",
     "crates/syu-task-model",
 ]

--- a/crates/syu-actions/Cargo.toml
+++ b/crates/syu-actions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "syu-actions"
+version = "0.0.1-alpha.0"
+edition = "2024"
+rust-version = "1.88"
+description = "Typed action layer for syu workspace workflows"
+license = "MIT"
+
+[dependencies]
+anyhow = "1.0.100"
+serde = { version = "1.0.228", features = ["derive"] }
+syu = { path = "../.." }
+syu-domain = { path = "../syu-domain" }
+syu-task-model = { path = "../syu-task-model" }

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -1,0 +1,457 @@
+use anyhow::Result;
+use serde::Serialize;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+pub use syu::cli::LookupKind;
+pub use syu::command::{
+    doctor::DoctorReport,
+    log::{HistoryRequest, HistoryResponse, HistoryScope},
+    relate::{JsonRelateOutput, JsonRelateRangeOutput},
+    task::{JsonTaskPlanOutput, JsonTaskPlanSourceEvidence},
+    trace::{TraceLookupOutput, TraceRangeOutput},
+};
+pub use syu::model::CheckResult as ValidationReport;
+pub use syu_task_model::{
+    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, RequestArtifact, ScaffoldPlan,
+    ScopeOutcome, TaskTestSelectionPlan,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ItemSummary {
+    pub kind: &'static str,
+    pub id: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BrowseSnapshot {
+    pub workspace_root: String,
+    pub spec_root: String,
+    pub validation: ValidationReport,
+    pub philosophies: Vec<ItemSummary>,
+    pub policies: Vec<ItemSummary>,
+    pub requirements: Vec<ItemSummary>,
+    pub features: Vec<ItemSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ListReport {
+    pub workspace_root: String,
+    pub kind: Option<String>,
+    pub items: Vec<ItemSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ShowReport {
+    pub workspace_root: String,
+    pub kind: String,
+    pub id: String,
+    pub title: String,
+    pub details: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchReport {
+    pub workspace_root: String,
+    pub query: String,
+    pub kind: Option<String>,
+    pub results: Vec<ItemSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditReport {
+    pub workspace_root: String,
+    pub validation: ValidationReport,
+    pub counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExplainReport {
+    pub workspace_root: String,
+    pub selector: String,
+    pub matches: Vec<ItemSummary>,
+    pub notes: Vec<String>,
+}
+
+pub fn validate_workspace(workspace: impl AsRef<Path>) -> ValidationReport {
+    syu::command::check::collect_check_result(workspace.as_ref())
+}
+
+pub fn doctor_workspace(workspace: impl AsRef<Path>) -> Result<DoctorReport> {
+    syu::command::doctor::build_doctor_report(workspace.as_ref())
+}
+
+pub fn classify_request(
+    workspace: impl AsRef<Path>,
+    request: &RequestArtifact,
+) -> Result<ClassificationOutcome> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::classify_request(&workspace, request)
+}
+
+pub fn scope_request(
+    workspace: impl AsRef<Path>,
+    request: &RequestArtifact,
+) -> Result<ScopeOutcome> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::scope_request(&workspace, request)
+}
+
+pub fn scaffold_request(
+    workspace: impl AsRef<Path>,
+    request: &RequestArtifact,
+) -> Result<ScaffoldPlan> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let classification = classify_request(&workspace.root, request)?;
+    let explicit_ids = request.explicit_ids();
+    syu::command::task::build_scaffold_plan(&workspace, &classification, &explicit_ids)
+}
+
+pub fn generate_goal_plan<P: AsRef<Path>>(
+    workspace: impl AsRef<Path>,
+    outcome: &ScopeOutcome,
+    explicit_ids: &[String],
+    request_path: impl AsRef<Path>,
+    output_path: Option<P>,
+) -> Result<JsonTaskPlanOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::build_goal_plan(
+        &workspace,
+        outcome,
+        explicit_ids,
+        request_path.as_ref(),
+        output_path.as_ref().map(AsRef::as_ref),
+    )
+}
+
+pub fn infer_goal_plan_from_diff<P: AsRef<Path>>(
+    workspace: impl AsRef<Path>,
+    range: &str,
+    changed_files: &[PathBuf],
+    output_path: Option<P>,
+) -> Result<JsonTaskPlanOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::build_diff_inferred_goal_plan(
+        &workspace,
+        range,
+        changed_files,
+        output_path.as_ref().map(AsRef::as_ref),
+    )
+}
+
+pub fn select_goal_tests(
+    workspace: impl AsRef<Path>,
+    artifact: &GoalPlanArtifact,
+) -> Result<TaskTestSelectionPlan> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::build_task_test_selection(&workspace, artifact)
+}
+
+pub fn check_goal_plan(
+    workspace: impl AsRef<Path>,
+    artifact: &GoalPlanArtifact,
+    range: &str,
+) -> Result<GoalPlanCheckReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::task::check_goal_plan(&workspace, artifact, range)
+}
+
+pub fn history_for_item(request: HistoryRequest<'_>) -> Result<HistoryResponse> {
+    syu::command::log::build_history_response(request)
+}
+
+pub fn relate_selector(workspace: impl AsRef<Path>, selector: &str) -> Result<JsonRelateOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::relate::build_relation_report(&workspace, selector)
+}
+
+pub fn relate_range(workspace: impl AsRef<Path>, range: &str) -> Result<JsonRelateRangeOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::relate::build_relation_range_report(&workspace, range)
+}
+
+pub fn trace_selector(
+    workspace: impl AsRef<Path>,
+    file: impl AsRef<Path>,
+    symbol: Option<&str>,
+) -> Result<TraceLookupOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::trace::trace_selector(&workspace, file.as_ref(), symbol)
+}
+
+pub fn trace_range(
+    workspace: impl AsRef<Path>,
+    range: &str,
+    strict: bool,
+    allowed_ids: &[String],
+) -> Result<TraceRangeOutput> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    syu::command::trace::trace_range(&workspace, range, strict, allowed_ids)
+}
+
+pub fn browse_workspace(workspace: impl AsRef<Path>) -> Result<BrowseSnapshot> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let validation = validate_workspace(&workspace.root);
+    Ok(BrowseSnapshot {
+        workspace_root: workspace.root.display().to_string(),
+        spec_root: workspace.spec_root.display().to_string(),
+        validation,
+        philosophies: workspace
+            .philosophies
+            .iter()
+            .map(|item| ItemSummary {
+                kind: "philosophy",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        policies: workspace
+            .policies
+            .iter()
+            .map(|item| ItemSummary {
+                kind: "policy",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        requirements: workspace
+            .requirements
+            .iter()
+            .map(|item| ItemSummary {
+                kind: "requirement",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        features: workspace
+            .features
+            .iter()
+            .map(|item| ItemSummary {
+                kind: "feature",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+    })
+}
+
+pub fn list_items(workspace: impl AsRef<Path>, kind: Option<LookupKind>) -> Result<ListReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    Ok(ListReport {
+        workspace_root: workspace.root.display().to_string(),
+        kind: kind.map(|value| value.label().to_string()),
+        items: collect_items(&workspace, kind),
+    })
+}
+
+pub fn show_item(workspace: impl AsRef<Path>, kind: LookupKind, id: &str) -> Result<ShowReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let item = find_item(&workspace, kind, id)
+        .ok_or_else(|| anyhow::anyhow!("`{id}` was not found in the workspace"))?;
+    Ok(ShowReport {
+        workspace_root: workspace.root.display().to_string(),
+        kind: kind.label().to_string(),
+        id: id.to_string(),
+        title: item.title.clone(),
+        details: item.details,
+    })
+}
+
+pub fn search_items(
+    workspace: impl AsRef<Path>,
+    query: &str,
+    kind: Option<LookupKind>,
+) -> Result<SearchReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let query = query.trim().to_lowercase();
+    let results = collect_items(&workspace, kind)
+        .into_iter()
+        .filter(|item| {
+            item.id.to_lowercase().contains(&query) || item.title.to_lowercase().contains(&query)
+        })
+        .collect();
+
+    Ok(SearchReport {
+        workspace_root: workspace.root.display().to_string(),
+        query: query.to_string(),
+        kind: kind.map(|value| value.label().to_string()),
+        results,
+    })
+}
+
+pub fn audit_workspace(workspace: impl AsRef<Path>) -> Result<AuditReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let validation = validate_workspace(&workspace.root);
+    let mut counts = BTreeMap::new();
+    counts.insert("philosophies".to_string(), workspace.philosophies.len());
+    counts.insert("policies".to_string(), workspace.policies.len());
+    counts.insert("requirements".to_string(), workspace.requirements.len());
+    counts.insert("features".to_string(), workspace.features.len());
+
+    Ok(AuditReport {
+        workspace_root: workspace.root.display().to_string(),
+        validation,
+        counts,
+    })
+}
+
+pub fn explain_selector(workspace: impl AsRef<Path>, selector: &str) -> Result<ExplainReport> {
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let trimmed = selector.trim();
+    let mut matches = Vec::new();
+    let mut notes = Vec::new();
+
+    if let Some(item) = find_any_item(&workspace, trimmed) {
+        matches.push(item);
+        notes.push("matched by exact id".to_string());
+    } else {
+        let search = search_items(&workspace.root, trimmed, None)?;
+        matches.extend(search.results);
+        notes.push("matched by id/title search".to_string());
+    }
+
+    Ok(ExplainReport {
+        workspace_root: workspace.root.display().to_string(),
+        selector: trimmed.to_string(),
+        matches,
+        notes,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ItemRecord {
+    title: String,
+    details: BTreeMap<String, String>,
+}
+
+fn collect_items(
+    workspace: &syu::workspace::Workspace,
+    kind: Option<LookupKind>,
+) -> Vec<ItemSummary> {
+    let mut items = Vec::new();
+    if kind.is_none() || kind == Some(LookupKind::Philosophy) {
+        items.extend(workspace.philosophies.iter().map(|item| ItemSummary {
+            kind: "philosophy",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        }));
+    }
+    if kind.is_none() || kind == Some(LookupKind::Policy) {
+        items.extend(workspace.policies.iter().map(|item| ItemSummary {
+            kind: "policy",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        }));
+    }
+    if kind.is_none() || kind == Some(LookupKind::Requirement) {
+        items.extend(workspace.requirements.iter().map(|item| ItemSummary {
+            kind: "requirement",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        }));
+    }
+    if kind.is_none() || kind == Some(LookupKind::Feature) {
+        items.extend(workspace.features.iter().map(|item| ItemSummary {
+            kind: "feature",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        }));
+    }
+    items
+}
+
+fn find_any_item(workspace: &syu::workspace::Workspace, id: &str) -> Option<ItemSummary> {
+    if let Some(item) = workspace.philosophies.iter().find(|item| item.id == id) {
+        return Some(ItemSummary {
+            kind: "philosophy",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        });
+    }
+    if let Some(item) = workspace.policies.iter().find(|item| item.id == id) {
+        return Some(ItemSummary {
+            kind: "policy",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        });
+    }
+    if let Some(item) = workspace.requirements.iter().find(|item| item.id == id) {
+        return Some(ItemSummary {
+            kind: "requirement",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        });
+    }
+    workspace
+        .features
+        .iter()
+        .find(|item| item.id == id)
+        .map(|item| ItemSummary {
+            kind: "feature",
+            id: item.id.clone(),
+            title: item.title.clone(),
+        })
+}
+
+fn find_item(
+    workspace: &syu::workspace::Workspace,
+    kind: LookupKind,
+    id: &str,
+) -> Option<ItemRecord> {
+    match kind {
+        LookupKind::Philosophy => workspace
+            .philosophies
+            .iter()
+            .find(|item| item.id == id)
+            .map(|item| ItemRecord {
+                title: item.title.clone(),
+                details: BTreeMap::from([
+                    (
+                        "product_design_principle".to_string(),
+                        item.product_design_principle.clone(),
+                    ),
+                    (
+                        "coding_guideline".to_string(),
+                        item.coding_guideline.clone(),
+                    ),
+                ]),
+            }),
+        LookupKind::Policy => workspace
+            .policies
+            .iter()
+            .find(|item| item.id == id)
+            .map(|item| ItemRecord {
+                title: item.title.clone(),
+                details: BTreeMap::from([
+                    ("summary".to_string(), item.summary.clone()),
+                    ("description".to_string(), item.description.clone()),
+                ]),
+            }),
+        LookupKind::Requirement => workspace
+            .requirements
+            .iter()
+            .find(|item| item.id == id)
+            .map(|item| ItemRecord {
+                title: item.title.clone(),
+                details: BTreeMap::from([
+                    ("description".to_string(), item.description.clone()),
+                    ("priority".to_string(), item.priority.clone()),
+                    ("status".to_string(), item.status.clone()),
+                ]),
+            }),
+        LookupKind::Feature => workspace
+            .features
+            .iter()
+            .find(|item| item.id == id)
+            .map(|item| ItemRecord {
+                title: item.title.clone(),
+                details: BTreeMap::from([
+                    ("summary".to_string(), item.summary.clone()),
+                    ("status".to_string(), item.status.clone()),
+                ]),
+            }),
+    }
+}

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use serde::Serialize;
 use std::{
     collections::BTreeMap,
@@ -266,14 +266,18 @@ pub fn search_items(
     kind: Option<LookupKind>,
 ) -> Result<SearchReport> {
     let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
-    let query = query.trim().to_lowercase();
+    let query = query.trim();
+    if query.is_empty() {
+        bail!("search query must not be empty or whitespace");
+    }
+    let normalized_query = query.to_lowercase();
     let results = match kind {
         Some(LookupKind::Philosophy) => workspace
             .philosophies
             .iter()
             .filter(|item| {
                 matches_search(
-                    &query,
+                    &normalized_query,
                     &[
                         item.id.as_str(),
                         item.title.as_str(),
@@ -293,7 +297,7 @@ pub fn search_items(
             .iter()
             .filter(|item| {
                 matches_search(
-                    &query,
+                    &normalized_query,
                     &[
                         item.id.as_str(),
                         item.title.as_str(),
@@ -313,7 +317,7 @@ pub fn search_items(
             .iter()
             .filter(|item| {
                 matches_search(
-                    &query,
+                    &normalized_query,
                     &[
                         item.id.as_str(),
                         item.title.as_str(),
@@ -332,7 +336,7 @@ pub fn search_items(
             .iter()
             .filter(|item| {
                 matches_search(
-                    &query,
+                    &normalized_query,
                     &[item.id.as_str(), item.title.as_str(), item.summary.as_str()],
                 )
             })
@@ -350,7 +354,7 @@ pub fn search_items(
                     .iter()
                     .filter(|item| {
                         matches_search(
-                            &query,
+                            &normalized_query,
                             &[
                                 item.id.as_str(),
                                 item.title.as_str(),
@@ -371,7 +375,7 @@ pub fn search_items(
                     .iter()
                     .filter(|item| {
                         matches_search(
-                            &query,
+                            &normalized_query,
                             &[
                                 item.id.as_str(),
                                 item.title.as_str(),
@@ -392,7 +396,7 @@ pub fn search_items(
                     .iter()
                     .filter(|item| {
                         matches_search(
-                            &query,
+                            &normalized_query,
                             &[item.id.as_str(), item.title.as_str(), item.summary.as_str()],
                         )
                     })
@@ -408,7 +412,7 @@ pub fn search_items(
                     .iter()
                     .filter(|item| {
                         matches_search(
-                            &query,
+                            &normalized_query,
                             &[
                                 item.id.as_str(),
                                 item.title.as_str(),
@@ -612,5 +616,43 @@ fn find_item(
                     ("status".to_string(), item.status.clone()),
                 ]),
             }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LookupKind, search_items};
+    use std::path::PathBuf;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/workspaces")
+            .join(name)
+    }
+
+    #[test]
+    fn search_items_preserves_trimmed_query_and_matches_case_insensitively() {
+        let report = search_items(fixture_path("passing"), "  Trace  ", None)
+            .expect("search should succeed");
+
+        assert_eq!(report.query, "Trace");
+        assert!(
+            report
+                .results
+                .iter()
+                .any(|item| item.id == "FEAT-TRACE-002" && item.kind == "feature")
+        );
+    }
+
+    #[test]
+    fn search_items_rejects_blank_queries() {
+        let error = search_items(fixture_path("passing"), "   ", Some(LookupKind::Feature))
+            .expect_err("blank query should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("search query must not be empty or whitespace")
+        );
     }
 }

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -77,7 +77,9 @@ pub struct ExplainReport {
 }
 
 pub fn validate_workspace(workspace: impl AsRef<Path>) -> ValidationReport {
-    syu::command::check::collect_check_result(workspace.as_ref())
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())
+        .expect("workspace should load before validation");
+    syu::command::check::collect_check_result_from_workspace(&workspace)
 }
 
 pub fn doctor_workspace(workspace: impl AsRef<Path>) -> Result<DoctorReport> {

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -267,12 +267,164 @@ pub fn search_items(
 ) -> Result<SearchReport> {
     let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
     let query = query.trim().to_lowercase();
-    let results = collect_items(&workspace, kind)
-        .into_iter()
-        .filter(|item| {
-            item.id.to_lowercase().contains(&query) || item.title.to_lowercase().contains(&query)
-        })
-        .collect();
+    let results = match kind {
+        Some(LookupKind::Philosophy) => workspace
+            .philosophies
+            .iter()
+            .filter(|item| {
+                matches_search(
+                    &query,
+                    &[
+                        item.id.as_str(),
+                        item.title.as_str(),
+                        item.product_design_principle.as_str(),
+                        item.coding_guideline.as_str(),
+                    ],
+                )
+            })
+            .map(|item| ItemSummary {
+                kind: "philosophy",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        Some(LookupKind::Policy) => workspace
+            .policies
+            .iter()
+            .filter(|item| {
+                matches_search(
+                    &query,
+                    &[
+                        item.id.as_str(),
+                        item.title.as_str(),
+                        item.summary.as_str(),
+                        item.description.as_str(),
+                    ],
+                )
+            })
+            .map(|item| ItemSummary {
+                kind: "policy",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        Some(LookupKind::Requirement) => workspace
+            .requirements
+            .iter()
+            .filter(|item| {
+                matches_search(
+                    &query,
+                    &[
+                        item.id.as_str(),
+                        item.title.as_str(),
+                        item.description.as_str(),
+                    ],
+                )
+            })
+            .map(|item| ItemSummary {
+                kind: "requirement",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        Some(LookupKind::Feature) => workspace
+            .features
+            .iter()
+            .filter(|item| {
+                matches_search(
+                    &query,
+                    &[item.id.as_str(), item.title.as_str(), item.summary.as_str()],
+                )
+            })
+            .map(|item| ItemSummary {
+                kind: "feature",
+                id: item.id.clone(),
+                title: item.title.clone(),
+            })
+            .collect(),
+        None => {
+            let mut results = Vec::new();
+            results.extend(
+                workspace
+                    .philosophies
+                    .iter()
+                    .filter(|item| {
+                        matches_search(
+                            &query,
+                            &[
+                                item.id.as_str(),
+                                item.title.as_str(),
+                                item.product_design_principle.as_str(),
+                                item.coding_guideline.as_str(),
+                            ],
+                        )
+                    })
+                    .map(|item| ItemSummary {
+                        kind: "philosophy",
+                        id: item.id.clone(),
+                        title: item.title.clone(),
+                    }),
+            );
+            results.extend(
+                workspace
+                    .policies
+                    .iter()
+                    .filter(|item| {
+                        matches_search(
+                            &query,
+                            &[
+                                item.id.as_str(),
+                                item.title.as_str(),
+                                item.summary.as_str(),
+                                item.description.as_str(),
+                            ],
+                        )
+                    })
+                    .map(|item| ItemSummary {
+                        kind: "policy",
+                        id: item.id.clone(),
+                        title: item.title.clone(),
+                    }),
+            );
+            results.extend(
+                workspace
+                    .features
+                    .iter()
+                    .filter(|item| {
+                        matches_search(
+                            &query,
+                            &[item.id.as_str(), item.title.as_str(), item.summary.as_str()],
+                        )
+                    })
+                    .map(|item| ItemSummary {
+                        kind: "feature",
+                        id: item.id.clone(),
+                        title: item.title.clone(),
+                    }),
+            );
+            results.extend(
+                workspace
+                    .requirements
+                    .iter()
+                    .filter(|item| {
+                        matches_search(
+                            &query,
+                            &[
+                                item.id.as_str(),
+                                item.title.as_str(),
+                                item.description.as_str(),
+                            ],
+                        )
+                    })
+                    .map(|item| ItemSummary {
+                        kind: "requirement",
+                        id: item.id.clone(),
+                        title: item.title.clone(),
+                    }),
+            );
+            results
+        }
+    };
 
     Ok(SearchReport {
         workspace_root: workspace.root.display().to_string(),
@@ -394,6 +546,13 @@ fn find_any_item(workspace: &syu::workspace::Workspace, id: &str) -> Option<Item
             id: item.id.clone(),
             title: item.title.clone(),
         })
+}
+
+fn matches_search(query: &str, fields: &[&str]) -> bool {
+    fields
+        .iter()
+        .filter(|value| !value.is_empty())
+        .any(|value| value.to_lowercase().contains(query))
 }
 
 fn find_item(

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -77,9 +77,7 @@ pub struct ExplainReport {
 }
 
 pub fn validate_workspace(workspace: impl AsRef<Path>) -> ValidationReport {
-    let workspace = syu::workspace::load_workspace(workspace.as_ref())
-        .expect("workspace should load before validation");
-    syu::command::check::collect_check_result_from_workspace(&workspace)
+    syu::command::check::collect_check_result(workspace.as_ref())
 }
 
 pub fn doctor_workspace(workspace: impl AsRef<Path>) -> Result<DoctorReport> {

--- a/docs/generated/site-spec/features/cli/log.md
+++ b/docs/generated/site-spec/features/cli/log.md
@@ -31,6 +31,14 @@ description: "Generated reference for docs/syu/features/cli/log.yaml"
           - build_history_target
           - load_git_history
           - parse_git_history
+          - build_history_response
+          - HistoryRequest
+          - HistoryResponse
+          - HistoryScope
+          - HistoryScopeResponse
+          - HistoryLifecycleEvent
+          - MatchedCommit
+          - TrackedPath
       - **file**: src/command/lookup.rs
         - **symbols**:
           - document_path_for_id
@@ -65,6 +73,14 @@ features:
             - build_history_target
             - load_git_history
             - parse_git_history
+            - build_history_response
+            - HistoryRequest
+            - HistoryResponse
+            - HistoryScope
+            - HistoryScopeResponse
+            - HistoryLifecycleEvent
+            - MatchedCommit
+            - TrackedPath
         - file: src/command/lookup.rs
           symbols:
             - document_path_for_id

--- a/docs/generated/site-spec/features/cli/relate.md
+++ b/docs/generated/site-spec/features/cli/relate.md
@@ -29,10 +29,19 @@ description: "Generated reference for docs/syu/features/cli/relate.yaml"
         - **symbols**:
           - run_relate_command
           - build_relation_report
+          - build_relation_range_report
           - resolve_selection
           - expand_related_ids
           - collect_related_traces
           - collect_gaps
+          - JsonRelateOutput
+          - JsonRelateRangeOutput
+          - RelateRangeSummary
+          - SelectionSummary
+          - DirectMatches
+          - RelatedNode
+          - RelatedTrace
+          - Gap
       - **file**: src/cli.rs
         - **symbols**:
           - RelateArgs
@@ -61,10 +70,19 @@ features:
           symbols:
             - run_relate_command
             - build_relation_report
+            - build_relation_range_report
             - resolve_selection
             - expand_related_ids
             - collect_related_traces
             - collect_gaps
+            - JsonRelateOutput
+            - JsonRelateRangeOutput
+            - RelateRangeSummary
+            - SelectionSummary
+            - DirectMatches
+            - RelatedNode
+            - RelatedTrace
+            - Gap
         - file: src/cli.rs
           symbols:
             - RelateArgs

--- a/docs/generated/site-spec/features/cli/search.md
+++ b/docs/generated/site-spec/features/cli/search.md
@@ -33,6 +33,7 @@ description: "Generated reference for docs/syu/features/cli/search.yaml"
           - search
           - extend_search_results
           - field_matches_query
+          - EntitySummary
       - **file**: src/cli.rs
         - **symbols**:
           - SearchArgs
@@ -60,6 +61,7 @@ features:
             - search
             - extend_search_results
             - field_matches_query
+            - EntitySummary
         - file: src/cli.rs
           symbols:
             - SearchArgs

--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -29,6 +29,7 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - run_task_command
           - run_task_classify_command
+          - classify_request
       - **file**: src/cli.rs
         - **symbols**:
           - TaskArgs
@@ -81,6 +82,7 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - run_task_command
           - run_task_scope_command
+          - scope_request
       - **file**: src/cli.rs
         - **symbols**:
           - TaskArgs
@@ -111,6 +113,10 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
           - run_task_infer_command
           - build_goal_plan
           - build_diff_inferred_goal_plan
+          - JsonTaskPlanOutput
+          - JsonTaskPlanSourceEvidence
+          - JsonTaskPlanScopeEntry
+          - DiffInferenceOutcome
           - GoalPlanArtifact
           - load_goal_plan_artifact
       - **file**: src/cli.rs
@@ -148,6 +154,7 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
         - **symbols**:
           - run_task_command
           - run_task_check_command
+          - check_goal_plan
           - GoalPlanArtifact
           - load_goal_plan_artifact
       - **file**: src/cli.rs
@@ -213,6 +220,7 @@ features:
           symbols:
             - run_task_command
             - run_task_classify_command
+            - classify_request
         - file: src/cli.rs
           symbols:
             - TaskArgs
@@ -265,6 +273,7 @@ features:
           symbols:
             - run_task_command
             - run_task_scope_command
+            - scope_request
         - file: src/cli.rs
           symbols:
             - TaskArgs
@@ -295,6 +304,10 @@ features:
             - run_task_infer_command
             - build_goal_plan
             - build_diff_inferred_goal_plan
+            - JsonTaskPlanOutput
+            - JsonTaskPlanSourceEvidence
+            - JsonTaskPlanScopeEntry
+            - DiffInferenceOutcome
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs
@@ -332,6 +345,7 @@ features:
           symbols:
             - run_task_command
             - run_task_check_command
+            - check_goal_plan
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs

--- a/docs/generated/site-spec/features/workbench/actions.md
+++ b/docs/generated/site-spec/features/workbench/actions.md
@@ -24,6 +24,29 @@ description: "Generated reference for docs/syu/features/workbench/actions.yaml"
   - **linked_requirements**:
     - REQ-WORKBENCH-002
   - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-actions/src/lib.rs
+        - **symbols**:
+          - classify_request
+          - scope_request
+          - scaffold_request
+          - generate_goal_plan
+          - infer_goal_plan_from_diff
+          - select_goal_tests
+          - check_goal_plan
+          - validate_workspace
+          - browse_workspace
+          - list_items
+          - show_item
+          - search_items
+          - audit_workspace
+          - trace_selector
+          - trace_range
+          - relate_selector
+          - relate_range
+          - explain_selector
+          - history_for_item
+          - doctor_workspace
     - **markdown**:
       - **file**: docs/guide/workbench.md
         - **symbols**:
@@ -46,6 +69,29 @@ features:
     linked_requirements:
       - REQ-WORKBENCH-002
     implementations:
+      rust:
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - classify_request
+            - scope_request
+            - scaffold_request
+            - generate_goal_plan
+            - infer_goal_plan_from_diff
+            - select_goal_tests
+            - check_goal_plan
+            - validate_workspace
+            - browse_workspace
+            - list_items
+            - show_item
+            - search_items
+            - audit_workspace
+            - trace_selector
+            - trace_range
+            - relate_selector
+            - relate_range
+            - explain_selector
+            - history_for_item
+            - doctor_workspace
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -15,7 +15,7 @@
 ## Traceability
 
 - Requirement-to-test traceability: 168/168
-- Feature-to-implementation traceability: 166/166
+- Feature-to-implementation traceability: 167/167
 
 ## Issues
 

--- a/docs/syu/features/cli/log.yaml
+++ b/docs/syu/features/cli/log.yaml
@@ -18,6 +18,14 @@ features:
             - build_history_target
             - load_git_history
             - parse_git_history
+            - build_history_response
+            - HistoryRequest
+            - HistoryResponse
+            - HistoryScope
+            - HistoryScopeResponse
+            - HistoryLifecycleEvent
+            - MatchedCommit
+            - TrackedPath
         - file: src/command/lookup.rs
           symbols:
             - document_path_for_id

--- a/docs/syu/features/cli/relate.yaml
+++ b/docs/syu/features/cli/relate.yaml
@@ -16,10 +16,19 @@ features:
           symbols:
             - run_relate_command
             - build_relation_report
+            - build_relation_range_report
             - resolve_selection
             - expand_related_ids
             - collect_related_traces
             - collect_gaps
+            - JsonRelateOutput
+            - JsonRelateRangeOutput
+            - RelateRangeSummary
+            - SelectionSummary
+            - DirectMatches
+            - RelatedNode
+            - RelatedTrace
+            - Gap
         - file: src/cli.rs
           symbols:
             - RelateArgs

--- a/docs/syu/features/cli/search.yaml
+++ b/docs/syu/features/cli/search.yaml
@@ -18,6 +18,7 @@ features:
             - search
             - extend_search_results
             - field_matches_query
+            - EntitySummary
         - file: src/cli.rs
           symbols:
             - SearchArgs

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -14,6 +14,7 @@ features:
           symbols:
             - run_task_command
             - run_task_classify_command
+            - classify_request
         - file: src/cli.rs
           symbols:
             - TaskArgs
@@ -66,6 +67,7 @@ features:
           symbols:
             - run_task_command
             - run_task_scope_command
+            - scope_request
         - file: src/cli.rs
           symbols:
             - TaskArgs
@@ -96,6 +98,10 @@ features:
             - run_task_infer_command
             - build_goal_plan
             - build_diff_inferred_goal_plan
+            - JsonTaskPlanOutput
+            - JsonTaskPlanSourceEvidence
+            - JsonTaskPlanScopeEntry
+            - DiffInferenceOutcome
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs
@@ -133,6 +139,7 @@ features:
           symbols:
             - run_task_command
             - run_task_check_command
+            - check_goal_plan
             - GoalPlanArtifact
             - load_goal_plan_artifact
         - file: src/cli.rs

--- a/docs/syu/features/workbench/actions.yaml
+++ b/docs/syu/features/workbench/actions.yaml
@@ -9,6 +9,29 @@ features:
     linked_requirements:
       - REQ-WORKBENCH-002
     implementations:
+      rust:
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - classify_request
+            - scope_request
+            - scaffold_request
+            - generate_goal_plan
+            - infer_goal_plan_from_diff
+            - select_goal_tests
+            - check_goal_plan
+            - validate_workspace
+            - browse_workspace
+            - list_items
+            - show_item
+            - search_items
+            - audit_workspace
+            - trace_selector
+            - trace_range
+            - relate_selector
+            - relate_range
+            - explain_selector
+            - history_for_item
+            - doctor_workspace
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -566,7 +566,7 @@ pub fn collect_check_result(workspace_path: &Path) -> CheckResult {
     }
 }
 
-pub(crate) fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
+pub fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
     collect_check_result_from_workspace_with_mode(workspace, false)
 }
 

--- a/src/command/doctor.rs
+++ b/src/command/doctor.rs
@@ -20,7 +20,7 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum DoctorStatus {
+pub enum DoctorStatus {
     Ok,
     Warning,
     Error,
@@ -39,14 +39,14 @@ impl DoctorStatus {
 }
 
 #[derive(Debug, Serialize)]
-struct DoctorReport {
+pub struct DoctorReport {
     workspace_root: PathBuf,
     summary: DoctorSummary,
     checks: Vec<DoctorCheck>,
 }
 
 #[derive(Debug, Default, Serialize)]
-struct DoctorSummary {
+pub struct DoctorSummary {
     ok: usize,
     warning: usize,
     error: usize,
@@ -54,7 +54,7 @@ struct DoctorSummary {
 }
 
 #[derive(Debug, Serialize)]
-struct DoctorCheck {
+pub struct DoctorCheck {
     id: &'static str,
     label: &'static str,
     status: DoctorStatus,
@@ -111,7 +111,7 @@ pub fn run_doctor_command(args: &DoctorArgs) -> Result<i32> {
     Ok(if report.summary.error > 0 { 1 } else { 0 })
 }
 
-fn build_doctor_report(workspace: &Path) -> Result<DoctorReport> {
+pub fn build_doctor_report(workspace: &Path) -> Result<DoctorReport> {
     let workspace_root = resolve_workspace_root(workspace)?;
     let mut checks = Vec::new();
 

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -40,77 +40,83 @@ const GIT_ENVIRONMENT_KEYS: [&str; 8] = [
     "GIT_WORK_TREE",
 ];
 
+// FEAT-LOG-001
 #[derive(Debug, Serialize)]
-pub(crate) struct HistoryResponse {
-    id: String,
-    entity_kind: &'static str,
-    title: String,
-    status: &'static str,
-    repository_root: String,
-    kind: &'static str,
-    include_related: bool,
+pub struct HistoryResponse {
+    pub id: String,
+    pub entity_kind: &'static str,
+    pub title: String,
+    pub status: &'static str,
+    pub repository_root: String,
+    pub kind: &'static str,
+    pub include_related: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    scope: Option<HistoryScopeResponse>,
+    pub scope: Option<HistoryScopeResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    path_filter: Option<String>,
-    tracked_paths: Vec<TrackedPath>,
+    pub path_filter: Option<String>,
+    pub tracked_paths: Vec<TrackedPath>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    lifecycle_events: Vec<HistoryLifecycleEvent>,
-    commits: Vec<MatchedCommit>,
+    pub lifecycle_events: Vec<HistoryLifecycleEvent>,
+    pub commits: Vec<MatchedCommit>,
 }
 
-pub(crate) struct HistoryRequest<'a> {
-    pub(crate) workspace: &'a Workspace,
-    pub(crate) repository_root: &'a Path,
-    pub(crate) id: &'a str,
-    pub(crate) kind: HistoryKind,
-    pub(crate) include_related: bool,
-    pub(crate) scope: Option<HistoryScope>,
-    pub(crate) path_filter: Option<&'a Path>,
-    pub(crate) limit: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct HistoryScopeResponse {
-    label: String,
-    revision_range: String,
+// FEAT-LOG-001
+pub struct HistoryRequest<'a> {
+    pub workspace: &'a Workspace,
+    pub repository_root: &'a Path,
+    pub id: &'a str,
+    pub kind: HistoryKind,
+    pub include_related: bool,
+    pub scope: Option<HistoryScope>,
+    pub path_filter: Option<&'a Path>,
+    pub limit: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct TrackedPath {
-    kind: &'static str,
-    path: String,
-    owner_kind: &'static str,
-    owner_id: String,
-    source: &'static str,
+// FEAT-LOG-001
+pub struct HistoryScopeResponse {
+    pub label: String,
+    pub revision_range: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+// FEAT-LOG-001
+pub struct TrackedPath {
+    pub kind: &'static str,
+    pub path: String,
+    pub owner_kind: &'static str,
+    pub owner_id: String,
+    pub source: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    language: Option<String>,
+    pub language: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    symbols: Vec<String>,
+    pub symbols: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct MatchedCommit {
-    sha: String,
-    short_sha: String,
-    summary: String,
-    author: String,
-    authored_at: String,
-    reasons: Vec<TrackedPath>,
+// FEAT-LOG-001
+pub struct MatchedCommit {
+    pub sha: String,
+    pub short_sha: String,
+    pub summary: String,
+    pub author: String,
+    pub authored_at: String,
+    pub reasons: Vec<TrackedPath>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct HistoryLifecycleEvent {
-    event: &'static str,
-    sha: String,
-    short_sha: String,
-    summary: String,
-    author: String,
-    authored_at: String,
+// FEAT-LOG-001
+pub struct HistoryLifecycleEvent {
+    pub event: &'static str,
+    pub sha: String,
+    pub short_sha: String,
+    pub summary: String,
+    pub author: String,
+    pub authored_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<String>,
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    note: Option<String>,
+    pub note: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -141,9 +147,10 @@ struct HistoryTargetRequest<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct HistoryScope {
-    label: String,
-    revision_range: String,
+// FEAT-LOG-001
+pub struct HistoryScope {
+    pub label: String,
+    pub revision_range: String,
 }
 
 pub fn run_log_command(args: &LogArgs) -> Result<i32> {
@@ -186,7 +193,8 @@ pub fn run_log_command(args: &LogArgs) -> Result<i32> {
     Ok(0)
 }
 
-pub(crate) fn build_history_response(request: HistoryRequest<'_>) -> Result<HistoryResponse> {
+// FEAT-LOG-001
+pub fn build_history_response(request: HistoryRequest<'_>) -> Result<HistoryResponse> {
     let lookup = WorkspaceLookup::new(request.workspace);
     let historical_ids =
         build_historical_id_index(&request.workspace.root, &request.workspace.config)?;

--- a/src/command/lookup.rs
+++ b/src/command/lookup.rs
@@ -18,8 +18,9 @@ use crate::{
     },
 };
 
+// FEAT-SEARCH-001
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct EntitySummary {
+pub struct EntitySummary {
     pub id: String,
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/command/relate.rs
+++ b/src/command/relate.rs
@@ -22,77 +22,85 @@ use super::{
     lookup::{EntitySummary, WorkspaceEntity, WorkspaceLookup},
 };
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, Serialize)]
-pub(crate) struct JsonRelateOutput {
-    pub(crate) selection: SelectionSummary,
-    pub(crate) direct_matches: DirectMatches,
-    pub(crate) philosophies: Vec<RelatedNode>,
-    pub(crate) policies: Vec<RelatedNode>,
-    pub(crate) requirements: Vec<RelatedNode>,
-    pub(crate) features: Vec<RelatedNode>,
-    pub(crate) traces: Vec<RelatedTrace>,
-    pub(crate) gaps: Vec<Gap>,
+pub struct JsonRelateOutput {
+    pub selection: SelectionSummary,
+    pub direct_matches: DirectMatches,
+    pub philosophies: Vec<RelatedNode>,
+    pub policies: Vec<RelatedNode>,
+    pub requirements: Vec<RelatedNode>,
+    pub features: Vec<RelatedNode>,
+    pub traces: Vec<RelatedTrace>,
+    pub gaps: Vec<Gap>,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Serialize)]
-struct JsonRelateRangeOutput {
-    range: String,
-    philosophies: Vec<RelatedNode>,
-    policies: Vec<RelatedNode>,
-    requirements: Vec<RelatedNode>,
-    features: Vec<RelatedNode>,
-    traces: Vec<RelatedTrace>,
-    gaps: Vec<Gap>,
-    summary: RelateRangeSummary,
+pub struct JsonRelateRangeOutput {
+    pub range: String,
+    pub philosophies: Vec<RelatedNode>,
+    pub policies: Vec<RelatedNode>,
+    pub requirements: Vec<RelatedNode>,
+    pub features: Vec<RelatedNode>,
+    pub traces: Vec<RelatedTrace>,
+    pub gaps: Vec<Gap>,
+    pub summary: RelateRangeSummary,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Serialize)]
-struct RelateRangeSummary {
-    total_files: usize,
-    total_philosophies: usize,
-    total_policies: usize,
-    total_requirements: usize,
-    total_features: usize,
+pub struct RelateRangeSummary {
+    pub total_files: usize,
+    pub total_philosophies: usize,
+    pub total_policies: usize,
+    pub total_requirements: usize,
+    pub total_features: usize,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, Serialize)]
-pub(crate) struct SelectionSummary {
-    pub(crate) kind: &'static str,
-    pub(crate) query: String,
+pub struct SelectionSummary {
+    pub kind: &'static str,
+    pub query: String,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, Default, Serialize)]
-pub(crate) struct DirectMatches {
-    pub(crate) definitions: Vec<RelatedNode>,
-    pub(crate) traces: Vec<RelatedTrace>,
+pub struct DirectMatches {
+    pub definitions: Vec<RelatedNode>,
+    pub traces: Vec<RelatedTrace>,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct RelatedNode {
-    pub(crate) kind: &'static str,
-    pub(crate) id: String,
-    pub(crate) title: String,
-    pub(crate) document_path: String,
+pub struct RelatedNode {
+    pub kind: &'static str,
+    pub id: String,
+    pub title: String,
+    pub document_path: String,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct RelatedTrace {
-    pub(crate) owner_kind: &'static str,
-    pub(crate) owner_id: String,
-    pub(crate) relation_kind: &'static str,
-    pub(crate) language: String,
-    pub(crate) file: String,
-    pub(crate) symbols: Vec<String>,
-    pub(crate) method: Option<String>,
-    pub(crate) path: Option<String>,
-    pub(crate) direct_match: bool,
+pub struct RelatedTrace {
+    pub owner_kind: &'static str,
+    pub owner_id: String,
+    pub relation_kind: &'static str,
+    pub language: String,
+    pub file: String,
+    pub symbols: Vec<String>,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    pub direct_match: bool,
 }
 
+// FEAT-RELATE-001
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct Gap {
-    pub(crate) kind: &'static str,
-    pub(crate) id: String,
-    pub(crate) message: String,
+pub struct Gap {
+    pub kind: &'static str,
+    pub id: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone)]
@@ -264,10 +272,8 @@ fn collect_related_ids_for_changed_files(
 
     combined_ids
 }
-pub(crate) fn build_relation_report(
-    workspace: &Workspace,
-    selector: &str,
-) -> Result<JsonRelateOutput> {
+// FEAT-RELATE-001
+pub fn build_relation_report(workspace: &Workspace, selector: &str) -> Result<JsonRelateOutput> {
     let lookup = WorkspaceLookup::new(workspace);
     let catalog = RelationCatalog::load(lookup)?;
     let selection = resolve_selection(workspace, lookup, &catalog, selector)?;
@@ -282,6 +288,64 @@ pub(crate) fn build_relation_report(
         features: catalog.nodes_for(LookupKind::Feature, &related_ids.features),
         traces: collect_related_traces(workspace, &related_ids, &selection.source),
         gaps: collect_gaps(workspace, &related_ids),
+    })
+}
+
+// FEAT-RELATE-001
+pub fn build_relation_range_report(
+    workspace: &Workspace,
+    range: &str,
+) -> Result<JsonRelateRangeOutput> {
+    let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
+
+    if changed_files.is_empty() {
+        return Ok(JsonRelateRangeOutput {
+            range: range.to_string(),
+            philosophies: Vec::new(),
+            policies: Vec::new(),
+            requirements: Vec::new(),
+            features: Vec::new(),
+            traces: Vec::new(),
+            gaps: Vec::new(),
+            summary: RelateRangeSummary {
+                total_files: 0,
+                total_philosophies: 0,
+                total_policies: 0,
+                total_requirements: 0,
+                total_features: 0,
+            },
+        });
+    }
+
+    let lookup = WorkspaceLookup::new(workspace);
+    let catalog = RelationCatalog::load(lookup)?;
+    let combined_ids = collect_related_ids_for_changed_files(workspace, &catalog, &changed_files);
+    let expanded_ids = expand_related_ids(workspace, combined_ids);
+
+    Ok(JsonRelateRangeOutput {
+        range: range.to_string(),
+        philosophies: catalog.nodes_for(LookupKind::Philosophy, &expanded_ids.philosophies),
+        policies: catalog.nodes_for(LookupKind::Policy, &expanded_ids.policies),
+        requirements: catalog.nodes_for(LookupKind::Requirement, &expanded_ids.requirements),
+        features: catalog.nodes_for(LookupKind::Feature, &expanded_ids.features),
+        traces: collect_related_traces(
+            workspace,
+            &expanded_ids,
+            &SelectionSource::RangePaths {
+                paths: changed_files
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect(),
+            },
+        ),
+        gaps: collect_gaps(workspace, &expanded_ids),
+        summary: RelateRangeSummary {
+            total_files: changed_files.len(),
+            total_philosophies: expanded_ids.philosophies.len(),
+            total_policies: expanded_ids.policies.len(),
+            total_requirements: expanded_ids.requirements.len(),
+            total_features: expanded_ids.features.len(),
+        },
     })
 }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -92,6 +92,7 @@ struct JsonTaskCheckOutput {
     issues: Vec<Issue>,
 }
 
+// FEAT-TASK-003
 #[derive(Debug, Serialize)]
 struct JsonTaskTestSelectOutput {
     goal_id: String,
@@ -115,8 +116,9 @@ struct JsonTaskTestSelectEscalation {
     reason: String,
 }
 
+// FEAT-TASK-004
 #[derive(Debug, Serialize)]
-struct JsonTaskPlanOutput {
+pub struct JsonTaskPlanOutput {
     version: u32,
     kind: String,
     request_path: String,
@@ -132,8 +134,9 @@ struct JsonTaskPlanOutput {
     warnings: Vec<String>,
 }
 
+// FEAT-TASK-004
 #[derive(Debug, Serialize)]
-struct JsonTaskPlanSourceEvidence {
+pub struct JsonTaskPlanSourceEvidence {
     changed_files: Vec<String>,
     traced_requirements: Vec<String>,
     traced_features: Vec<String>,
@@ -213,11 +216,12 @@ struct JsonTaskPlanScope {
     exclude: Vec<String>,
 }
 
+// FEAT-TASK-004
 #[derive(Debug, Serialize)]
-struct JsonTaskPlanScopeEntry {
-    file: String,
+pub struct JsonTaskPlanScopeEntry {
+    pub file: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    symbols: Vec<String>,
+    pub symbols: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -252,13 +256,14 @@ struct JsonScopeSignals {
     philosophy_discussion: bool,
     planned_feature_updates: bool,
 }
+// FEAT-TASK-004
 #[derive(Debug)]
-struct DiffInferenceOutcome {
-    scope: ScopeOutcome,
-    scope_entries: Vec<JsonTaskPlanScopeEntry>,
-    source: JsonTaskPlanSourceEvidence,
-    confidence: &'static str,
-    warnings: Vec<String>,
+pub struct DiffInferenceOutcome {
+    pub scope: ScopeOutcome,
+    pub scope_entries: Vec<JsonTaskPlanScopeEntry>,
+    pub source: JsonTaskPlanSourceEvidence,
+    pub confidence: &'static str,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -553,7 +558,8 @@ pub fn run_task_infer_command(args: &TaskInferArgs) -> Result<i32> {
     Ok(0)
 }
 
-fn build_goal_plan(
+// FEAT-TASK-004
+pub fn build_goal_plan(
     workspace: &crate::workspace::Workspace,
     outcome: &ScopeOutcome,
     explicit_ids: &[String],
@@ -658,7 +664,8 @@ fn inferred_goal_plan_completion_checks(range: &str, output_path: Option<&Path>)
     ]
 }
 
-fn build_task_test_selection(
+// FEAT-TASK-005
+pub fn build_task_test_selection(
     workspace: &crate::workspace::Workspace,
     artifact: &GoalPlanArtifact,
 ) -> Result<TaskTestSelectionPlan> {
@@ -1291,7 +1298,8 @@ fn print_source_evidence_section(output: &mut String, heading: &str, items: &[St
     }
 }
 
-fn build_diff_inferred_goal_plan(
+// FEAT-TASK-004
+pub fn build_diff_inferred_goal_plan(
     workspace: &crate::workspace::Workspace,
     range: &str,
     changed_files: &[PathBuf],
@@ -2422,7 +2430,8 @@ fn load_goal_plan_artifact(path: &PathBuf) -> Result<GoalPlanArtifact> {
     Ok(artifact)
 }
 
-fn classify_request(
+// FEAT-TASK-003
+pub fn classify_request(
     workspace: &crate::workspace::Workspace,
     artifact: &RequestArtifact,
 ) -> Result<ClassificationOutcome> {
@@ -2518,7 +2527,8 @@ fn classify_request(
     })
 }
 
-fn scope_request(
+// FEAT-TASK-003
+pub fn scope_request(
     workspace: &crate::workspace::Workspace,
     artifact: &RequestArtifact,
 ) -> Result<ScopeOutcome> {
@@ -2619,7 +2629,8 @@ fn scope_request(
     })
 }
 
-fn build_scaffold_plan(
+// FEAT-TASK-004
+pub fn build_scaffold_plan(
     workspace: &crate::workspace::Workspace,
     outcome: &ClassificationOutcome,
     explicit_ids: &[String],
@@ -2948,7 +2959,8 @@ fn print_task_check_text_output(plan_path: &Path, report: &GoalPlanCheckReport) 
     }
 }
 
-fn check_goal_plan(
+// FEAT-TASK-005
+pub fn check_goal_plan(
     workspace: &crate::workspace::Workspace,
     artifact: &GoalPlanArtifact,
     range: &str,

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -24,7 +24,7 @@ use super::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
-enum TraceLookupStatus {
+pub enum TraceLookupStatus {
     Owned,
     Partial,
     Unowned,
@@ -74,104 +74,104 @@ impl MatchMode {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
-struct TraceOwnerMatch {
-    kind: &'static str,
-    id: String,
-    title: String,
-    trace_role: String,
-    language: String,
-    file: String,
-    declared_symbols: Vec<String>,
+pub struct TraceOwnerMatch {
+    pub kind: &'static str,
+    pub id: String,
+    pub title: String,
+    pub trace_role: String,
+    pub language: String,
+    pub file: String,
+    pub declared_symbols: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    method: Option<String>,
+    pub method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<String>,
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    matched_symbol: Option<String>,
-    match_mode: &'static str,
+    pub matched_symbol: Option<String>,
+    pub match_mode: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceLookupOutput {
-    file: String,
+pub struct TraceLookupOutput {
+    pub file: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    symbol: Option<String>,
-    status: TraceLookupStatus,
-    matched_owners: Vec<TraceOwnerMatch>,
-    file_only_owners: Vec<TraceOwnerMatch>,
-    requirements: Vec<EntitySummary>,
-    features: Vec<EntitySummary>,
-    policies: Vec<EntitySummary>,
-    philosophies: Vec<EntitySummary>,
+    pub symbol: Option<String>,
+    pub status: TraceLookupStatus,
+    pub matched_owners: Vec<TraceOwnerMatch>,
+    pub file_only_owners: Vec<TraceOwnerMatch>,
+    pub requirements: Vec<EntitySummary>,
+    pub features: Vec<EntitySummary>,
+    pub policies: Vec<EntitySummary>,
+    pub philosophies: Vec<EntitySummary>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeOutput {
-    range: String,
-    files: Vec<TraceLookupOutput>,
-    skipped_files: Vec<TraceSkippedFile>,
-    summary: TraceRangeSummary,
+pub struct TraceRangeOutput {
+    pub range: String,
+    pub files: Vec<TraceLookupOutput>,
+    pub skipped_files: Vec<TraceSkippedFile>,
+    pub summary: TraceRangeSummary,
     #[serde(skip_serializing_if = "Option::is_none")]
-    scope_guard: Option<TraceRangeScopeGuard>,
+    pub scope_guard: Option<TraceRangeScopeGuard>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    strict_review: Option<TraceRangeReviewOutput>,
+    pub strict_review: Option<TraceRangeReviewOutput>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeEntityGroup {
-    requirements: Vec<EntitySummary>,
-    features: Vec<EntitySummary>,
-    policies: Vec<EntitySummary>,
-    philosophies: Vec<EntitySummary>,
+pub struct TraceRangeEntityGroup {
+    pub requirements: Vec<EntitySummary>,
+    pub features: Vec<EntitySummary>,
+    pub policies: Vec<EntitySummary>,
+    pub philosophies: Vec<EntitySummary>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeIdSummary {
-    direct: TraceRangeEntityGroup,
-    indirect: TraceRangeEntityGroup,
+pub struct TraceRangeIdSummary {
+    pub direct: TraceRangeEntityGroup,
+    pub indirect: TraceRangeEntityGroup,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeSummary {
-    changed_files_total: usize,
-    inspected_files: usize,
-    skipped_files: usize,
-    owned_files: usize,
-    partial_files: usize,
-    unowned_files: usize,
-    total_requirements: usize,
-    total_features: usize,
-    total_policies: usize,
-    total_philosophies: usize,
-    ids: TraceRangeIdSummary,
+pub struct TraceRangeSummary {
+    pub changed_files_total: usize,
+    pub inspected_files: usize,
+    pub skipped_files: usize,
+    pub owned_files: usize,
+    pub partial_files: usize,
+    pub unowned_files: usize,
+    pub total_requirements: usize,
+    pub total_features: usize,
+    pub total_policies: usize,
+    pub total_philosophies: usize,
+    pub ids: TraceRangeIdSummary,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeScopeGuard {
-    allowed_ids: Vec<TraceScopeGuardItem>,
-    out_of_scope_items: Vec<TraceScopeGuardViolation>,
+pub struct TraceRangeScopeGuard {
+    pub allowed_ids: Vec<TraceScopeGuardItem>,
+    pub out_of_scope_items: Vec<TraceScopeGuardViolation>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeReviewOutput {
-    enabled: bool,
-    failed: bool,
-    findings: Vec<TraceRangeReviewFinding>,
+pub struct TraceRangeReviewOutput {
+    pub enabled: bool,
+    pub failed: bool,
+    pub findings: Vec<TraceRangeReviewFinding>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceRangeReviewFinding {
-    kind: TraceRangeReviewFindingKind,
-    file: String,
+pub struct TraceRangeReviewFinding {
+    pub kind: TraceRangeReviewFindingKind,
+    pub file: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    owners: Vec<TraceScopeGuardOwner>,
+    pub owners: Vec<TraceScopeGuardOwner>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<String>,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum TraceRangeReviewFindingKind {
+pub enum TraceRangeReviewFindingKind {
     Unowned,
     AmbiguousOwnership,
     OutOfScope,
@@ -179,32 +179,32 @@ enum TraceRangeReviewFindingKind {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceScopeGuardItem {
-    kind: String,
-    id: String,
-    title: String,
+pub struct TraceScopeGuardItem {
+    pub kind: String,
+    pub id: String,
+    pub title: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceScopeGuardOwner {
-    kind: String,
-    id: String,
-    title: String,
+pub struct TraceScopeGuardOwner {
+    pub kind: String,
+    pub id: String,
+    pub title: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceScopeGuardViolation {
-    file: String,
+pub struct TraceScopeGuardViolation {
+    pub file: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    owners: Vec<TraceScopeGuardOwner>,
+    pub owners: Vec<TraceScopeGuardOwner>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<String>,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct TraceSkippedFile {
-    file: String,
-    reason: String,
+pub struct TraceSkippedFile {
+    pub file: String,
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -221,13 +221,8 @@ pub fn run_trace_command(args: &TraceArgs) -> Result<i32> {
         if args.symbol.is_some() {
             bail!("--symbol cannot be used with --range");
         }
-        return run_trace_range(
-            &workspace,
-            range,
-            args.format,
-            args.strict,
-            &args.allowed_id,
-        );
+        let report = trace_range(&workspace, range, args.strict, &args.allowed_id)?;
+        return render_trace_range_output(range, report, args.format);
     }
 
     let Some(file) = &args.file else {
@@ -244,7 +239,7 @@ pub fn run_trace_command(args: &TraceArgs) -> Result<i32> {
 
     let workspace = load_workspace(&args.workspace)?;
     let normalized_file = normalize_lookup_file(&workspace, file)?;
-    let output = lookup_trace(&workspace, &normalized_file, symbol);
+    let output = trace_selector(&workspace, &normalized_file, symbol)?;
 
     match args.format {
         OutputFormat::Text => print!("{}", render_text_output(&output)),
@@ -258,78 +253,90 @@ pub fn run_trace_command(args: &TraceArgs) -> Result<i32> {
     Ok(0)
 }
 
-fn run_trace_range(
+fn render_trace_range_output(
+    range: &str,
+    report: TraceRangeOutput,
+    format: OutputFormat,
+) -> Result<i32> {
+    let guard_failed = report
+        .scope_guard
+        .as_ref()
+        .is_some_and(|guard| !guard.out_of_scope_items.is_empty());
+    let strict_failed = report
+        .strict_review
+        .as_ref()
+        .is_some_and(|review| review.failed);
+
+    match format {
+        OutputFormat::Text => {
+            print!(
+                "{}",
+                render_range_text(
+                    range,
+                    &report.files,
+                    &report.skipped_files,
+                    &report.summary,
+                    report.scope_guard.as_ref(),
+                    report.strict_review.as_ref(),
+                )
+            );
+        }
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .expect("serializing trace range output to JSON should succeed")
+            );
+        }
+    }
+
+    Ok(if guard_failed || strict_failed { 1 } else { 0 })
+}
+
+pub fn trace_range(
     workspace: &Workspace,
     range: &str,
-    format: OutputFormat,
     strict: bool,
     allowed_ids: &[String],
-) -> Result<i32> {
+) -> Result<TraceRangeOutput> {
     let changed_files = resolve_git_range_changed_files(&workspace.root, range)?;
 
     if changed_files.is_empty() {
-        let summary = TraceRangeSummary {
-            changed_files_total: 0,
-            inspected_files: 0,
-            skipped_files: 0,
-            owned_files: 0,
-            partial_files: 0,
-            unowned_files: 0,
-            total_requirements: 0,
-            total_features: 0,
-            total_policies: 0,
-            total_philosophies: 0,
-            ids: TraceRangeIdSummary {
-                direct: TraceRangeEntityGroup {
-                    requirements: Vec::new(),
-                    features: Vec::new(),
-                    policies: Vec::new(),
-                    philosophies: Vec::new(),
-                },
-                indirect: TraceRangeEntityGroup {
-                    requirements: Vec::new(),
-                    features: Vec::new(),
-                    policies: Vec::new(),
-                    philosophies: Vec::new(),
-                },
-            },
-        };
         let scope_guard = collect_trace_scope_guard(workspace, &[], &[], allowed_ids)?;
         let strict_review = collect_trace_review_output(&[], &[], scope_guard.as_ref(), strict);
-        let guard_failed = scope_guard
-            .as_ref()
-            .is_some_and(|guard| !guard.out_of_scope_items.is_empty());
-        let strict_failed = strict_review.as_ref().is_some_and(|review| review.failed);
-        match format {
-            OutputFormat::Text => {
-                print!(
-                    "{}",
-                    render_range_text(
-                        range,
-                        &[],
-                        &[],
-                        &summary,
-                        scope_guard.as_ref(),
-                        strict_review.as_ref(),
-                    )
-                );
-            }
-            OutputFormat::Json => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&TraceRangeOutput {
-                        range: range.to_string(),
-                        files: Vec::new(),
-                        skipped_files: Vec::new(),
-                        summary,
-                        scope_guard,
-                        strict_review,
-                    })
-                    .expect("serializing empty trace range output to JSON should succeed")
-                );
-            }
-        }
-        return Ok(if guard_failed || strict_failed { 1 } else { 0 });
+        return Ok(TraceRangeOutput {
+            range: range.to_string(),
+            files: Vec::new(),
+            skipped_files: Vec::new(),
+            summary: TraceRangeSummary {
+                changed_files_total: 0,
+                inspected_files: 0,
+                skipped_files: 0,
+                owned_files: 0,
+                partial_files: 0,
+                unowned_files: 0,
+                total_requirements: 0,
+                total_features: 0,
+                total_policies: 0,
+                total_philosophies: 0,
+                ids: TraceRangeIdSummary {
+                    direct: TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                    indirect: TraceRangeEntityGroup {
+                        requirements: Vec::new(),
+                        features: Vec::new(),
+                        policies: Vec::new(),
+                        philosophies: Vec::new(),
+                    },
+                },
+            },
+            scope_guard,
+            strict_review,
+        });
     }
 
     let (results, skipped) = collect_trace_range_outputs(workspace, &changed_files);
@@ -338,38 +345,14 @@ fn run_trace_range(
     let scope_guard = collect_trace_scope_guard(workspace, &results, &skipped, allowed_ids)?;
     let strict_review =
         collect_trace_review_output(&results, &skipped, scope_guard.as_ref(), strict);
-    let guard_failed = scope_guard
-        .as_ref()
-        .is_some_and(|guard| !guard.out_of_scope_items.is_empty());
-    let strict_failed = strict_review.as_ref().is_some_and(|review| review.failed);
-
-    match format {
-        OutputFormat::Text => print!(
-            "{}",
-            render_range_text(
-                range,
-                &results,
-                &skipped,
-                &summary,
-                scope_guard.as_ref(),
-                strict_review.as_ref(),
-            )
-        ),
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&TraceRangeOutput {
-                range: range.to_string(),
-                files: results,
-                skipped_files: skipped,
-                summary,
-                scope_guard,
-                strict_review,
-            })
-            .expect("serializing trace range output to JSON should succeed")
-        ),
-    }
-
-    Ok(if guard_failed || strict_failed { 1 } else { 0 })
+    Ok(TraceRangeOutput {
+        range: range.to_string(),
+        files: results,
+        skipped_files: skipped,
+        summary,
+        scope_guard,
+        strict_review,
+    })
 }
 
 fn compute_range_summary(
@@ -962,6 +945,14 @@ fn normalize_lookup_file(workspace: &Workspace, file: &Path) -> Result<PathBuf> 
         );
     }
     Ok(normalized)
+}
+
+pub fn trace_selector(
+    workspace: &Workspace,
+    file: &Path,
+    symbol: Option<&str>,
+) -> Result<TraceLookupOutput> {
+    Ok(lookup_trace(workspace, file, symbol))
 }
 
 fn lookup_trace(workspace: &Workspace, file: &Path, symbol: Option<&str>) -> TraceLookupOutput {


### PR DESCRIPTION
Summary:
- Added a new `syu-actions` workspace crate exposing typed workspace/action helpers for validation, task planning, trace/relate/history, and simple browse/list/show/search/audit/explain workflows.
- Exposed the underlying command-side report builders needed to call those workflows in-process.
- Kept the existing CLI tests passing after the visibility changes.

Validation:
- `cargo test -p syu-actions --lib`
- `cargo test -p syu --lib`

Closes #734
