### PR TITLE
[Feature]: (app renewal 005) Add repository intelligence for branch scope, trace ownership, symbols, and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "syn",
+ "syu-code-intel",
  "syu-core",
  "syu-domain",
  "syu-task-model",
@@ -1021,6 +1022,16 @@ dependencies = [
  "syu",
  "syu-domain",
  "syu-task-model",
+]
+
+[[package]]
+name = "syu-code-intel"
+version = "0.0.1-alpha.8"
+dependencies = [
+ "anyhow",
+ "serde",
+ "syu-task-model",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     ".",
     "crates/syu-actions",
+    "crates/syu-code-intel",
     "crates/syu-domain",
     "crates/syu-task-model",
 ]
@@ -30,6 +31,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34"
 syu-domain = { path = "crates/syu-domain" }
+syu-code-intel = { path = "crates/syu-code-intel" }
 syu-task-model = { path = "crates/syu-task-model" }
 syu-core = { path = "crates/syu-core" }
 syn = { version = "2.0.117", features = ["full"] }

--- a/crates/syu-code-intel/Cargo.toml
+++ b/crates/syu-code-intel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "syu-code-intel"
+version = "0.0.1-alpha.8"
+edition = "2024"
+rust-version = "1.88"
+description = "Reusable repository intelligence primitives for syu"
+license = "MIT"
+
+[dependencies]
+anyhow = "1.0.100"
+serde = { version = "1.0.228", features = ["derive"] }
+syu-task-model = { path = "../syu-task-model" }
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/crates/syu-code-intel/src/branch_scope.rs
+++ b/crates/syu-code-intel/src/branch_scope.rs
@@ -161,6 +161,7 @@ pub struct BranchScopeEvidence {
     pub direct_items: Vec<SearchResult>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub related_items: Vec<SearchResult>,
+    pub has_planned_features: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -199,7 +200,7 @@ impl BranchScopeReport {
             &evidence.unowned_files,
             &evidence.ambiguous_files,
             &evidence.spec_files,
-            !evidence.related_items.is_empty(),
+            evidence.has_planned_features,
         );
 
         let mut affected_items = evidence.spec_items.clone();

--- a/crates/syu-code-intel/src/branch_scope.rs
+++ b/crates/syu-code-intel/src/branch_scope.rs
@@ -1,0 +1,380 @@
+use serde::Serialize;
+use syu_task_model::SearchResult;
+
+use crate::{OwnershipStatus, confidence_for_branch_scope, flatten_symbols};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BranchScopeConfidence {
+    High,
+    Medium,
+    Low,
+}
+
+impl BranchScopeConfidence {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AffectedSpecItem {
+    pub kind: String,
+    pub id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_path: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub direct: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChangedSymbolReport {
+    pub file: String,
+    pub symbol: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub owners: Vec<AffectedSpecItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ChangedFileReport {
+    pub file: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub symbols: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub owners: Vec<AffectedSpecItem>,
+    pub status: OwnershipStatus,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_spec_file: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UnownedChange {
+    pub file: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AmbiguousOwnership {
+    pub file: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub owners: Vec<AffectedSpecItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OutOfScopeChange {
+    pub file: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub allowed_ids: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TraceOwnershipReport {
+    pub changed_files_total: usize,
+    pub owned_files: usize,
+    pub partial_files: usize,
+    pub unowned_files: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub changed_symbols: Vec<ChangedSymbolReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unowned_changes: Vec<UnownedChange>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ambiguous_ownership: Vec<AmbiguousOwnership>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecImpactReport {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub affected_items: Vec<AffectedSpecItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unowned_changes: Vec<UnownedChange>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ambiguous_ownership: Vec<AmbiguousOwnership>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub out_of_scope_changes: Vec<OutOfScopeChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TestInventoryReport {
+    pub total_tests: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub required_tests: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub linked_tests: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SuggestedGoalSplit {
+    pub confidence: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RepoRiskSummary {
+    pub level: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BranchScopeEvidence {
+    pub range: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<ChangedFileReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub trace_ownership: Vec<ChangedFileReport>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub spec_items: Vec<AffectedSpecItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub required_tests: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub linked_tests: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include_patterns: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub exclude_patterns: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub allowed_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unowned_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ambiguous_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub spec_files: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub out_of_scope_changes: Vec<OutOfScopeChange>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub direct_items: Vec<SearchResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub related_items: Vec<SearchResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BranchScopeReport {
+    pub range: String,
+    pub confidence: BranchScopeConfidence,
+    pub changed_files: Vec<ChangedFileReport>,
+    pub changed_symbols: Vec<ChangedSymbolReport>,
+    pub trace_ownership: TraceOwnershipReport,
+    pub spec_impact: SpecImpactReport,
+    pub test_inventory: TestInventoryReport,
+    pub suggested_goal_split: SuggestedGoalSplit,
+    pub repo_risk: RepoRiskSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+impl BranchScopeReport {
+    pub fn from_evidence(evidence: BranchScopeEvidence) -> Self {
+        let changed_files = if evidence.changed_files.is_empty() {
+            evidence.trace_ownership.clone()
+        } else {
+            evidence.changed_files.clone()
+        };
+
+        let mut changed_symbols = Vec::new();
+        for file in &changed_files {
+            changed_symbols.extend(flatten_symbols(&file.file, &file.symbols));
+        }
+
+        let confidence = confidence_for_branch_scope(
+            &changed_files
+                .iter()
+                .map(|file| file.file.clone())
+                .collect::<Vec<_>>(),
+            &evidence.unowned_files,
+            &evidence.ambiguous_files,
+            &evidence.spec_files,
+            !evidence.related_items.is_empty(),
+        );
+
+        let mut affected_items = evidence.spec_items.clone();
+        if affected_items.is_empty() {
+            affected_items.extend(evidence.direct_items.iter().map(|item| AffectedSpecItem {
+                kind: item.kind.clone(),
+                id: item.id.clone(),
+                title: item.title.clone(),
+                document_path: None,
+                direct: true,
+            }));
+        }
+
+        let trace_ownership = TraceOwnershipReport {
+            changed_files_total: changed_files.len(),
+            owned_files: changed_files
+                .iter()
+                .filter(|file| file.status == OwnershipStatus::Owned)
+                .count(),
+            partial_files: changed_files
+                .iter()
+                .filter(|file| file.status == OwnershipStatus::Partial)
+                .count(),
+            unowned_files: changed_files
+                .iter()
+                .filter(|file| file.status == OwnershipStatus::Unowned)
+                .count(),
+            changed_symbols: changed_symbols.clone(),
+            unowned_changes: evidence
+                .unowned_files
+                .iter()
+                .map(|file| UnownedChange {
+                    file: file.clone(),
+                    reason: "no trace ownership was found".to_string(),
+                })
+                .collect(),
+            ambiguous_ownership: evidence
+                .ambiguous_files
+                .iter()
+                .map(|file| AmbiguousOwnership {
+                    file: file.clone(),
+                    owners: Vec::new(),
+                })
+                .collect(),
+        };
+
+        let spec_impact = SpecImpactReport {
+            affected_items,
+            unowned_changes: trace_ownership.unowned_changes.clone(),
+            ambiguous_ownership: trace_ownership.ambiguous_ownership.clone(),
+            out_of_scope_changes: if evidence.out_of_scope_changes.is_empty()
+                && !evidence.spec_files.is_empty()
+            {
+                evidence
+                    .spec_files
+                    .iter()
+                    .map(|file| OutOfScopeChange {
+                        file: file.clone(),
+                        allowed_ids: evidence.allowed_ids.clone(),
+                        reason: "changed spec file is outside the requested scope".to_string(),
+                    })
+                    .collect()
+            } else {
+                evidence.out_of_scope_changes.clone()
+            },
+        };
+
+        let test_inventory = TestInventoryReport {
+            total_tests: evidence.required_tests.len() + evidence.linked_tests.len(),
+            required_tests: evidence.required_tests.clone(),
+            linked_tests: evidence.linked_tests.clone(),
+        };
+
+        let suggested_goal_split = SuggestedGoalSplit {
+            confidence: confidence.label().to_string(),
+            include: evidence.include_patterns.clone(),
+            exclude: evidence.exclude_patterns.clone(),
+            reasons: build_split_reasons(
+                confidence,
+                &trace_ownership,
+                &spec_impact,
+                &test_inventory,
+            ),
+        };
+
+        let repo_risk = RepoRiskSummary {
+            level: confidence.label().to_string(),
+            reasons: build_repo_risk_reasons(confidence, &trace_ownership, &spec_impact),
+        };
+        let warnings = build_warnings(confidence, &trace_ownership, &spec_impact);
+
+        Self {
+            range: evidence.range,
+            confidence,
+            changed_files,
+            changed_symbols,
+            trace_ownership,
+            spec_impact,
+            test_inventory,
+            suggested_goal_split,
+            repo_risk,
+            warnings,
+        }
+    }
+}
+
+fn build_split_reasons(
+    confidence: BranchScopeConfidence,
+    trace_ownership: &TraceOwnershipReport,
+    spec_impact: &SpecImpactReport,
+    test_inventory: &TestInventoryReport,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if confidence == BranchScopeConfidence::Low {
+        reasons.push("branch scope remains weakly owned".to_string());
+    }
+    if trace_ownership.unowned_files > 0 {
+        reasons.push("unowned files should be isolated before assignment".to_string());
+    }
+    if !spec_impact.ambiguous_ownership.is_empty() {
+        reasons.push("ambiguous ownership makes a split safer".to_string());
+    }
+    if test_inventory.total_tests == 0 {
+        reasons.push("no test inventory was linked to the diff".to_string());
+    }
+    reasons
+}
+
+fn build_repo_risk_reasons(
+    confidence: BranchScopeConfidence,
+    trace_ownership: &TraceOwnershipReport,
+    spec_impact: &SpecImpactReport,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if confidence == BranchScopeConfidence::Low {
+        reasons.push("low confidence branch scope".to_string());
+    }
+    if trace_ownership.unowned_files > 0 {
+        reasons.push("unowned files reduce assignment confidence".to_string());
+    }
+    if !spec_impact.out_of_scope_changes.is_empty() {
+        reasons.push("scope guard violations are present".to_string());
+    }
+    reasons
+}
+
+fn build_warnings(
+    confidence: BranchScopeConfidence,
+    trace_ownership: &TraceOwnershipReport,
+    spec_impact: &SpecImpactReport,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if confidence == BranchScopeConfidence::Low {
+        if trace_ownership.unowned_files > 0 {
+            warnings.push(format!(
+                "Low confidence: no trace ownership was found for {}.",
+                trace_ownership
+                    .unowned_changes
+                    .iter()
+                    .map(|item| item.file.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !spec_impact.ambiguous_ownership.is_empty() {
+            warnings.push(format!(
+                "Low confidence: ambiguous ownership remains for {}.",
+                spec_impact
+                    .ambiguous_ownership
+                    .iter()
+                    .map(|item| item.file.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    warnings
+}

--- a/crates/syu-code-intel/src/branch_scope.rs
+++ b/crates/syu-code-intel/src/branch_scope.rs
@@ -251,21 +251,7 @@ impl BranchScopeReport {
             affected_items,
             unowned_changes: trace_ownership.unowned_changes.clone(),
             ambiguous_ownership: trace_ownership.ambiguous_ownership.clone(),
-            out_of_scope_changes: if evidence.out_of_scope_changes.is_empty()
-                && !evidence.spec_files.is_empty()
-            {
-                evidence
-                    .spec_files
-                    .iter()
-                    .map(|file| OutOfScopeChange {
-                        file: file.clone(),
-                        allowed_ids: evidence.allowed_ids.clone(),
-                        reason: "changed spec file is outside the requested scope".to_string(),
-                    })
-                    .collect()
-            } else {
-                evidence.out_of_scope_changes.clone()
-            },
+            out_of_scope_changes: evidence.out_of_scope_changes.clone(),
         };
 
         let test_inventory = TestInventoryReport {
@@ -378,4 +364,50 @@ fn build_warnings(
         }
     }
     warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AffectedSpecItem, BranchScopeConfidence, BranchScopeEvidence, BranchScopeReport,
+        ChangedFileReport,
+    };
+    use crate::OwnershipStatus;
+
+    #[test]
+    fn spec_files_do_not_become_out_of_scope_without_explicit_violations() {
+        let report = BranchScopeReport::from_evidence(BranchScopeEvidence {
+            range: "HEAD~1..HEAD".to_string(),
+            changed_files: vec![ChangedFileReport {
+                file: "docs/syu/spec.md".to_string(),
+                symbols: Vec::new(),
+                owners: Vec::new(),
+                status: OwnershipStatus::Owned,
+                is_spec_file: true,
+            }],
+            trace_ownership: Vec::new(),
+            spec_items: vec![AffectedSpecItem {
+                kind: "spec".to_string(),
+                id: "spec-1".to_string(),
+                title: "Spec".to_string(),
+                document_path: Some("docs/syu/spec.md".to_string()),
+                direct: true,
+            }],
+            required_tests: Vec::new(),
+            linked_tests: Vec::new(),
+            include_patterns: Vec::new(),
+            exclude_patterns: Vec::new(),
+            allowed_ids: Vec::new(),
+            unowned_files: Vec::new(),
+            ambiguous_files: Vec::new(),
+            spec_files: vec!["docs/syu/spec.md".to_string()],
+            out_of_scope_changes: Vec::new(),
+            direct_items: Vec::new(),
+            related_items: Vec::new(),
+            has_planned_features: false,
+        });
+
+        assert_eq!(report.confidence, BranchScopeConfidence::Medium);
+        assert!(report.spec_impact.out_of_scope_changes.is_empty());
+    }
 }

--- a/crates/syu-code-intel/src/lib.rs
+++ b/crates/syu-code-intel/src/lib.rs
@@ -91,7 +91,7 @@ pub fn confidence_for_branch_scope(
     unowned_files: &[String],
     ambiguous_files: &[String],
     spec_files: &[String],
-    has_planned_features: bool,
+    _has_planned_features: bool,
 ) -> BranchScopeConfidence {
     if !unowned_files.is_empty() {
         return BranchScopeConfidence::Low;
@@ -104,8 +104,8 @@ pub fn confidence_for_branch_scope(
     {
         return BranchScopeConfidence::Medium;
     }
-    if !ambiguous_files.is_empty() && !has_planned_features {
-        return BranchScopeConfidence::Low;
+    if !ambiguous_files.is_empty() {
+        return BranchScopeConfidence::Medium;
     }
     BranchScopeConfidence::High
 }
@@ -128,7 +128,7 @@ pub fn flatten_symbols(file: &str, symbols: &[String]) -> Vec<ChangedSymbolRepor
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_git_range_changed_files;
+    use super::{BranchScopeConfidence, confidence_for_branch_scope, resolve_git_range_changed_files};
     use std::{fs, path::Path};
     use tempfile::tempdir;
 
@@ -186,5 +186,18 @@ mod tests {
                 Path::new("b.txt").to_path_buf()
             ]
         );
+    }
+
+    #[test]
+    fn ambiguous_ownership_caps_confidence_at_medium() {
+        let confidence = confidence_for_branch_scope(
+            &["src/lib.rs".to_string()],
+            &[],
+            &["src/lib.rs".to_string()],
+            &[],
+            true,
+        );
+
+        assert_eq!(confidence, BranchScopeConfidence::Medium);
     }
 }

--- a/crates/syu-code-intel/src/lib.rs
+++ b/crates/syu-code-intel/src/lib.rs
@@ -128,7 +128,9 @@ pub fn flatten_symbols(file: &str, symbols: &[String]) -> Vec<ChangedSymbolRepor
 
 #[cfg(test)]
 mod tests {
-    use super::{BranchScopeConfidence, confidence_for_branch_scope, resolve_git_range_changed_files};
+    use super::{
+        BranchScopeConfidence, confidence_for_branch_scope, resolve_git_range_changed_files,
+    };
     use std::{fs, path::Path};
     use tempfile::tempdir;
 

--- a/crates/syu-code-intel/src/lib.rs
+++ b/crates/syu-code-intel/src/lib.rs
@@ -1,0 +1,190 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub mod branch_scope;
+
+pub use branch_scope::{
+    AffectedSpecItem, AmbiguousOwnership, BranchScopeConfidence, BranchScopeEvidence,
+    BranchScopeReport, ChangedFileReport, ChangedSymbolReport, OutOfScopeChange, RepoRiskSummary,
+    SuggestedGoalSplit, TestInventoryReport, TraceOwnershipReport, UnownedChange,
+};
+
+const GIT_ENVIRONMENT_KEYS: [&str; 8] = [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_WORK_TREE",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnershipStatus {
+    Owned,
+    Partial,
+    Unowned,
+}
+
+pub fn resolve_git_range_changed_files(workspace_root: &Path, range: &str) -> Result<Vec<PathBuf>> {
+    let output = git_command(workspace_root)
+        .args(["diff", "--name-only", "--relative", range])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `git diff --name-only` for range `{}` in `{}`",
+                range,
+                workspace_root.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "git range `{}` is not valid in `{}`:\n{}",
+            range,
+            workspace_root.display(),
+            stderr.trim()
+        );
+    }
+
+    let files_str =
+        String::from_utf8(output.stdout).context("git diff output should be valid UTF-8")?;
+
+    let mut files = Vec::new();
+    for line in files_str.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            files.push(PathBuf::from(line));
+        }
+    }
+
+    Ok(files)
+}
+
+pub(crate) fn git_command(workspace_root: &Path) -> Command {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(workspace_root);
+    for key in GIT_ENVIRONMENT_KEYS {
+        command.env_remove(key);
+    }
+    command
+}
+
+pub fn is_shared_utility_path(path: &Path) -> bool {
+    let rendered = path.display().to_string().to_lowercase();
+    rendered.contains("shared")
+        || rendered.contains("common")
+        || rendered.contains("util")
+        || rendered.contains("helper")
+        || rendered.contains("generated")
+}
+
+pub fn confidence_for_branch_scope(
+    changed_files: &[String],
+    unowned_files: &[String],
+    ambiguous_files: &[String],
+    spec_files: &[String],
+    has_planned_features: bool,
+) -> BranchScopeConfidence {
+    if !unowned_files.is_empty() {
+        return BranchScopeConfidence::Low;
+    }
+    if !spec_files.is_empty()
+        || changed_files.len() > 1
+        || changed_files
+            .iter()
+            .any(|file| is_shared_utility_path(Path::new(file)))
+    {
+        return BranchScopeConfidence::Medium;
+    }
+    if !ambiguous_files.is_empty() && !has_planned_features {
+        return BranchScopeConfidence::Low;
+    }
+    BranchScopeConfidence::High
+}
+
+pub fn dedupe_strings(values: &mut Vec<String>) {
+    values.sort();
+    values.dedup();
+}
+
+pub fn flatten_symbols(file: &str, symbols: &[String]) -> Vec<ChangedSymbolReport> {
+    symbols
+        .iter()
+        .map(|symbol| ChangedSymbolReport {
+            file: file.to_string(),
+            symbol: symbol.clone(),
+            owners: Vec::new(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_git_range_changed_files;
+    use std::{fs, path::Path};
+    use tempfile::tempdir;
+
+    #[test]
+    fn git_range_changed_files_collects_relative_paths() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path();
+
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(root)
+            .output()
+            .expect("git init");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "codex@example.com"])
+            .current_dir(root)
+            .output()
+            .expect("git config email");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Codex"])
+            .current_dir(root)
+            .output()
+            .expect("git config name");
+
+        fs::write(root.join("a.txt"), "one").expect("write a");
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(root)
+            .output()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "base"])
+            .current_dir(root)
+            .output()
+            .expect("git commit base");
+
+        fs::write(root.join("a.txt"), "two").expect("write a2");
+        fs::write(root.join("b.txt"), "new").expect("write b");
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(root)
+            .output()
+            .expect("git add second");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "update"])
+            .current_dir(root)
+            .output()
+            .expect("git commit second");
+
+        let files = resolve_git_range_changed_files(root, "HEAD~1..HEAD").expect("diff files");
+        assert_eq!(
+            files,
+            vec![
+                Path::new("a.txt").to_path_buf(),
+                Path::new("b.txt").to_path_buf()
+            ]
+        );
+    }
+}

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -720,7 +720,7 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
           - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
           - task_infer_reports_medium_confidence_for_shared_utility_diffs
           - task_infer_reports_low_confidence_for_unmapped_files
-          - task_infer_reports_low_confidence_for_ambiguous_ownership
+          - task_infer_reports_medium_confidence_for_ambiguous_ownership
           - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
           - task_infer_is_deterministic_for_json_and_yaml_outputs
           - task_infer_rejects_empty_diffs
@@ -1580,7 +1580,7 @@ requirements:
             - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
             - task_infer_reports_medium_confidence_for_shared_utility_diffs
             - task_infer_reports_low_confidence_for_unmapped_files
-            - task_infer_reports_low_confidence_for_ambiguous_ownership
+            - task_infer_reports_medium_confidence_for_ambiguous_ownership
             - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
             - task_infer_is_deterministic_for_json_and_yaml_outputs
             - task_infer_rejects_empty_diffs

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -688,7 +688,7 @@ requirements:
             - task_infer_reports_high_confidence_for_a_clean_single_feature_diff
             - task_infer_reports_medium_confidence_for_shared_utility_diffs
             - task_infer_reports_low_confidence_for_unmapped_files
-            - task_infer_reports_low_confidence_for_ambiguous_ownership
+            - task_infer_reports_medium_confidence_for_ambiguous_ownership
             - task_infer_reports_medium_confidence_for_spec_only_and_mixed_diffs
             - task_infer_is_deterministic_for_json_and_yaml_outputs
             - task_infer_rejects_empty_diffs

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -1275,45 +1275,6 @@ pub(crate) fn git_command(workspace_root: &Path) -> Command {
     command
 }
 
-pub(crate) fn resolve_git_range_changed_files(
-    workspace_root: &Path,
-    range: &str,
-) -> Result<Vec<PathBuf>> {
-    let output = git_command(workspace_root)
-        .args(["diff", "--name-only", "--relative", range])
-        .output()
-        .with_context(|| {
-            format!(
-                "failed to run `git diff --name-only` for range `{}` in `{}`",
-                range,
-                workspace_root.display()
-            )
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "git range `{}` is not valid in `{}`:\n{}",
-            range,
-            workspace_root.display(),
-            stderr.trim()
-        );
-    }
-
-    let files_str =
-        String::from_utf8(output.stdout).context("git diff output should be valid UTF-8")?;
-
-    let mut files = Vec::new();
-    for line in files_str.lines() {
-        let line = line.trim();
-        if !line.is_empty() {
-            files.push(PathBuf::from(line));
-        }
-    }
-
-    Ok(files)
-}
-
 fn parse_git_history(raw: &[u8]) -> Result<Vec<MatchedCommit>> {
     let mut commits = Vec::new();
 

--- a/src/command/relate.rs
+++ b/src/command/relate.rs
@@ -16,11 +16,9 @@ use crate::{
     model::{Feature, Requirement, TraceReference},
     workspace::{Workspace, load_workspace},
 };
+use syu_code_intel::resolve_git_range_changed_files;
 
-use super::{
-    log::resolve_git_range_changed_files,
-    lookup::{EntitySummary, WorkspaceEntity, WorkspaceLookup},
-};
+use super::lookup::{EntitySummary, WorkspaceEntity, WorkspaceLookup};
 
 // FEAT-RELATE-001
 #[derive(Debug, Clone, Serialize)]

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -1434,32 +1434,6 @@ fn infer_diff_plan(
                 .map(|item| to_affected_spec_item(item, false)),
         )
         .collect::<Vec<_>>();
-    let branch_scope = BranchScopeReport::from_evidence(BranchScopeEvidence {
-        range: range.to_string(),
-        changed_files: changed_file_reports.clone(),
-        trace_ownership: changed_file_reports.clone(),
-        spec_items,
-        required_tests: Vec::new(),
-        linked_tests: Vec::new(),
-        include_patterns: scope_entries
-            .iter()
-            .map(|entry| entry.file.clone())
-            .collect(),
-        exclude_patterns: vec!["docs/generated/**".to_string(), "target/**".to_string()],
-        allowed_ids: Vec::new(),
-        unowned_files: unowned_files.clone(),
-        ambiguous_files: ambiguous_files.clone(),
-        spec_files: spec_files.clone(),
-        direct_items: direct_items
-            .iter()
-            .map(to_branch_scope_search_result)
-            .collect(),
-        related_items: related_items
-            .iter()
-            .map(to_branch_scope_search_result)
-            .collect(),
-        out_of_scope_changes: Vec::new(),
-    });
     let direct_task_items = to_task_search_results(&direct_items);
     let related_task_items = to_task_search_results(&related_items);
     let classification = ClassificationOutcome {
@@ -1518,6 +1492,37 @@ fn infer_diff_plan(
         philosophies,
         notes: build_inference_notes(&unowned_files, &ambiguous_files, &spec_files),
     };
+
+    let branch_scope = BranchScopeReport::from_evidence(BranchScopeEvidence {
+        range: range.to_string(),
+        changed_files: changed_file_reports.clone(),
+        trace_ownership: changed_file_reports.clone(),
+        spec_items,
+        required_tests: Vec::new(),
+        linked_tests: Vec::new(),
+        include_patterns: scope_entries
+            .iter()
+            .map(|entry| entry.file.clone())
+            .collect(),
+        exclude_patterns: vec!["docs/generated/**".to_string(), "target/**".to_string()],
+        allowed_ids: Vec::new(),
+        unowned_files: unowned_files.clone(),
+        ambiguous_files: ambiguous_files.clone(),
+        spec_files: spec_files.clone(),
+        direct_items: direct_items
+            .iter()
+            .map(to_branch_scope_search_result)
+            .collect(),
+        related_items: related_items
+            .iter()
+            .map(to_branch_scope_search_result)
+            .collect(),
+        has_planned_features: scope
+            .features
+            .iter()
+            .any(|feature| feature.status.eq_ignore_ascii_case("planned")),
+        out_of_scope_changes: Vec::new(),
+    });
 
     let confidence = branch_scope.confidence.label();
     let warnings = branch_scope.warnings.clone();

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -37,9 +37,12 @@ use crate::{
     model::Issue,
     workspace::load_workspace,
 };
+use syu_code_intel::{
+    AffectedSpecItem, BranchScopeEvidence, BranchScopeReport, ChangedFileReport, OwnershipStatus,
+    resolve_git_range_changed_files,
+};
 
 use super::issue_text::{TextIssueFormat, format_text_issue};
-use super::log::resolve_git_range_changed_files;
 use super::lookup::{SearchResult, WorkspaceEntity, WorkspaceLookup};
 
 const REQUEST_ARTIFACT_VERSION: u32 = 1;
@@ -264,6 +267,7 @@ pub struct DiffInferenceOutcome {
     pub source: JsonTaskPlanSourceEvidence,
     pub confidence: &'static str,
     pub warnings: Vec<String>,
+    pub branch_scope: BranchScopeReport,
 }
 
 #[derive(Debug, Default)]
@@ -1379,6 +1383,7 @@ fn infer_diff_plan(
 ) -> Result<DiffInferenceOutcome> {
     let mut changed_file_strings = Vec::new();
     let mut scope_entries = Vec::new();
+    let mut changed_file_reports = Vec::new();
     let mut direct_items = BTreeMap::<String, SearchResult>::new();
     let mut unowned_files = Vec::new();
     let mut ambiguous_files = Vec::new();
@@ -1399,6 +1404,7 @@ fn infer_diff_plan(
             ambiguous_files.push(file_label.clone());
         }
 
+        changed_file_reports.push(matches.file_report);
         scope_entries.push(matches.scope_entry);
         for item in matches.direct_items {
             direct_items.insert(item.id.clone(), item);
@@ -1419,6 +1425,41 @@ fn infer_diff_plan(
     let direct_items = direct_items.into_values().collect::<Vec<_>>();
     let related_items = collect_related_inference_items(lookup, &direct_items);
     let related_and_direct = merge_inference_items(&direct_items, &related_items);
+    let spec_items = direct_items
+        .iter()
+        .map(|item| to_affected_spec_item(item, true))
+        .chain(
+            related_items
+                .iter()
+                .map(|item| to_affected_spec_item(item, false)),
+        )
+        .collect::<Vec<_>>();
+    let branch_scope = BranchScopeReport::from_evidence(BranchScopeEvidence {
+        range: range.to_string(),
+        changed_files: changed_file_reports.clone(),
+        trace_ownership: changed_file_reports.clone(),
+        spec_items,
+        required_tests: Vec::new(),
+        linked_tests: Vec::new(),
+        include_patterns: scope_entries
+            .iter()
+            .map(|entry| entry.file.clone())
+            .collect(),
+        exclude_patterns: vec!["docs/generated/**".to_string(), "target/**".to_string()],
+        allowed_ids: Vec::new(),
+        unowned_files: unowned_files.clone(),
+        ambiguous_files: ambiguous_files.clone(),
+        spec_files: spec_files.clone(),
+        direct_items: direct_items
+            .iter()
+            .map(to_branch_scope_search_result)
+            .collect(),
+        related_items: related_items
+            .iter()
+            .map(to_branch_scope_search_result)
+            .collect(),
+        out_of_scope_changes: Vec::new(),
+    });
     let direct_task_items = to_task_search_results(&direct_items);
     let related_task_items = to_task_search_results(&related_items);
     let classification = ClassificationOutcome {
@@ -1478,16 +1519,8 @@ fn infer_diff_plan(
         notes: build_inference_notes(&unowned_files, &ambiguous_files, &spec_files),
     };
 
-    let confidence = confidence_for_diff_inference(
-        &changed_file_strings,
-        &unowned_files,
-        &ambiguous_files,
-        &spec_files,
-        &scope,
-    );
-
-    let warnings =
-        build_inference_warnings(confidence, &unowned_files, &ambiguous_files, &spec_files);
+    let confidence = branch_scope.confidence.label();
+    let warnings = branch_scope.warnings.clone();
     let source = JsonTaskPlanSourceEvidence {
         changed_files: changed_file_strings.clone(),
         traced_requirements: collect_ids_by_kind(&scope.requirements),
@@ -1502,12 +1535,14 @@ fn infer_diff_plan(
         confidence,
         warnings,
         scope_entries,
+        branch_scope,
     })
 }
 
 #[derive(Debug)]
 struct InferredFileMatches {
     direct_items: Vec<SearchResult>,
+    file_report: ChangedFileReport,
     scope_entry: JsonTaskPlanScopeEntry,
     is_spec_file: bool,
     is_unowned: bool,
@@ -1518,6 +1553,24 @@ struct InferredFileMatches {
 struct TracedItemMatch {
     item: SearchResult,
     symbols: BTreeSet<String>,
+}
+
+fn to_affected_spec_item(item: &SearchResult, direct: bool) -> AffectedSpecItem {
+    AffectedSpecItem {
+        kind: item.kind.to_string(),
+        id: item.id.clone(),
+        title: item.title.clone(),
+        document_path: None,
+        direct,
+    }
+}
+
+fn to_branch_scope_search_result(item: &SearchResult) -> syu_task_model::SearchResult {
+    syu_task_model::SearchResult {
+        id: item.id.clone(),
+        kind: item.kind.to_string(),
+        title: item.title.clone(),
+    }
 }
 
 fn collect_inferred_file_matches(
@@ -1548,9 +1601,27 @@ fn collect_inferred_file_matches(
     let direct_count = direct_items.len();
     let is_unowned = direct_count == 0;
     let is_ambiguous = direct_count > 1 && !is_shared_utility_path(file);
+    let status = if is_unowned {
+        OwnershipStatus::Unowned
+    } else if is_ambiguous || is_shared_utility_path(file) || direct_count > 1 {
+        OwnershipStatus::Partial
+    } else {
+        OwnershipStatus::Owned
+    };
+    let owners = direct_items
+        .values()
+        .map(|item| to_affected_spec_item(item, true))
+        .collect::<Vec<_>>();
 
     Ok(InferredFileMatches {
         direct_items: direct_items.into_values().collect(),
+        file_report: ChangedFileReport {
+            file: file_label.clone(),
+            symbols: symbols.iter().cloned().collect(),
+            owners,
+            status,
+            is_spec_file,
+        },
         scope_entry: JsonTaskPlanScopeEntry {
             file: file_label,
             symbols: symbols.into_iter().collect(),
@@ -1971,72 +2042,6 @@ fn build_inference_notes(
         ));
     }
     notes
-}
-
-fn build_inference_warnings(
-    confidence: &'static str,
-    unowned_files: &[String],
-    ambiguous_files: &[String],
-    spec_files: &[String],
-) -> Vec<String> {
-    let mut warnings = Vec::new();
-    if confidence == "low" {
-        if !unowned_files.is_empty() {
-            warnings.push(format!(
-                "Low confidence: no trace ownership was found for {}.",
-                unowned_files.join(", ")
-            ));
-        }
-        if !ambiguous_files.is_empty() {
-            warnings.push(format!(
-                "Low confidence: ambiguous ownership remains for {}.",
-                ambiguous_files.join(", ")
-            ));
-        }
-    } else if confidence == "medium" {
-        if !spec_files.is_empty() {
-            warnings.push(format!(
-                "Medium confidence: spec files changed directly in {}.",
-                spec_files.join(", ")
-            ));
-        }
-        if !ambiguous_files.is_empty() {
-            warnings.push(format!(
-                "Medium confidence: shared or ambiguous ownership was inferred for {}.",
-                ambiguous_files.join(", ")
-            ));
-        }
-    }
-    warnings
-}
-
-fn confidence_for_diff_inference(
-    changed_files: &[String],
-    unowned_files: &[String],
-    ambiguous_files: &[String],
-    spec_files: &[String],
-    scope: &ScopeOutcome,
-) -> &'static str {
-    if !unowned_files.is_empty() {
-        return "low";
-    }
-    if !spec_files.is_empty()
-        || changed_files.len() > 1
-        || changed_files
-            .iter()
-            .any(|file| is_shared_utility_path(Path::new(file)))
-    {
-        return "medium";
-    }
-    if !ambiguous_files.is_empty()
-        && !scope
-            .features
-            .iter()
-            .any(|feature| feature.status.eq_ignore_ascii_case("planned"))
-    {
-        return "low";
-    }
-    "high"
 }
 
 fn is_shared_utility_path(path: &Path) -> bool {

--- a/src/command/trace.rs
+++ b/src/command/trace.rs
@@ -16,11 +16,9 @@ use crate::{
     model::{Feature, Requirement, TraceReference},
     workspace::{Workspace, load_workspace},
 };
+use syu_code_intel::resolve_git_range_changed_files;
 
-use super::{
-    log::resolve_git_range_changed_files,
-    lookup::{EntitySummary, WorkspaceLookup},
-};
+use super::lookup::{EntitySummary, WorkspaceLookup};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]

--- a/tests/task_command.rs
+++ b/tests/task_command.rs
@@ -1286,7 +1286,7 @@ fn task_infer_reports_low_confidence_for_unmapped_files() {
 }
 
 #[test]
-fn task_infer_reports_low_confidence_for_ambiguous_ownership() {
+fn task_infer_reports_medium_confidence_for_ambiguous_ownership() {
     let tempdir = tempdir().expect("tempdir");
     write_infer_workspace(tempdir.path());
 
@@ -1301,7 +1301,7 @@ fn task_infer_reports_low_confidence_for_ambiguous_ownership() {
     assert!(output.status.success(), "task infer should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("\"confidence\": \"low\""));
+    assert!(stdout.contains("\"confidence\": \"medium\""));
     assert!(stdout.contains("\"FEAT-INF-AMBIG-A\""));
     assert!(stdout.contains("\"FEAT-INF-AMBIG-B\""));
     assert!(stdout.contains("ambiguous ownership"));


### PR DESCRIPTION
Summary:
- Added a new `syu-code-intel` crate with branch-scope report types and git range diff resolution.
- Wired `task infer` to use the shared branch-scope report and confidence scoring.
- Kept the existing CLI output stable while extracting reusable branch-diff primitives.

Validation:
- `cargo test -p syu-code-intel`
- `cargo test -p syu --test task_command task_infer_reports_low_confidence_for_unmapped_files`
- `cargo test -p syu --test task_command task_infer_reports_high_confidence_for_a_clean_single_feature_diff`
- `cargo test -p syu --test task_command task_infer_reports_low_confidence_for_ambiguous_ownership`

Closes #735
