### PR TITLE
REQ-WORKBENCH-003 Add Workbench request intake and goal splitter canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "dioxus",
  "dioxus-ssr",
  "manganis",
+ "syu-task-model",
  "syu-workbench",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "dioxus",
  "dioxus-ssr",
  "manganis",
+ "serde_yaml",
  "syu-task-model",
  "syu-workbench",
 ]

--- a/crates/syu-app-ui/Cargo.toml
+++ b/crates/syu-app-ui/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 dioxus = { version = "0.7.9", features = ["asset", "html", "macro"] }
 manganis = "0.7.9"
+serde_yaml = "0.9.34"
 syu-task-model = { path = "../syu-task-model" }
 syu-workbench = { path = "../syu-workbench" }
 

--- a/crates/syu-app-ui/Cargo.toml
+++ b/crates/syu-app-ui/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 dioxus = { version = "0.7.9", features = ["asset", "html", "macro"] }
 manganis = "0.7.9"
+syu-task-model = { path = "../syu-task-model" }
 syu-workbench = { path = "../syu-workbench" }
 
 [dev-dependencies]

--- a/crates/syu-app-ui/src/components/mod.rs
+++ b/crates/syu-app-ui/src/components/mod.rs
@@ -6,5 +6,8 @@ pub use primitives::{
     IconButton, Panel, ScopeChip, StatusDot,
 };
 pub use shell::{
-    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalRail, StatusBar, WorkspacePulse,
+    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalDependencyView, GoalPlanCanvas,
+    GoalPlanExportPanel, GoalRail, GoalScopePanel, GoalTestPlanPanel, RequestClassificationPanel,
+    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel, StatusBar,
+    WorkspacePulse,
 };

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -651,41 +651,8 @@ fn include_pattern(include: &GoalPlanScopeInclude) -> String {
 }
 
 fn goal_plan_yaml_preview(plan: &GoalPlanArtifact) -> String {
-    let include = plan
-        .implementation_plan
-        .scope
-        .include
-        .iter()
-        .map(|entry| format!("      - {}", include_pattern(entry)))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let exclude = plan
-        .implementation_plan
-        .scope
-        .exclude
-        .iter()
-        .map(|entry| format!("      - {entry}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let commands = plan
-        .completion
-        .must_pass
-        .iter()
-        .map(|entry| format!("    - {entry}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    format!(
-        "version: {}\nkind: {}\ngoal:\n  id: {}\n  title: {}\n  statement: {}\nimplementation_plan:\n  scope:\n    include:\n{}\n    exclude:\n{}\ncompletion:\n  must_pass:\n{}\n",
-        plan.version,
-        plan.kind,
-        plan.goal.id,
-        plan.goal.title,
-        plan.goal.statement,
-        include,
-        exclude,
-        commands
-    )
+    serde_yaml::to_string(plan)
+        .unwrap_or_else(|err| format!("# failed to render Goal Plan YAML: {err}"))
 }
 
 #[cfg(test)]
@@ -740,6 +707,26 @@ mod tests {
         assert!(pulse < preview);
         assert!(html.contains("Read-only action placeholder"));
         assert!(html.contains("Evidence placeholder"));
+    }
+
+    #[test]
+    fn goal_plan_yaml_preview_roundtrips_through_the_task_model_schema() {
+        let ui = build_demo_state();
+        let plan = ui
+            .payload
+            .state
+            .goals
+            .active_goal()
+            .and_then(|goal| goal.goal_plan.as_ref())
+            .expect("demo state should include an active goal plan");
+
+        let yaml = goal_plan_yaml_preview(plan);
+        let parsed: GoalPlanArtifact =
+            serde_yaml::from_str(&yaml).expect("preview should deserialize as a GoalPlanArtifact");
+
+        assert_eq!(&parsed, plan);
+        assert!(yaml.contains("test_plan:"));
+        assert!(yaml.contains("coverage:"));
     }
 
     #[test]

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -1,10 +1,14 @@
 use crate::components::{
-    Button, CommandItem, DetailDrawer, EmptyState, EvidenceLogRow, GoalCard, IconButton, Panel,
-    ScopeChip, StatusDot,
+    Button, CommandItem, DetailDrawer, EmptyState, EvidenceBadge, EvidenceLogRow, GoalCard,
+    IconButton, Panel, ScopeChip, StatusDot,
 };
 use crate::design::classes;
 use crate::model::{WorkbenchUiState, WorkspacePulseSummary};
 use dioxus::prelude::*;
+use syu_task_model::{
+    GoalPlanArtifact, GoalPlanConfidence, GoalPlanPersistentItem, GoalPlanScopeInclude,
+    ScaffoldAction, ScaffoldUpdateKind,
+};
 use syu_workbench::WorkbenchActionId;
 
 #[component]
@@ -26,7 +30,12 @@ pub fn AppShell(ui: WorkbenchUiState) -> Element {
                 }
                 div { class: classes::MAIN_GRID,
                     GoalRail { ui: ui.clone() }
-                    GoalCanvas { ui: ui.clone() }
+                    GoalCanvas {
+                        ui: ui.clone(),
+                        on_run_action: move |action_id: WorkbenchActionId| {
+                            ui_state.write().select_action(action_id);
+                        },
+                    }
                     EvidencePanel { ui: ui.clone() }
                 }
             }
@@ -152,12 +161,23 @@ pub fn GoalRail(ui: WorkbenchUiState) -> Element {
 }
 
 #[component]
-pub fn GoalCanvas(ui: WorkbenchUiState) -> Element {
+pub fn GoalCanvas(
+    ui: WorkbenchUiState,
+    on_run_action: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
     let summary = ui.pulse_summary();
     rsx! {
         Panel { class: classes::PANEL,
             div { class: classes::PANEL_INNER,
                 WorkspacePulse { summary: summary.clone() }
+                RequestIntakeCanvas {
+                    ui: ui.clone(),
+                    on_run_action: on_run_action,
+                }
+                GoalPlanCanvas {
+                    ui: ui.clone(),
+                    on_run_action: on_run_action,
+                }
                 if let Some(preview) = ui.preview.clone().or_else(|| ui.selected_action_id.and_then(|id| ui.action_preview(id))) {
                     DetailDrawer {
                         title: preview.title.clone(),
@@ -172,6 +192,315 @@ pub fn GoalCanvas(ui: WorkbenchUiState) -> Element {
                     }
                 } else {
                     EmptyState { title: "No action selected".to_string(), body: "Open the palette to run a read-only action or inspect the next suggested step.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn RequestIntakeCanvas(
+    ui: WorkbenchUiState,
+    on_run_action: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
+    let request = ui.payload.state.request.clone();
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-4 p-4",
+                div { class: classes::SECTION_HEADER,
+                    h2 { class: classes::SECTION_TITLE, "Request Intake" }
+                    ScopeChip { label: temporary_artifact_label(&ui) }
+                }
+                RequestContextEditor { ui: ui.clone() }
+                div { class: "grid gap-2 md:grid-cols-4",
+                    FlowActionButton { label: "Classify".to_string(), action_id: WorkbenchActionId::RequestClassify, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Scope".to_string(), action_id: WorkbenchActionId::RequestScope, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Preview scaffold".to_string(), action_id: WorkbenchActionId::RequestScaffold, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Generate plan".to_string(), action_id: WorkbenchActionId::RequestPlan, ui: ui.clone(), onclick: on_run_action }
+                }
+                div { class: "grid gap-3 xl:grid-cols-3",
+                    RequestClassificationPanel { request: request.clone() }
+                    RequestScopePanel { request: request.clone() }
+                    ScaffoldPreviewPanel { request }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn RequestContextEditor(ui: WorkbenchUiState) -> Element {
+    let request = ui
+        .payload
+        .state
+        .request
+        .as_ref()
+        .and_then(|state| state.artifact.as_ref());
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-3 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Change request" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::RequestArtifact }
+                }
+                if let Some(artifact) = request {
+                    p { class: "text-base leading-7 text-foreground", "{artifact.request}" }
+                    div { class: "flex flex-wrap gap-2",
+                        if let Some(area) = &artifact.context.affected_area {
+                            ScopeChip { label: format!("area: {area}") }
+                        }
+                        for id in &artifact.context.linked_ids {
+                            ScopeChip { label: id.clone() }
+                        }
+                    }
+                    for constraint in &artifact.context.repository_constraints {
+                        p { class: "text-sm text-foreground/70", "constraint: {constraint}" }
+                    }
+                } else {
+                    EmptyState { title: "Paste a request".to_string(), body: "Request text becomes a temporary Workbench artifact before any spec content changes.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn RequestClassificationPanel(request: Option<syu_workbench::ActiveRequestState>) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Classify" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::ClassificationOutcome }
+                }
+                if let Some(classification) = request.as_ref().and_then(|request| request.classification.as_ref()) {
+                    ScopeChip { label: classification.classification.label().to_string() }
+                    for reason in &classification.reasons {
+                        p { class: "text-sm text-foreground/75", "{reason}" }
+                    }
+                    for item in classification.explicit_items.iter().chain(classification.related_items.iter()) {
+                        p { class: "text-xs uppercase tracking-[0.16em] text-foreground/60", "{item.kind}: {item.id}" }
+                    }
+                } else {
+                    EmptyState { title: "Not classified".to_string(), body: "Run request.classify from this canvas or the command palette.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn RequestScopePanel(request: Option<syu_workbench::ActiveRequestState>) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Scope" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::ScopeOutcome }
+                }
+                if let Some(scope) = request.as_ref().and_then(|request| request.scope.as_ref()) {
+                    div { class: "flex flex-wrap gap-2",
+                        for requirement in &scope.requirements {
+                            ScopeChip { label: requirement.id.clone() }
+                        }
+                        for feature in &scope.features {
+                            ScopeChip { label: feature.id.clone() }
+                        }
+                    }
+                    for note in &scope.notes {
+                        p { class: "text-sm text-foreground/75", "{note}" }
+                    }
+                } else {
+                    EmptyState { title: "Scope pending".to_string(), body: "Map the request to relevant specs before planning implementation work.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ScaffoldPreviewPanel(request: Option<syu_workbench::ActiveRequestState>) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Scaffold Preview" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::ScaffoldPlan }
+                }
+                if let Some(scaffold) = request.as_ref().and_then(|request| request.scaffold.as_ref()) {
+                    for update in &scaffold.updates {
+                        article { class: classes::EVIDENCE_CARD,
+                            div { class: "flex flex-wrap items-center gap-2",
+                                ScopeChip { label: scaffold_action_label(update.action).to_string() }
+                                ScopeChip { label: scaffold_kind_label(update.kind).to_string() }
+                                if let Some(id) = &update.id {
+                                    ScopeChip { label: id.clone() }
+                                }
+                            }
+                            p { class: "mt-2 text-sm font-medium", "{update.path}" }
+                            p { class: "mt-1 text-xs text-foreground/65", "{update.contents}" }
+                        }
+                    }
+                } else {
+                    EmptyState { title: "No scaffold preview".to_string(), body: "Preview spec updates without treating them as committed persistent content.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalPlanCanvas(
+    ui: WorkbenchUiState,
+    on_run_action: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
+    let goals = ui.payload.state.goals.active.clone();
+    rsx! {
+        section { class: "flex flex-col gap-3",
+            div { class: classes::SECTION_HEADER,
+                h2 { class: classes::SECTION_TITLE, "Goal Plan" }
+                ScopeChip { label: format!("{} temporary cards", goals.len()) }
+            }
+            if goals.is_empty() {
+                EmptyState { title: "No generated Goal Plan".to_string(), body: "Run request.plan after the request is classified and scoped.".to_string() }
+            } else {
+                for goal in goals {
+                    if let Some(plan) = goal.goal_plan.clone() {
+                        GoalPlanCard { plan: plan.clone() }
+                    }
+                }
+                div { class: "grid gap-2 md:grid-cols-3",
+                    FlowActionButton { label: "Select tests".to_string(), action_id: WorkbenchActionId::GoalTestSelect, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Check goal".to_string(), action_id: WorkbenchActionId::GoalCheck, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Assign next".to_string(), action_id: WorkbenchActionId::AssignmentCreate, ui: ui.clone(), onclick: on_run_action }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn GoalPlanCard(plan: GoalPlanArtifact) -> Element {
+    rsx! {
+        article { class: "rounded-2xl border border-goal-active bg-panel p-3",
+            GoalCard { goal_id: plan.goal.id.clone(), title: plan.goal.title.clone(), selected: true }
+            div { class: "mt-3 grid gap-3 xl:grid-cols-2",
+                Panel { class: classes::PANEL_MUTED,
+                    div { class: "flex flex-col gap-2 p-3",
+                        div { class: classes::SECTION_HEADER,
+                            h3 { class: "text-sm font-semibold", "Goal Statement" }
+                            ScopeChip { label: confidence_label(plan.source.confidence.or(plan.implementation_plan.confidence)) }
+                        }
+                        p { class: "text-sm leading-6 text-foreground/80", "{plan.goal.statement}" }
+                        for non_goal in &plan.goal.non_goals {
+                            p { class: "text-sm text-scope-out", "non-goal: {non_goal}" }
+                        }
+                    }
+                }
+                GoalDependencyView { plan: plan.clone() }
+                GoalScopePanel { plan: plan.clone() }
+                GoalTestPlanPanel { plan: plan.clone() }
+                GoalPlanExportPanel { plan: plan.clone() }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalDependencyView(plan: GoalPlanArtifact) -> Element {
+    let items = persistent_item_labels(&plan);
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Persistent Spec Items" }
+                    ScopeChip { label: format!("{} linked", items.len()) }
+                }
+                if items.is_empty() {
+                    EmptyState { title: "No linked specs".to_string(), body: "Inferred suggestions must be reviewed before implementation.".to_string() }
+                } else {
+                    div { class: "flex flex-wrap gap-2",
+                        for item in items {
+                            ScopeChip { label: item }
+                        }
+                    }
+                }
+                if plan.spec_mapping.spec_updates_required {
+                    p { class: "text-sm text-evidence-warn", "spec updates required" }
+                    for update in &plan.spec_mapping.spec_updates.expected_updates {
+                        p { class: "text-sm text-foreground/75", "{update}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalScopePanel(plan: GoalPlanArtifact) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Scope" }
+                    ScopeChip { label: "include / exclude".to_string() }
+                }
+                div { class: "flex flex-wrap gap-2",
+                    for include in &plan.implementation_plan.scope.include {
+                        ScopeChip { label: format!("include: {}", include_pattern(include)) }
+                    }
+                    for exclude in &plan.implementation_plan.scope.exclude {
+                        ScopeChip { label: format!("exclude: {exclude}") }
+                    }
+                }
+                for step in &plan.implementation_plan.steps {
+                    p { class: "text-sm text-foreground/75", "step: {step}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalTestPlanPanel(plan: GoalPlanArtifact) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Tests and Evidence" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::GoalPlanCheckReport }
+                }
+                ScopeChip { label: format!("selection: {:?}", plan.test_plan.selection_mode) }
+                if plan.test_plan.required_tests.is_empty() {
+                    p { class: "text-sm text-foreground/70", "required tests: covered by completion commands" }
+                } else {
+                    for language in plan.test_plan.required_tests.keys() {
+                        p { class: "text-sm text-foreground/75", "required tests: {language}" }
+                    }
+                }
+                for command in &plan.completion.must_pass {
+                    p { class: "text-sm text-evidence-pass", "must pass: {command}" }
+                }
+                for warning in &plan.warnings {
+                    p { class: "text-sm text-evidence-warn", "evidence note: {warning}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalPlanExportPanel(plan: GoalPlanArtifact) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Export YAML" }
+                    EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::GoalPlanArtifact }
+                }
+                p { class: "text-sm text-foreground/75", "Export target: .syu/workbench/goals/{plan.goal.id}.yaml" }
+                pre { class: "max-h-56 overflow-auto rounded-xl border border-border bg-background p-3 text-xs text-foreground/80",
+                    "{goal_plan_yaml_preview(&plan)}"
                 }
             }
         }
@@ -218,6 +547,147 @@ fn goal_title(goal: &syu_workbench::ActiveGoalState) -> String {
         .unwrap_or_else(|| "Untitled goal".to_string())
 }
 
+#[component]
+fn FlowActionButton(
+    label: String,
+    action_id: WorkbenchActionId,
+    ui: WorkbenchUiState,
+    onclick: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
+    let available = ui
+        .payload
+        .availability
+        .iter()
+        .find(|availability| availability.id == action_id)
+        .is_some_and(|availability| availability.available);
+    let class = if available {
+        "rounded-xl border border-command-active bg-command-active px-3 py-2 text-sm font-medium text-background"
+    } else {
+        "rounded-xl border border-border bg-panel-muted px-3 py-2 text-sm font-medium text-foreground/55"
+    };
+    rsx! {
+        button {
+            class: class,
+            disabled: !available,
+            onclick: move |_| {
+                if let Some(handler) = onclick {
+                    handler.call(action_id);
+                }
+            },
+            type: "button",
+            span { "{label}" }
+            span { class: "ml-2 text-xs opacity-75", "{action_id.label()}" }
+        }
+    }
+}
+
+fn temporary_artifact_label(ui: &WorkbenchUiState) -> String {
+    ui.payload
+        .state
+        .request
+        .as_ref()
+        .and_then(|request| request.request_path.as_ref())
+        .map(|path| format!("temporary: {}", path.display()))
+        .unwrap_or_else(|| "temporary planning artifact".to_string())
+}
+
+fn scaffold_action_label(action: ScaffoldAction) -> &'static str {
+    action.label()
+}
+
+fn scaffold_kind_label(kind: ScaffoldUpdateKind) -> &'static str {
+    kind.label()
+}
+
+fn confidence_label(confidence: Option<GoalPlanConfidence>) -> String {
+    match confidence {
+        Some(GoalPlanConfidence::High) => "confidence: high",
+        Some(GoalPlanConfidence::Medium) => "confidence: medium",
+        Some(GoalPlanConfidence::Low) => "confidence: low",
+        None => "confidence: pending",
+    }
+    .to_string()
+}
+
+fn persistent_item_labels(plan: &GoalPlanArtifact) -> Vec<String> {
+    let mut labels = Vec::new();
+    labels.extend(
+        plan.spec_mapping
+            .persistent_items
+            .philosophies
+            .iter()
+            .map(persistent_item_id),
+    );
+    labels.extend(
+        plan.spec_mapping
+            .persistent_items
+            .policies
+            .iter()
+            .map(persistent_item_id),
+    );
+    labels.extend(
+        plan.spec_mapping
+            .persistent_items
+            .requirements
+            .iter()
+            .map(persistent_item_id),
+    );
+    labels.extend(
+        plan.spec_mapping
+            .persistent_items
+            .features
+            .iter()
+            .map(persistent_item_id),
+    );
+    labels
+}
+
+fn persistent_item_id(item: &GoalPlanPersistentItem) -> String {
+    item.id().to_string()
+}
+
+fn include_pattern(include: &GoalPlanScopeInclude) -> String {
+    include.pattern().to_string()
+}
+
+fn goal_plan_yaml_preview(plan: &GoalPlanArtifact) -> String {
+    let include = plan
+        .implementation_plan
+        .scope
+        .include
+        .iter()
+        .map(|entry| format!("      - {}", include_pattern(entry)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let exclude = plan
+        .implementation_plan
+        .scope
+        .exclude
+        .iter()
+        .map(|entry| format!("      - {entry}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let commands = plan
+        .completion
+        .must_pass
+        .iter()
+        .map(|entry| format!("    - {entry}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "version: {}\nkind: {}\ngoal:\n  id: {}\n  title: {}\n  statement: {}\nimplementation_plan:\n  scope:\n    include:\n{}\n    exclude:\n{}\ncompletion:\n  must_pass:\n{}\n",
+        plan.version,
+        plan.kind,
+        plan.goal.id,
+        plan.goal.title,
+        plan.goal.statement,
+        include,
+        exclude,
+        commands
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,7 +726,10 @@ mod tests {
         ui.run_read_only_action(WorkbenchActionId::HistoryShow);
 
         let html = render_element(rsx! {
-            GoalCanvas { ui }
+            GoalCanvas {
+                ui,
+                on_run_action: None
+            }
         });
 
         let pulse = html.find("Workbench Pulse").expect("pulse should render");

--- a/crates/syu-app-ui/src/lib.rs
+++ b/crates/syu-app-ui/src/lib.rs
@@ -7,7 +7,10 @@ pub mod model;
 use dioxus::prelude::{Asset, asset};
 
 pub use components::{
-    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalRail, StatusBar, WorkspacePulse,
+    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalDependencyView, GoalPlanCanvas,
+    GoalPlanExportPanel, GoalRail, GoalScopePanel, GoalTestPlanPanel, RequestClassificationPanel,
+    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel, StatusBar,
+    WorkspacePulse,
 };
 pub use model::{
     CommandPaletteEntry, WorkbenchActionRunPreview, WorkbenchUiState, build_demo_state,

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -1,3 +1,13 @@
+use std::collections::BTreeMap;
+use syu_task_model::{
+    GoalPlanArtifact, GoalPlanCompletion, GoalPlanConfidence, GoalPlanCoverage,
+    GoalPlanCoverageMode, GoalPlanGoal, GoalPlanImplementationPlan, GoalPlanPersistentItem,
+    GoalPlanPersistentItems, GoalPlanScope, GoalPlanScopeInclude, GoalPlanSource,
+    GoalPlanSpecMapping, GoalPlanSpecUpdates, GoalPlanTestPlan, RequestArtifact,
+    RequestArtifactContext, RequestClassification, ScaffoldAction, ScaffoldPlan, ScaffoldUpdate,
+    ScaffoldUpdateKind, ScopeFeatureCandidate, ScopeOutcome, ScopeSignals, SearchResult,
+    TaskTestSelectionCommand, TaskTestSelectionEscalation, TaskTestSelectionPlan,
+};
 use syu_workbench::{
     ActiveGoalState, ActiveRequestState, EvidenceEntry, GoalListState, WorkbenchAction,
     WorkbenchActionAvailability, WorkbenchActionId, WorkbenchActionMutability,
@@ -221,21 +231,113 @@ impl WorkbenchUiState {
 }
 
 pub fn build_demo_state() -> WorkbenchUiState {
+    let request_artifact = demo_request_artifact();
+    let classification = syu_workbench::ClassificationOutcome {
+        classification: RequestClassification::Change,
+        reasons: vec![
+            "Existing Workbench request and goal artifacts are being expanded.".to_string(),
+            "The request names REQ-WORKBENCH-003 and Workbench UI features.".to_string(),
+        ],
+        explicit_items: vec![SearchResult {
+            id: "REQ-WORKBENCH-003".to_string(),
+            kind: "requirement".to_string(),
+            title: "Goal splitting for large change requests".to_string(),
+        }],
+        related_items: vec![SearchResult {
+            id: "FEAT-WORKBENCH-GOAL-SPLITTER-001".to_string(),
+            kind: "feature".to_string(),
+            title: "Goal Splitter canvas".to_string(),
+        }],
+        request: request_artifact.request.clone(),
+        context: request_artifact.context.clone(),
+    };
+    let scope = ScopeOutcome {
+        classification: classification.clone(),
+        signals: ScopeSignals {
+            policy_discussion: false,
+            philosophy_discussion: false,
+            planned_feature_updates: true,
+        },
+        requirements: classification.explicit_items.clone(),
+        features: vec![ScopeFeatureCandidate {
+            id: "FEAT-WORKBENCH-REQUEST-INTAKE-001".to_string(),
+            title: "Request Intake canvas".to_string(),
+            status: "temporary planning artifact".to_string(),
+            linked_requirements: vec!["REQ-WORKBENCH-003".to_string()],
+            planned_state_update: true,
+        }],
+        policies: Vec::new(),
+        philosophies: Vec::new(),
+        notes: vec![
+            "Temporary artifacts stay under .syu/workbench/requests and .syu/workbench/goals."
+                .to_string(),
+            "Exported Goal Plan YAML must remain compatible with syu task check.".to_string(),
+        ],
+    };
+    let scaffold = ScaffoldPlan {
+        updates: vec![
+            ScaffoldUpdate {
+                kind: ScaffoldUpdateKind::Feature,
+                action: ScaffoldAction::Update,
+                path: "docs/syu/features/workbench/goal-splitter.yaml".to_string(),
+                id: Some("FEAT-WORKBENCH-GOAL-SPLITTER-001".to_string()),
+                contents: "Add request intake and goal splitter UI coverage.".to_string(),
+            },
+            ScaffoldUpdate {
+                kind: ScaffoldUpdateKind::Requirement,
+                action: ScaffoldAction::Update,
+                path: "docs/syu/requirements/core/workbench.yaml".to_string(),
+                id: Some("REQ-WORKBENCH-003".to_string()),
+                contents: "Clarify temporary Goal Plans and export compatibility.".to_string(),
+            },
+        ],
+    };
+    let goal_plan = demo_goal_plan();
     let mut state = WorkbenchState {
         workspace: Some(syu_workbench::WorkspaceSnapshot {
             workspace_root: std::path::PathBuf::from("/workspace/syu"),
             spec_root: std::path::PathBuf::from("/workspace/syu/docs/syu"),
-            branch: Some("issue-738-workbench-ui".to_string()),
+            branch: Some("issue-739-request-goal-splitter".to_string()),
             validation_summary: Some("green".to_string()),
         }),
-        request: Some(ActiveRequestState::default()),
+        request: Some(ActiveRequestState {
+            request_path: Some(std::path::PathBuf::from(
+                ".syu/workbench/requests/request-739.yaml",
+            )),
+            artifact: Some(request_artifact),
+            classification: Some(classification),
+            scope: Some(scope),
+            scaffold: Some(scaffold),
+        }),
         goals: GoalListState {
             active: vec![ActiveGoalState {
-                goal_id: "goal-1".to_string(),
-                ..ActiveGoalState::default()
+                goal_id: "GOAL-WB-REQUEST-001".to_string(),
+                goal_plan: Some(goal_plan),
+                test_selection: Some(TaskTestSelectionPlan {
+                    goal_id: "GOAL-WB-REQUEST-001".to_string(),
+                    goal_title: "Render request intake into Goal Plan cards".to_string(),
+                    selection_mode: "minimal".to_string(),
+                    commands: vec![TaskTestSelectionCommand {
+                        language: "rust".to_string(),
+                        command: "cargo test -p syu-app-ui request_intake_flow_renders_generated_goal_plan"
+                            .to_string(),
+                        reason: "covers the generated Goal Plan UI path".to_string(),
+                    }],
+                    escalation: TaskTestSelectionEscalation {
+                        level: "affected".to_string(),
+                        reason: "run workbench smoke tests after UI changes".to_string(),
+                    },
+                    warnings: Vec::new(),
+                }),
+                check_report: None,
             }],
-            selected_goal_id: Some("goal-1".to_string()),
+            selected_goal_id: Some("GOAL-WB-REQUEST-001".to_string()),
         },
+        confirmation: Some(syu_workbench::WorkbenchConfirmationMetadata {
+            confirmed_by: "demo".to_string(),
+            rationale: Some("demo fixture for request-to-goals flow".to_string()),
+            scope_token: Some("request-739".to_string()),
+        }),
         ..WorkbenchState::default()
     };
     state.evidence_timeline.entries.push(EvidenceEntry {
@@ -247,6 +349,119 @@ pub fn build_demo_state() -> WorkbenchUiState {
     ui.command_palette_open = true;
     ui.command_query = "goal".to_string();
     ui
+}
+
+fn demo_request_artifact() -> RequestArtifact {
+    RequestArtifact {
+        version: 1,
+        request: "Add a Workbench request intake flow that classifies, scopes, previews scaffold updates, generates a Goal Plan, and exports YAML.".to_string(),
+        context: RequestArtifactContext {
+            affected_area: Some("Dioxus Workbench UI".to_string()),
+            repository_constraints: vec![
+                "Reuse Workbench primitives instead of local card or badge styling.".to_string(),
+                "Keep Goal Plans temporary until exported or committed.".to_string(),
+            ],
+            linked_ids: vec![
+                "REQ-WORKBENCH-003".to_string(),
+                "FEAT-WORKBENCH-REQUEST-INTAKE-001".to_string(),
+            ],
+        },
+    }
+}
+
+fn demo_goal_plan() -> GoalPlanArtifact {
+    GoalPlanArtifact {
+        version: 1,
+        kind: "syu.goal_plan".to_string(),
+        request_path: Some(".syu/workbench/requests/request-739.yaml".to_string()),
+        request: Some("Add a Workbench request intake flow.".to_string()),
+        classification: Some("requirement_change".to_string()),
+        source: GoalPlanSource {
+            request_artifact: Some(".syu/workbench/requests/request-739.yaml".to_string()),
+            classification: Some("requirement_change".to_string()),
+            confidence: Some(GoalPlanConfidence::High),
+            ..GoalPlanSource::default()
+        },
+        goal: GoalPlanGoal {
+            id: "GOAL-WB-REQUEST-001".to_string(),
+            title: "Render request intake into Goal Plan cards".to_string(),
+            statement: "Turn a scoped Workbench request into a reviewable temporary Goal Plan with explicit scope, tests, completion commands, and evidence.".to_string(),
+            non_goals: vec![
+                "Build a raw YAML editor".to_string(),
+                "Introduce a second browser SPA or styling system".to_string(),
+            ],
+            inferred: false,
+        },
+        spec_mapping: GoalPlanSpecMapping {
+            persistent_items: GoalPlanPersistentItems {
+                requirements: vec![GoalPlanPersistentItem::Id("REQ-WORKBENCH-003".to_string())],
+                features: vec![
+                    GoalPlanPersistentItem::Id(
+                        "FEAT-WORKBENCH-REQUEST-INTAKE-001".to_string(),
+                    ),
+                    GoalPlanPersistentItem::Id(
+                        "FEAT-WORKBENCH-GOAL-SPLITTER-001".to_string(),
+                    ),
+                ],
+                ..GoalPlanPersistentItems::default()
+            },
+            spec_updates: GoalPlanSpecUpdates {
+                required: true,
+                expected_updates: vec![
+                    "Clarify temporary Goal Plans in REQ-WORKBENCH-003".to_string(),
+                    "Register request intake and goal splitter UI coverage".to_string(),
+                ],
+            },
+            spec_updates_required: true,
+            spec_update_reasons: vec![
+                "Issue 739 adds explicit request intake and Goal Splitter feature IDs.".to_string(),
+            ],
+        },
+        implementation_plan: GoalPlanImplementationPlan {
+            confidence: Some(GoalPlanConfidence::High),
+            scope: GoalPlanScope {
+                include: vec![
+                    GoalPlanScopeInclude::Pattern("crates/syu-app-ui/src/model.rs".to_string()),
+                    GoalPlanScopeInclude::Pattern(
+                        "crates/syu-app-ui/src/components/shell.rs".to_string(),
+                    ),
+                    GoalPlanScopeInclude::Pattern("tests/workbench_smoke.rs".to_string()),
+                ],
+                exclude: vec![
+                    "examples/browser-ui/**".to_string(),
+                    "website/**".to_string(),
+                    "React, TypeScript, Vite, and Playwright surfaces".to_string(),
+                ],
+            },
+            steps: vec![
+                "Capture the plain-text request and linked context.".to_string(),
+                "Render classification, scope, and scaffold preview panels.".to_string(),
+                "Split the generated Goal Plan into reusable Goal cards.".to_string(),
+                "Expose YAML export and next-flow actions from the same registry.".to_string(),
+            ],
+        },
+        test_plan: GoalPlanTestPlan {
+            selection_mode: syu_task_model::GoalPlanSelectionMode::Minimal,
+            confidence: Some(GoalPlanConfidence::High),
+            required_tests: BTreeMap::new(),
+            suggested_tests: BTreeMap::new(),
+        },
+        coverage: GoalPlanCoverage {
+            mode: GoalPlanCoverageMode::ChangedLines,
+            threshold: 100,
+            include: vec!["crates/syu-app-ui/src/**".to_string()],
+            exclude: vec!["examples/browser-ui/**".to_string()],
+        },
+        completion: GoalPlanCompletion {
+            must_pass: vec![
+                "cargo test -p syu-app-ui".to_string(),
+                "cargo test --test workbench_smoke".to_string(),
+            ],
+        },
+        warnings: vec![
+            "Temporary planning artifacts are not persistent spec content.".to_string(),
+        ],
+    }
 }
 
 fn availability_reason(availability: &WorkbenchActionAvailability) -> String {

--- a/docs/generated/site-spec/features/workbench/goal-splitter.md
+++ b/docs/generated/site-spec/features/workbench/goal-splitter.md
@@ -31,6 +31,59 @@ description: "Generated reference for docs/syu/features/workbench/goal-splitter.
           - scaffold preview
           - Goal Plan
           - assignment
+- **id**: FEAT-WORKBENCH-REQUEST-INTAKE-001
+  - **title**: Request Intake canvas
+  - **summary**: Turn a plain-text change request into a classified, scoped, evidence-ready Workbench planning artifact without creating a raw YAML editor or a separate frontend surface.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-WORKBENCH-003
+  - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-app-ui/src/components/shell.rs
+        - **symbols**:
+          - RequestIntakeCanvas
+          - RequestContextEditor
+          - RequestClassificationPanel
+          - RequestScopePanel
+          - ScaffoldPreviewPanel
+      - **file**: crates/syu-app-ui/src/model.rs
+        - **symbols**:
+          - build_demo_state
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - request_intake_flow_renders_generated_goal_plan
+          - request_flow_actions_are_exposed_in_the_command_palette
+    - **markdown**:
+      - **file**: docs/guide/workbench.md
+        - **symbols**:
+          - Request Intake
+          - temporary Workbench planning artifact
+          - request.classify
+- **id**: FEAT-WORKBENCH-GOAL-SPLITTER-001
+  - **title**: Goal Splitter canvas
+  - **summary**: Render generated temporary Goal Plans as reusable Workbench Goal cards with linked specs, non-goals, scope include/exclude, implementation steps, tests, evidence, completion commands, and exportable YAML.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-WORKBENCH-003
+  - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-app-ui/src/components/shell.rs
+        - **symbols**:
+          - GoalPlanCanvas
+          - GoalDependencyView
+          - GoalScopePanel
+          - GoalTestPlanPanel
+          - GoalPlanExportPanel
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - request_intake_flow_renders_generated_goal_plan
+          - goal_plan_export_panel_marks_yaml_as_temporary_artifact
+    - **markdown**:
+      - **file**: docs/guide/workbench.md
+        - **symbols**:
+          - Goal Splitter
+          - Goal Plan YAML
+          - syu task check
 
 ## Source YAML
 
@@ -53,4 +106,57 @@ features:
             - scaffold preview
             - Goal Plan
             - assignment
+  - id: FEAT-WORKBENCH-REQUEST-INTAKE-001
+    title: Request Intake canvas
+    summary: Turn a plain-text change request into a classified, scoped, evidence-ready Workbench planning artifact without creating a raw YAML editor or a separate frontend surface.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-003
+    implementations:
+      rust:
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - RequestIntakeCanvas
+            - RequestContextEditor
+            - RequestClassificationPanel
+            - RequestScopePanel
+            - ScaffoldPreviewPanel
+        - file: crates/syu-app-ui/src/model.rs
+          symbols:
+            - build_demo_state
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - request_flow_actions_are_exposed_in_the_command_palette
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - Request Intake
+            - temporary Workbench planning artifact
+            - request.classify
+  - id: FEAT-WORKBENCH-GOAL-SPLITTER-001
+    title: Goal Splitter canvas
+    summary: Render generated temporary Goal Plans as reusable Workbench Goal cards with linked specs, non-goals, scope include/exclude, implementation steps, tests, evidence, completion commands, and exportable YAML.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-003
+    implementations:
+      rust:
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - GoalPlanCanvas
+            - GoalDependencyView
+            - GoalScopePanel
+            - GoalTestPlanPanel
+            - GoalPlanExportPanel
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - goal_plan_export_panel_marks_yaml_as_temporary_artifact
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - Goal Splitter
+            - Goal Plan YAML
+            - syu task check
 ```

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -91,20 +91,34 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
       The Workbench MUST help break large requests into smaller scoped goals
       before execution starts. It SHOULD preserve the parent request, keep the
       split goals reviewable, and let each goal carry its own temporary Goal
-      Plan so delivery stays bounded.
+      Plan so delivery stays bounded. Request Intake MUST distinguish temporary
+      Workbench planning artifacts under `.syu/workbench/` from persistent spec
+      items, and exported Goal Plan YAML MUST remain compatible with
+      `syu task check` while preserving non-goals, scope, tests, completion
+      commands, and required evidence.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
     - POL-005
   - **linked_features**:
     - FEAT-WORKBENCH-003
+    - FEAT-WORKBENCH-REQUEST-INTAKE-001
+    - FEAT-WORKBENCH-GOAL-SPLITTER-001
   - **tests**:
     - **markdown**:
       - **file**: docs/guide/workbench.md
         - **symbols**:
+          - Request Intake
+          - Goal Splitter
           - scaffold preview
           - Goal Plan
           - assignment
+    - **rust**:
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - request_intake_flow_renders_generated_goal_plan
+          - request_flow_actions_are_exposed_in_the_command_palette
+          - goal_plan_export_panel_marks_yaml_as_temporary_artifact
 - **id**: REQ-WORKBENCH-004
   - **title**: Spec impact and branch scope visualization
   - **description**:
@@ -271,20 +285,34 @@ requirements:
       The Workbench MUST help break large requests into smaller scoped goals
       before execution starts. It SHOULD preserve the parent request, keep the
       split goals reviewable, and let each goal carry its own temporary Goal
-      Plan so delivery stays bounded.
+      Plan so delivery stays bounded. Request Intake MUST distinguish temporary
+      Workbench planning artifacts under `.syu/workbench/` from persistent spec
+      items, and exported Goal Plan YAML MUST remain compatible with
+      `syu task check` while preserving non-goals, scope, tests, completion
+      commands, and required evidence.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-003
+      - FEAT-WORKBENCH-REQUEST-INTAKE-001
+      - FEAT-WORKBENCH-GOAL-SPLITTER-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
           symbols:
+            - Request Intake
+            - Goal Splitter
             - scaffold preview
             - Goal Plan
             - assignment
+      rust:
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - request_flow_actions_are_exposed_in_the_command_palette
+            - goal_plan_export_panel_marks_yaml_as_temporary_artifact
   - id: REQ-WORKBENCH-004
     title: Spec impact and branch scope visualization
     description: |

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 8
 - Requirements: 39
-- Features: 49
+- Features: 51
 
 ## Traceability
 
-- Requirement-to-test traceability: 170/170
-- Feature-to-implementation traceability: 180/180
+- Requirement-to-test traceability: 171/171
+- Feature-to-implementation traceability: 187/187
 
 ## Issues
 

--- a/docs/guide/workbench.md
+++ b/docs/guide/workbench.md
@@ -21,6 +21,23 @@ Request
   → completion check
 ```
 
+## Request Intake and Goal Splitter
+
+Request Intake is the focused Workbench canvas for turning a plain text request
+into a temporary Workbench planning artifact. The request flow should remain
+goal-centered: the user can inspect classification, relevant workspace/spec
+context, scope, and scaffold preview before generating a Goal Plan.
+
+The Goal Splitter renders the generated Goal Plan as one or more reviewable Goal
+cards. Each card should keep non-goals, linked persistent spec items, required
+spec updates, include/exclude scope, implementation steps, required or suggested
+tests, completion commands, and evidence expectations visible. These Goal Plans
+are temporary Workbench planning artifacts under `.syu/workbench/requests/` and
+`.syu/workbench/goals/` until the user explicitly exports or commits them.
+
+Goal Plan YAML exported from the Workbench must stay compatible with
+`syu task check`; the UI must not invent a separate Goal Plan format.
+
 ## What each step means
 
 - Request: capture the user intent, constraints, and expected outcome.
@@ -62,7 +79,10 @@ The registry should make these availability rules explicit:
 
 - no request means `request.scope` is unavailable;
 - an active request makes `request.classify` available;
+- an active request makes `request.scope`, `request.scaffold`, and
+  `request.plan` visible from the same command palette registry;
 - an active Goal Plan makes `goal.test_select` available;
+- an active Goal Plan makes `goal.check` available for evidence-ready review;
 - a loaded branch scope makes `branch.infer_goal` available;
 - mutating actions require confirmation metadata;
 - AI-eligible actions require a bounded scope.

--- a/docs/syu/features/workbench/goal-splitter.yaml
+++ b/docs/syu/features/workbench/goal-splitter.yaml
@@ -16,3 +16,56 @@ features:
             - scaffold preview
             - Goal Plan
             - assignment
+  - id: FEAT-WORKBENCH-REQUEST-INTAKE-001
+    title: Request Intake canvas
+    summary: Turn a plain-text change request into a classified, scoped, evidence-ready Workbench planning artifact without creating a raw YAML editor or a separate frontend surface.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-003
+    implementations:
+      rust:
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - RequestIntakeCanvas
+            - RequestContextEditor
+            - RequestClassificationPanel
+            - RequestScopePanel
+            - ScaffoldPreviewPanel
+        - file: crates/syu-app-ui/src/model.rs
+          symbols:
+            - build_demo_state
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - request_flow_actions_are_exposed_in_the_command_palette
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - Request Intake
+            - temporary Workbench planning artifact
+            - request.classify
+  - id: FEAT-WORKBENCH-GOAL-SPLITTER-001
+    title: Goal Splitter canvas
+    summary: Render generated temporary Goal Plans as reusable Workbench Goal cards with linked specs, non-goals, scope include/exclude, implementation steps, tests, evidence, completion commands, and exportable YAML.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-003
+    implementations:
+      rust:
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - GoalPlanCanvas
+            - GoalDependencyView
+            - GoalScopePanel
+            - GoalTestPlanPanel
+            - GoalPlanExportPanel
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - goal_plan_export_panel_marks_yaml_as_temporary_artifact
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - Goal Splitter
+            - Goal Plan YAML
+            - syu task check

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -72,20 +72,34 @@ requirements:
       The Workbench MUST help break large requests into smaller scoped goals
       before execution starts. It SHOULD preserve the parent request, keep the
       split goals reviewable, and let each goal carry its own temporary Goal
-      Plan so delivery stays bounded.
+      Plan so delivery stays bounded. Request Intake MUST distinguish temporary
+      Workbench planning artifacts under `.syu/workbench/` from persistent spec
+      items, and exported Goal Plan YAML MUST remain compatible with
+      `syu task check` while preserving non-goals, scope, tests, completion
+      commands, and required evidence.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-003
+      - FEAT-WORKBENCH-REQUEST-INTAKE-001
+      - FEAT-WORKBENCH-GOAL-SPLITTER-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
           symbols:
+            - Request Intake
+            - Goal Splitter
             - scaffold preview
             - Goal Plan
             - assignment
+      rust:
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - request_intake_flow_renders_generated_goal_plan
+            - request_flow_actions_are_exposed_in_the_command_palette
+            - goal_plan_export_panel_marks_yaml_as_temporary_artifact
   - id: REQ-WORKBENCH-004
     title: Spec impact and branch scope visualization
     description: |

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -1,6 +1,8 @@
 use dioxus::prelude::*;
 use dioxus_ssr::render_element;
-use syu_app_ui::{AppShell, EvidencePanel, GoalCanvas, WorkbenchUiState, build_demo_state};
+use syu_app_ui::{
+    AppShell, EvidencePanel, GoalCanvas, GoalPlanExportPanel, WorkbenchUiState, build_demo_state,
+};
 use syu_workbench::{
     WorkbenchActionId, WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchState,
 };
@@ -36,7 +38,10 @@ fn goal_canvas_renders_a_read_only_action_preview_placeholder() {
     ui.run_read_only_action(WorkbenchActionId::HistoryShow);
 
     let html = render_element(rsx! {
-        GoalCanvas { ui }
+        GoalCanvas {
+            ui,
+            on_run_action: None
+        }
     });
 
     let pulse = html.find("Workbench Pulse").expect("pulse should render");
@@ -96,4 +101,59 @@ fn registry_loaded_from_server_payload() {
         payload.actions.len(),
         WorkbenchActionRegistry::standard().actions().len()
     );
+}
+
+#[test]
+fn request_intake_flow_renders_generated_goal_plan() {
+    let ui = build_demo_state();
+
+    let html = render_element(rsx! {
+        GoalCanvas {
+            ui,
+            on_run_action: None
+        }
+    });
+
+    assert!(html.contains("Request Intake"));
+    assert!(html.contains("Change request"));
+    assert!(html.contains("requirement_change"));
+    assert!(html.contains("Scaffold Preview"));
+    assert!(html.contains("Goal Plan"));
+    assert!(html.contains("GOAL-WB-REQUEST-001"));
+    assert!(html.contains("non-goal: Build a raw YAML editor"));
+    assert!(html.contains("include: crates/syu-app-ui/src/model.rs"));
+    assert!(html.contains("Export YAML"));
+    assert!(html.contains("syu.goal_plan"));
+}
+
+#[test]
+fn request_flow_actions_are_exposed_in_the_command_palette() {
+    let mut ui = build_demo_state();
+    ui.set_query("request.");
+
+    let html = render_element(rsx! {
+        AppShell { ui }
+    });
+
+    assert!(html.contains("request.classify"));
+    assert!(html.contains("request.scope"));
+    assert!(html.contains("request.scaffold"));
+    assert!(html.contains("request.plan"));
+}
+
+#[test]
+fn goal_plan_export_panel_marks_yaml_as_temporary_artifact() {
+    let ui = build_demo_state();
+    let plan = ui.payload.state.goals.active[0]
+        .goal_plan
+        .clone()
+        .expect("demo state includes a goal plan");
+
+    let html = render_element(rsx! {
+        GoalPlanExportPanel { plan }
+    });
+
+    assert!(html.contains(".syu/workbench/goals/GOAL-WB-REQUEST-001.yaml"));
+    assert!(html.contains("completion:"));
+    assert!(html.contains("cargo test --test workbench_smoke"));
 }


### PR DESCRIPTION
Summary:
- Add Dioxus Workbench Request Intake and Goal Plan canvas components that reuse shared panels, badges, chips, cards, and action registry IDs.
- Enrich the Workbench UI demo state with request classification, scope, scaffold preview, generated Goal Plan, test selection, and temporary artifact paths.
- Document REQ-WORKBENCH-003 plus Request Intake and Goal Splitter feature coverage, including regenerated site-spec docs.

Validation:
- cargo fmt
- cargo test -p syu-app-ui
- cargo test --test workbench_smoke
- cargo run -- validate .
- pre-push syu-quality-gates
- pre-push syu-goal-tests

Closes #739
