### PR TITLE
Add Workbench spec impact graph and branch scope lens

### DIFF
--- a/crates/syu-app-ui/assets/tailwind.css
+++ b/crates/syu-app-ui/assets/tailwind.css
@@ -8,8 +8,15 @@
   --color-command-active: oklch(0.36 0.06 167);
   --color-goal: oklch(0.76 0.16 146);
   --color-goal-active: oklch(0.86 0.13 146);
+  --color-spec-linked: oklch(0.8 0.09 265);
+  --color-code-linked: oklch(0.78 0.11 200);
+  --color-test-linked: oklch(0.82 0.1 145);
   --color-scope-in: oklch(0.79 0.1 230);
   --color-scope-out: oklch(0.74 0.14 28);
+  --color-scope-ambiguous: oklch(0.84 0.14 90);
+  --color-ownership-known: oklch(0.78 0.12 150);
+  --color-ownership-missing: oklch(0.73 0.17 27);
+  --color-ownership-ambiguous: oklch(0.83 0.12 82);
   --color-evidence-pass: oklch(0.79 0.13 146);
   --color-evidence-warn: oklch(0.84 0.14 90);
   --color-evidence-fail: oklch(0.73 0.17 27);

--- a/crates/syu-app-ui/src/components/mod.rs
+++ b/crates/syu-app-ui/src/components/mod.rs
@@ -6,8 +6,10 @@ pub use primitives::{
     IconButton, Panel, ScopeChip, StatusDot,
 };
 pub use shell::{
-    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalDependencyView, GoalPlanCanvas,
-    GoalPlanExportPanel, GoalRail, GoalScopePanel, GoalTestPlanPanel, RequestClassificationPanel,
-    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel, StatusBar,
-    WorkspacePulse,
+    AffectedSpecPanel, AppShell, BranchScopeLens, ChangedFilesPanel, CommandPalette, EvidencePanel,
+    GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel,
+    GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel, OutOfScopePanel, OwnershipBadge,
+    OwnershipPanel, RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas,
+    RequestScopePanel, ScaffoldPreviewPanel, ScopeLegend, SpecImpactGraph, StatusBar,
+    SuggestedGoalSplitPanel, TestRecommendationPanel, WorkspacePulse,
 };

--- a/crates/syu-app-ui/src/components/primitives.rs
+++ b/crates/syu-app-ui/src/components/primitives.rs
@@ -160,6 +160,7 @@ fn evidence_tone(kind: WorkbenchEvidenceKind) -> &'static str {
     match kind {
         WorkbenchEvidenceKind::ValidationReport => "text-evidence-pass",
         WorkbenchEvidenceKind::BranchScopeReport => "text-scope-in",
+        WorkbenchEvidenceKind::SpecImpactReport => "text-spec-linked",
         WorkbenchEvidenceKind::GoalPlanCheckReport => "text-evidence-warn",
         WorkbenchEvidenceKind::HistoryResponse => "text-evidence-pending",
         WorkbenchEvidenceKind::AssignmentState => "text-goal",

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -5,11 +5,20 @@ use crate::components::{
 use crate::design::classes;
 use crate::model::{WorkbenchUiState, WorkspacePulseSummary};
 use dioxus::prelude::*;
+use std::collections::HashMap;
 use syu_task_model::{
     GoalPlanArtifact, GoalPlanConfidence, GoalPlanPersistentItem, GoalPlanScopeInclude,
     ScaffoldAction, ScaffoldUpdateKind,
 };
 use syu_workbench::WorkbenchActionId;
+
+const GRAPH_COLUMNS: usize = 4;
+const GRAPH_COLUMN_WIDTH: i32 = 210;
+const GRAPH_ROW_HEIGHT: i32 = 86;
+const GRAPH_NODE_X: i32 = 95;
+const GRAPH_NODE_Y: i32 = 56;
+const GRAPH_NODE_WIDTH: i32 = 172;
+const GRAPH_NODE_HEIGHT: i32 = 44;
 
 #[component]
 pub fn AppShell(ui: WorkbenchUiState) -> Element {
@@ -260,6 +269,19 @@ pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
         .and_then(|report| report.spec_impact_graph.nodes.first())
         .map(|node| node.id.clone())
         .unwrap_or_default();
+    let graph_layout = report.as_ref().map(|report| {
+        let node_positions = report
+            .spec_impact_graph
+            .nodes
+            .iter()
+            .enumerate()
+            .map(|(index, node)| (node.id.clone(), index))
+            .collect::<HashMap<_, _>>();
+        let svg_height = graph_view_height(report.spec_impact_graph.nodes.len());
+        let view_box = format!("0 0 900 {svg_height}");
+
+        (node_positions, svg_height, view_box)
+    });
     let mut selected_node_id = use_signal(|| initial_node);
     rsx! {
         Panel { class: classes::PANEL_MUTED,
@@ -268,12 +290,19 @@ pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
                     h2 { class: classes::SECTION_TITLE, "Spec Impact Graph" }
                     ScopeLegend {}
                 }
-                if let Some(report) = report {
+                if let (Some(report), Some((node_positions, svg_height, view_box))) = (report, graph_layout) {
                     div { class: "grid gap-3 xl:grid-cols-[minmax(0,1fr)_16rem]",
                         div { class: "min-h-72 rounded-xl border border-border bg-background p-3",
-                            svg { class: "h-72 w-full", view_box: "0 0 900 320", role: "img",
-                                for (index, edge) in report.spec_impact_graph.edges.iter().enumerate() {
-                                    GraphEdge { index, state: edge.state.clone(), label: format!("{} to {}", edge.from, edge.to) }
+                            svg { class: "w-full", height: "{svg_height}", view_box, role: "img",
+                                for edge in &report.spec_impact_graph.edges {
+                                    if let (Some(from_index), Some(to_index)) = (node_positions.get(&edge.from), node_positions.get(&edge.to)) {
+                                        GraphEdge {
+                                            from_index: *from_index,
+                                            to_index: *to_index,
+                                            state: edge.state.clone(),
+                                            label: format!("{} to {}", edge.from, edge.to),
+                                        }
+                                    }
                                 }
                                 for (index, node) in report.spec_impact_graph.nodes.iter().enumerate() {
                                     GraphNode {
@@ -328,8 +357,7 @@ pub fn GraphNode(
     selected: bool,
     onclick: EventHandler<MouseEvent>,
 ) -> Element {
-    let x = 95 + ((index % 4) as i32 * 210);
-    let y = 56 + ((index / 4) as i32 * 86);
+    let (x, y) = graph_node_origin(index);
     let class = graph_state_class(&state);
     let selected_class = if selected {
         "stroke-[3px]"
@@ -349,11 +377,9 @@ pub fn GraphNode(
 }
 
 #[component]
-pub fn GraphEdge(index: usize, state: String, label: String) -> Element {
-    let from_x = 266 + ((index % 4) as i32 * 210);
-    let from_y = 78 + ((index / 4) as i32 * 86);
-    let to_x = 305 + ((index % 4) as i32 * 210);
-    let to_y = if index % 3 == 2 { from_y + 86 } else { from_y };
+pub fn GraphEdge(from_index: usize, to_index: usize, state: String, label: String) -> Element {
+    let (from_x, from_y) = graph_edge_anchor(from_index, to_index);
+    let (to_x, to_y) = graph_edge_anchor(to_index, from_index);
     let class = graph_state_class(&state);
     rsx! {
         g {
@@ -362,6 +388,36 @@ pub fn GraphEdge(index: usize, state: String, label: String) -> Element {
             circle { cx: "{to_x}", cy: "{to_y}", r: "3", class: "fill-current {class}" }
         }
     }
+}
+
+fn graph_node_origin(index: usize) -> (i32, i32) {
+    (
+        GRAPH_NODE_X + ((index % GRAPH_COLUMNS) as i32 * GRAPH_COLUMN_WIDTH),
+        GRAPH_NODE_Y + ((index / GRAPH_COLUMNS) as i32 * GRAPH_ROW_HEIGHT),
+    )
+}
+
+fn graph_edge_anchor(index: usize, target_index: usize) -> (i32, i32) {
+    let (x, y) = graph_node_origin(index);
+    let column = index % GRAPH_COLUMNS;
+    let target_column = target_index % GRAPH_COLUMNS;
+    let row = index / GRAPH_COLUMNS;
+    let target_row = target_index / GRAPH_COLUMNS;
+
+    if target_row > row {
+        (x + (GRAPH_NODE_WIDTH / 2), y + GRAPH_NODE_HEIGHT)
+    } else if target_row < row {
+        (x + (GRAPH_NODE_WIDTH / 2), y)
+    } else if target_column >= column {
+        (x + GRAPH_NODE_WIDTH, y + (GRAPH_NODE_HEIGHT / 2))
+    } else {
+        (x, y + (GRAPH_NODE_HEIGHT / 2))
+    }
+}
+
+fn graph_view_height(node_count: usize) -> i32 {
+    let rows = node_count.max(1).div_ceil(GRAPH_COLUMNS);
+    320.max(70 + (rows as i32 * GRAPH_ROW_HEIGHT))
 }
 
 #[component]

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -227,6 +227,10 @@ pub fn BranchScopeLens(
                 }
                 if let Some(report) = report {
                     ImpactSummaryPanel { report: report.clone() }
+                    GoalScopeComparisonPanel {
+                        report: report.clone(),
+                        plan: ui.payload.state.goals.active_goal().and_then(|goal| goal.goal_plan.clone()),
+                    }
                     div { class: "grid gap-3 xl:grid-cols-2",
                         ChangedFilesPanel { report: report.clone() }
                         OwnershipPanel { report: report.clone() }
@@ -251,6 +255,12 @@ pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
         .branch_scope
         .as_ref()
         .and_then(|state| state.report.clone());
+    let initial_node = report
+        .as_ref()
+        .and_then(|report| report.spec_impact_graph.nodes.first())
+        .map(|node| node.id.clone())
+        .unwrap_or_default();
+    let mut selected_node_id = use_signal(|| initial_node);
     rsx! {
         Panel { class: classes::PANEL_MUTED,
             div { class: "flex flex-col gap-4 p-4",
@@ -267,17 +277,29 @@ pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
                                 }
                                 for (index, node) in report.spec_impact_graph.nodes.iter().enumerate() {
                                     GraphNode {
+                                        id: node.id.clone(),
                                         index,
                                         label: node.label.clone(),
                                         kind: node.kind.clone(),
                                         state: node.state.clone(),
+                                        selected: selected_node_id.read().as_str() == node.id.as_str(),
+                                        onclick: {
+                                            let node_id = node.id.clone();
+                                            move |_| selected_node_id.set(node_id.clone())
+                                        },
                                     }
                                 }
                             }
                         }
                         div { class: "space-y-2",
                             for node in &report.spec_impact_graph.nodes {
-                                article { class: "rounded-lg border border-border bg-panel p-2",
+                                button {
+                                    class: if selected_node_id.read().as_str() == node.id.as_str() { "w-full rounded-lg border border-command-active bg-panel-muted p-2 text-left" } else { "w-full rounded-lg border border-border bg-panel p-2 text-left" },
+                                    type: "button",
+                                    onclick: {
+                                        let node_id = node.id.clone();
+                                        move |_| selected_node_id.set(node_id.clone())
+                                    },
                                     div { class: "flex flex-wrap items-center gap-2",
                                         ScopeChip { label: node.kind.clone() }
                                         ScopeChip { label: node.state.clone() }
@@ -297,15 +319,29 @@ pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
 }
 
 #[component]
-pub fn GraphNode(index: usize, label: String, kind: String, state: String) -> Element {
+pub fn GraphNode(
+    id: String,
+    index: usize,
+    label: String,
+    kind: String,
+    state: String,
+    selected: bool,
+    onclick: EventHandler<MouseEvent>,
+) -> Element {
     let x = 95 + ((index % 4) as i32 * 210);
     let y = 56 + ((index / 4) as i32 * 86);
     let class = graph_state_class(&state);
+    let selected_class = if selected {
+        "stroke-[3px]"
+    } else {
+        "stroke-[1.5px]"
+    };
     let short = truncate_label(&label, 26);
     rsx! {
-        g { tabindex: "0",
+        g { tabindex: "0", role: "button", onclick: move |event| onclick.call(event),
             title { "{kind}: {label}" }
-            rect { x: "{x}", y: "{y}", width: "172", height: "44", rx: "7", class: "fill-panel stroke-current {class}" }
+            desc { "{id}" }
+            rect { x: "{x}", y: "{y}", width: "172", height: "44", rx: "7", class: "fill-panel stroke-current {class} {selected_class}" }
             text { x: "{x + 12}", y: "{y + 19}", class: "fill-foreground text-[11px] font-semibold", "{short}" }
             text { x: "{x + 12}", y: "{y + 34}", class: "fill-foreground/60 text-[9px] uppercase", "{kind} / {state}" }
         }
@@ -336,6 +372,91 @@ pub fn ScopeLegend() -> Element {
                 span { class: "inline-flex items-center gap-1 text-[10px] uppercase text-foreground/70",
                     span { class: "h-2 w-2 rounded-full {graph_state_class(label)} bg-current" }
                     span { "{label}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GoalScopeComparisonPanel(
+    report: syu_workbench::BranchScopeReport,
+    plan: Option<GoalPlanArtifact>,
+) -> Element {
+    let Some(plan) = plan else {
+        return rsx! {
+            EmptyState { title: "No Goal Plan comparison".to_string(), body: "Branch Scope Lens compares changed files against a selected Goal Plan when one is active.".to_string() }
+        };
+    };
+    let include_patterns = plan
+        .implementation_plan
+        .scope
+        .include
+        .iter()
+        .map(include_pattern)
+        .collect::<Vec<_>>();
+    let exclude_patterns = plan.implementation_plan.scope.exclude.clone();
+    let mut included = Vec::new();
+    let mut excluded = Vec::new();
+    let mut uncovered = Vec::new();
+
+    for file in &report.changed_files {
+        if exclude_patterns
+            .iter()
+            .any(|pattern| path_matches_goal_pattern(&file.file, pattern))
+        {
+            excluded.push(file.file.clone());
+        } else if include_patterns
+            .iter()
+            .any(|pattern| path_matches_goal_pattern(&file.file, pattern))
+        {
+            included.push(file.file.clone());
+        } else {
+            uncovered.push(file.file.clone());
+        }
+    }
+
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-3 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Goal Scope Comparison" }
+                    ScopeChip { label: plan.goal.id.clone() }
+                }
+                div { class: "grid gap-3 md:grid-cols-3",
+                    GoalComparisonColumn { title: "files included by Goal".to_string(), tone: "scope-in".to_string(), files: included }
+                    GoalComparisonColumn { title: "files excluded by Goal".to_string(), tone: "scope-out".to_string(), files: excluded }
+                    GoalComparisonColumn { title: "changed files not covered by Goal".to_string(), tone: "scope-ambiguous".to_string(), files: uncovered }
+                }
+                div { class: "grid gap-3 md:grid-cols-2",
+                    div { class: classes::EVIDENCE_CARD,
+                        p { class: "text-xs uppercase tracking-[0.18em] text-foreground/60", "tests required by Goal" }
+                        for command in &plan.completion.must_pass {
+                            p { class: "mt-1 text-sm text-test-linked", "{command}" }
+                        }
+                    }
+                    div { class: classes::EVIDENCE_CARD,
+                        p { class: "text-xs uppercase tracking-[0.18em] text-foreground/60", "tests detected from code ownership" }
+                        for test in report.test_inventory.required_tests.iter().chain(report.test_inventory.linked_tests.iter()) {
+                            p { class: "mt-1 text-sm text-test-linked", "{test}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn GoalComparisonColumn(title: String, tone: String, files: Vec<String>) -> Element {
+    rsx! {
+        div { class: classes::EVIDENCE_CARD,
+            p { class: "text-xs uppercase tracking-[0.18em] text-foreground/60", "{title}" }
+            if files.is_empty() {
+                p { class: "mt-1 text-sm text-foreground/60", "none" }
+            } else {
+                for file in files {
+                    p { class: "mt-1 text-sm {graph_state_class(&tone)}", "{file}" }
                 }
             }
         }
@@ -447,6 +568,13 @@ pub fn OutOfScopePanel(report: syu_workbench::BranchScopeReport) -> Element {
 
 #[component]
 pub fn AffectedSpecPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    let initial_spec = report
+        .spec_impact
+        .affected_items
+        .first()
+        .map(|item| item.id.clone())
+        .unwrap_or_default();
+    let mut selected_spec_id = use_signal(|| initial_spec);
     rsx! {
         Panel { class: classes::PANEL_MUTED,
             div { class: "flex flex-col gap-2 p-3",
@@ -455,7 +583,13 @@ pub fn AffectedSpecPanel(report: syu_workbench::BranchScopeReport) -> Element {
                     ScopeChip { label: format!("{} linked", report.spec_impact.affected_items.len()) }
                 }
                 for item in &report.spec_impact.affected_items {
-                    article { class: classes::EVIDENCE_CARD,
+                    button {
+                        class: if selected_spec_id.read().as_str() == item.id.as_str() { "w-full rounded-xl border border-command-active bg-panel p-3 text-left" } else { classes::EVIDENCE_CARD },
+                        type: "button",
+                        onclick: {
+                            let item_id = item.id.clone();
+                            move |_| selected_spec_id.set(item_id.clone())
+                        },
                         div { class: "flex flex-wrap items-center gap-2",
                             ScopeChip { label: item.kind.clone() }
                             ScopeChip { label: if item.direct { "spec-linked".to_string() } else { "scope-ambiguous".to_string() } }
@@ -962,6 +1096,26 @@ fn persistent_item_id(item: &GoalPlanPersistentItem) -> String {
 
 fn include_pattern(include: &GoalPlanScopeInclude) -> String {
     include.pattern().to_string()
+}
+
+fn path_matches_goal_pattern(path: &str, pattern: &str) -> bool {
+    if path == pattern {
+        return true;
+    }
+
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return path.starts_with(prefix);
+    }
+
+    if let Some(prefix) = pattern.strip_suffix("/*") {
+        return path.starts_with(prefix);
+    }
+
+    if let Some((prefix, suffix)) = pattern.split_once('*') {
+        return path.starts_with(prefix) && path.ends_with(suffix);
+    }
+
+    false
 }
 
 fn goal_plan_yaml_preview(plan: &GoalPlanArtifact) -> String {

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -178,6 +178,8 @@ pub fn GoalCanvas(
                     ui: ui.clone(),
                     on_run_action: on_run_action,
                 }
+                BranchScopeLens { ui: ui.clone(), on_run_action: on_run_action }
+                SpecImpactGraph { ui: ui.clone() }
                 if let Some(preview) = ui.preview.clone().or_else(|| ui.selected_action_id.and_then(|id| ui.action_preview(id))) {
                     DetailDrawer {
                         title: preview.title.clone(),
@@ -192,6 +194,318 @@ pub fn GoalCanvas(
                     }
                 } else {
                     EmptyState { title: "No action selected".to_string(), body: "Open the palette to run a read-only action or inspect the next suggested step.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn BranchScopeLens(
+    ui: WorkbenchUiState,
+    on_run_action: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
+    let report = ui
+        .payload
+        .state
+        .branch_scope
+        .as_ref()
+        .and_then(|state| state.report.clone());
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-4 p-4",
+                div { class: classes::SECTION_HEADER,
+                    h2 { class: classes::SECTION_TITLE, "Branch Scope Lens" }
+                    ScopeChip { label: report.as_ref().map(|report| report.range.clone()).unwrap_or_else(|| "range pending".to_string()) }
+                }
+                div { class: "grid gap-2 md:grid-cols-5",
+                    FlowActionButton { label: "Load scope".to_string(), action_id: WorkbenchActionId::BranchScope, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Infer goal".to_string(), action_id: WorkbenchActionId::BranchInferGoal, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Spec impact".to_string(), action_id: WorkbenchActionId::SpecImpact, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Trace range".to_string(), action_id: WorkbenchActionId::TraceRange, ui: ui.clone(), onclick: on_run_action }
+                    FlowActionButton { label: "Relate range".to_string(), action_id: WorkbenchActionId::RelateRange, ui: ui.clone(), onclick: on_run_action }
+                }
+                if let Some(report) = report {
+                    ImpactSummaryPanel { report: report.clone() }
+                    div { class: "grid gap-3 xl:grid-cols-2",
+                        ChangedFilesPanel { report: report.clone() }
+                        OwnershipPanel { report: report.clone() }
+                        OutOfScopePanel { report: report.clone() }
+                        AffectedSpecPanel { report: report.clone() }
+                        SuggestedGoalSplitPanel { split: report.suggested_goal_split.clone() }
+                        TestRecommendationPanel { report: report.clone() }
+                    }
+                } else {
+                    EmptyState { title: "Branch scope pending".to_string(), body: "Load branch.scope to inspect changed files, owners, affected specs, test impact, and strict review status.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn SpecImpactGraph(ui: WorkbenchUiState) -> Element {
+    let report = ui
+        .payload
+        .state
+        .branch_scope
+        .as_ref()
+        .and_then(|state| state.report.clone());
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-4 p-4",
+                div { class: classes::SECTION_HEADER,
+                    h2 { class: classes::SECTION_TITLE, "Spec Impact Graph" }
+                    ScopeLegend {}
+                }
+                if let Some(report) = report {
+                    div { class: "grid gap-3 xl:grid-cols-[minmax(0,1fr)_16rem]",
+                        div { class: "min-h-72 rounded-xl border border-border bg-background p-3",
+                            svg { class: "h-72 w-full", view_box: "0 0 900 320", role: "img",
+                                for (index, edge) in report.spec_impact_graph.edges.iter().enumerate() {
+                                    GraphEdge { index, state: edge.state.clone(), label: format!("{} to {}", edge.from, edge.to) }
+                                }
+                                for (index, node) in report.spec_impact_graph.nodes.iter().enumerate() {
+                                    GraphNode {
+                                        index,
+                                        label: node.label.clone(),
+                                        kind: node.kind.clone(),
+                                        state: node.state.clone(),
+                                    }
+                                }
+                            }
+                        }
+                        div { class: "space-y-2",
+                            for node in &report.spec_impact_graph.nodes {
+                                article { class: "rounded-lg border border-border bg-panel p-2",
+                                    div { class: "flex flex-wrap items-center gap-2",
+                                        ScopeChip { label: node.kind.clone() }
+                                        ScopeChip { label: node.state.clone() }
+                                    }
+                                    p { class: "mt-2 text-sm font-medium", "{node.label}" }
+                                    p { class: "mt-1 text-xs text-foreground/60", "{node.id}" }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    EmptyState { title: "No impact graph".to_string(), body: "A Branch Scope report supplies typed nodes and edges for specs, code, and tests.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn GraphNode(index: usize, label: String, kind: String, state: String) -> Element {
+    let x = 95 + ((index % 4) as i32 * 210);
+    let y = 56 + ((index / 4) as i32 * 86);
+    let class = graph_state_class(&state);
+    let short = truncate_label(&label, 26);
+    rsx! {
+        g { tabindex: "0",
+            title { "{kind}: {label}" }
+            rect { x: "{x}", y: "{y}", width: "172", height: "44", rx: "7", class: "fill-panel stroke-current {class}" }
+            text { x: "{x + 12}", y: "{y + 19}", class: "fill-foreground text-[11px] font-semibold", "{short}" }
+            text { x: "{x + 12}", y: "{y + 34}", class: "fill-foreground/60 text-[9px] uppercase", "{kind} / {state}" }
+        }
+    }
+}
+
+#[component]
+pub fn GraphEdge(index: usize, state: String, label: String) -> Element {
+    let from_x = 266 + ((index % 4) as i32 * 210);
+    let from_y = 78 + ((index / 4) as i32 * 86);
+    let to_x = 305 + ((index % 4) as i32 * 210);
+    let to_y = if index % 3 == 2 { from_y + 86 } else { from_y };
+    let class = graph_state_class(&state);
+    rsx! {
+        g {
+            title { "{label}" }
+            line { x1: "{from_x}", y1: "{from_y}", x2: "{to_x}", y2: "{to_y}", class: "stroke-current {class}", stroke_width: "2" }
+            circle { cx: "{to_x}", cy: "{to_y}", r: "3", class: "fill-current {class}" }
+        }
+    }
+}
+
+#[component]
+pub fn ScopeLegend() -> Element {
+    rsx! {
+        div { class: "flex flex-wrap justify-end gap-2",
+            for label in ["spec-linked", "code-linked", "test-linked", "scope-in", "scope-out", "scope-ambiguous", "ownership-known", "ownership-missing", "ownership-ambiguous", "evidence-pass", "evidence-warn", "evidence-fail", "evidence-pending"] {
+                span { class: "inline-flex items-center gap-1 text-[10px] uppercase text-foreground/70",
+                    span { class: "h-2 w-2 rounded-full {graph_state_class(label)} bg-current" }
+                    span { "{label}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ImpactSummaryPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    let strict_status = if report.spec_impact.out_of_scope_changes.is_empty()
+        && report.trace_ownership.unowned_changes.is_empty()
+    {
+        "strict review: pass"
+    } else {
+        "strict review: warn"
+    };
+    rsx! {
+        div { class: "grid gap-3 md:grid-cols-4",
+            PulseMetric { label: "changed files".to_string(), value: report.changed_files.len().to_string() }
+            PulseMetric { label: "affected specs".to_string(), value: report.spec_impact.affected_items.len().to_string() }
+            PulseMetric { label: "tests".to_string(), value: report.test_inventory.total_tests.to_string() }
+            PulseMetric { label: "strict status".to_string(), value: strict_status.to_string() }
+        }
+    }
+}
+
+#[component]
+pub fn ChangedFilesPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Changed Files" }
+                    ScopeChip { label: format!("{} files", report.changed_files.len()) }
+                }
+                for file in &report.changed_files {
+                    article { class: classes::EVIDENCE_CARD,
+                        div { class: "flex flex-wrap items-center gap-2",
+                            OwnershipBadge { status: format!("{:?}", file.status) }
+                            ScopeChip { label: if file.is_spec_file { "spec-linked".to_string() } else { "code-linked".to_string() } }
+                        }
+                        p { class: "mt-2 text-sm font-medium", "{file.file}" }
+                        for symbol in &file.symbols {
+                            p { class: "text-xs text-foreground/65", "symbol: {symbol}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn OwnershipPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Ownership" }
+                    ScopeChip { label: format!("{} owned", report.trace_ownership.owned_files) }
+                }
+                for change in &report.trace_ownership.unowned_changes {
+                    p { class: "text-sm text-ownership-missing", "unowned: {change.file}" }
+                    p { class: "text-xs text-foreground/65", "{change.reason}" }
+                }
+                for change in &report.trace_ownership.ambiguous_ownership {
+                    p { class: "text-sm text-ownership-ambiguous", "ambiguous: {change.file}" }
+                }
+                if report.trace_ownership.unowned_changes.is_empty() && report.trace_ownership.ambiguous_ownership.is_empty() {
+                    p { class: "text-sm text-ownership-known", "ownership-known" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn OwnershipBadge(status: String) -> Element {
+    let state = match status.as_str() {
+        "Owned" => "ownership-known",
+        "Partial" => "ownership-ambiguous",
+        _ => "ownership-missing",
+    };
+    rsx! {
+        span { class: "{classes::CHIP} {graph_state_class(state)}", "{state}" }
+    }
+}
+
+#[component]
+pub fn OutOfScopePanel(report: syu_workbench::BranchScopeReport) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Out Of Scope" }
+                    ScopeChip { label: format!("{} files", report.spec_impact.out_of_scope_changes.len()) }
+                }
+                if report.spec_impact.out_of_scope_changes.is_empty() {
+                    p { class: "text-sm text-scope-in", "scope-in" }
+                } else {
+                    for change in &report.spec_impact.out_of_scope_changes {
+                        p { class: "text-sm text-scope-out", "{change.file}" }
+                        p { class: "text-xs text-foreground/65", "{change.reason}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AffectedSpecPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Affected Specs" }
+                    ScopeChip { label: format!("{} linked", report.spec_impact.affected_items.len()) }
+                }
+                for item in &report.spec_impact.affected_items {
+                    article { class: classes::EVIDENCE_CARD,
+                        div { class: "flex flex-wrap items-center gap-2",
+                            ScopeChip { label: item.kind.clone() }
+                            ScopeChip { label: if item.direct { "spec-linked".to_string() } else { "scope-ambiguous".to_string() } }
+                        }
+                        p { class: "mt-2 text-sm font-medium", "{item.id}" }
+                        p { class: "text-xs text-foreground/65", "{item.title}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn SuggestedGoalSplitPanel(split: syu_workbench::SuggestedGoalSplit) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Suggested Goal Split" }
+                    ScopeChip { label: format!("confidence: {}", split.confidence) }
+                }
+                for include in &split.include {
+                    p { class: "text-sm text-scope-in", "include: {include}" }
+                }
+                for exclude in &split.exclude {
+                    p { class: "text-sm text-scope-out", "exclude: {exclude}" }
+                }
+                for reason in &split.reasons {
+                    p { class: "text-xs text-evidence-warn", "{reason}" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn TestRecommendationPanel(report: syu_workbench::BranchScopeReport) -> Element {
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "flex flex-col gap-2 p-3",
+                div { class: classes::SECTION_HEADER,
+                    h3 { class: "text-sm font-semibold", "Test Impact" }
+                    ScopeChip { label: format!("{} tests", report.test_inventory.total_tests) }
+                }
+                for test in report.test_inventory.required_tests.iter().chain(report.test_inventory.linked_tests.iter()) {
+                    p { class: "text-sm text-test-linked", "{test}" }
+                }
+                if report.test_inventory.total_tests == 0 {
+                    p { class: "text-sm text-evidence-warn", "evidence-pending" }
                 }
             }
         }
@@ -653,6 +967,38 @@ fn include_pattern(include: &GoalPlanScopeInclude) -> String {
 fn goal_plan_yaml_preview(plan: &GoalPlanArtifact) -> String {
     serde_yaml::to_string(plan)
         .unwrap_or_else(|err| format!("# failed to render Goal Plan YAML: {err}"))
+}
+
+fn graph_state_class(state: &str) -> &'static str {
+    match state {
+        "spec-linked" => "text-spec-linked",
+        "code-linked" => "text-code-linked",
+        "test-linked" => "text-test-linked",
+        "scope-in" => "text-scope-in",
+        "scope-out" => "text-scope-out",
+        "scope-ambiguous" => "text-scope-ambiguous",
+        "ownership-known" => "text-ownership-known",
+        "ownership-missing" => "text-ownership-missing",
+        "ownership-ambiguous" => "text-ownership-ambiguous",
+        "evidence-pass" => "text-evidence-pass",
+        "evidence-warn" => "text-evidence-warn",
+        "evidence-fail" => "text-evidence-fail",
+        "evidence-pending" => "text-evidence-pending",
+        _ => "text-foreground/70",
+    }
+}
+
+fn truncate_label(label: &str, max_chars: usize) -> String {
+    if label.chars().count() <= max_chars {
+        return label.to_string();
+    }
+
+    let mut truncated = label
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
 }
 
 #[cfg(test)]

--- a/crates/syu-app-ui/src/design/tokens.rs
+++ b/crates/syu-app-ui/src/design/tokens.rs
@@ -7,8 +7,15 @@ pub const COMMAND: &str = "command";
 pub const COMMAND_ACTIVE: &str = "command-active";
 pub const GOAL: &str = "goal";
 pub const GOAL_ACTIVE: &str = "goal-active";
+pub const SPEC_LINKED: &str = "spec-linked";
+pub const CODE_LINKED: &str = "code-linked";
+pub const TEST_LINKED: &str = "test-linked";
 pub const SCOPE_IN: &str = "scope-in";
 pub const SCOPE_OUT: &str = "scope-out";
+pub const SCOPE_AMBIGUOUS: &str = "scope-ambiguous";
+pub const OWNERSHIP_KNOWN: &str = "ownership-known";
+pub const OWNERSHIP_MISSING: &str = "ownership-missing";
+pub const OWNERSHIP_AMBIGUOUS: &str = "ownership-ambiguous";
 pub const EVIDENCE_PASS: &str = "evidence-pass";
 pub const EVIDENCE_WARN: &str = "evidence-warn";
 pub const EVIDENCE_FAIL: &str = "evidence-fail";
@@ -24,8 +31,15 @@ pub const WORKBENCH_TOKENS: &[&str] = &[
     COMMAND_ACTIVE,
     GOAL,
     GOAL_ACTIVE,
+    SPEC_LINKED,
+    CODE_LINKED,
+    TEST_LINKED,
     SCOPE_IN,
     SCOPE_OUT,
+    SCOPE_AMBIGUOUS,
+    OWNERSHIP_KNOWN,
+    OWNERSHIP_MISSING,
+    OWNERSHIP_AMBIGUOUS,
     EVIDENCE_PASS,
     EVIDENCE_WARN,
     EVIDENCE_FAIL,

--- a/crates/syu-app-ui/src/lib.rs
+++ b/crates/syu-app-ui/src/lib.rs
@@ -7,10 +7,12 @@ pub mod model;
 use dioxus::prelude::{Asset, asset};
 
 pub use components::{
-    AppShell, CommandPalette, EvidencePanel, GoalCanvas, GoalDependencyView, GoalPlanCanvas,
-    GoalPlanExportPanel, GoalRail, GoalScopePanel, GoalTestPlanPanel, RequestClassificationPanel,
-    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel, StatusBar,
-    WorkspacePulse,
+    AffectedSpecPanel, AppShell, BranchScopeLens, ChangedFilesPanel, CommandPalette, EvidencePanel,
+    GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel,
+    GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel, OutOfScopePanel, OwnershipBadge,
+    OwnershipPanel, RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas,
+    RequestScopePanel, ScaffoldPreviewPanel, ScopeLegend, SpecImpactGraph, StatusBar,
+    SuggestedGoalSplitPanel, TestRecommendationPanel, WorkspacePulse,
 };
 pub use model::{
     CommandPaletteEntry, WorkbenchActionRunPreview, WorkbenchUiState, build_demo_state,

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -529,6 +529,7 @@ fn demo_goal_plan() -> GoalPlanArtifact {
                 ],
                 exclude: vec![
                     "examples/browser-ui/**".to_string(),
+                    "examples/legacy-browser/**".to_string(),
                     "website/**".to_string(),
                     "React, TypeScript, Vite, and Playwright surfaces".to_string(),
                 ],

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -9,8 +9,9 @@ use syu_task_model::{
     TaskTestSelectionCommand, TaskTestSelectionEscalation, TaskTestSelectionPlan,
 };
 use syu_workbench::{
-    ActiveGoalState, ActiveRequestState, EvidenceEntry, GoalListState, WorkbenchAction,
-    WorkbenchActionAvailability, WorkbenchActionId, WorkbenchActionMutability,
+    ActiveGoalState, ActiveRequestState, AffectedSpecItem, BranchScopeEvidence, BranchScopeReport,
+    ChangedFileReport, EvidenceEntry, GoalListState, OutOfScopeChange, OwnershipStatus,
+    WorkbenchAction, WorkbenchActionAvailability, WorkbenchActionId, WorkbenchActionMutability,
     WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchEvidenceKind, WorkbenchState,
 };
 
@@ -338,6 +339,24 @@ pub fn build_demo_state() -> WorkbenchUiState {
             rationale: Some("demo fixture for request-to-goals flow".to_string()),
             scope_token: Some("request-739".to_string()),
         }),
+        branch_scope: Some(syu_workbench::BranchScopeState {
+            range: Some("origin/main...HEAD".to_string()),
+            report: Some(demo_branch_scope_report()),
+            bounded_scope: Some(syu_workbench::BoundedScope {
+                range: Some("origin/main...HEAD".to_string()),
+                allowed_ids: vec![
+                    "REQ-WORKBENCH-004".to_string(),
+                    "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+                    "FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string(),
+                ],
+                max_files: Some(3),
+            }),
+            allowed_ids: vec![
+                "REQ-WORKBENCH-004".to_string(),
+                "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+                "FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string(),
+            ],
+        }),
         ..WorkbenchState::default()
     };
     state.evidence_timeline.entries.push(EvidenceEntry {
@@ -345,10 +364,91 @@ pub fn build_demo_state() -> WorkbenchUiState {
         summary: "validation passed".to_string(),
         action_id: None,
     });
+    state.evidence_timeline.entries.push(EvidenceEntry {
+        kind: WorkbenchEvidenceKind::BranchScopeReport,
+        summary: "branch.scope connected specs, code, tests, and ownership".to_string(),
+        action_id: Some(WorkbenchActionId::BranchScope),
+    });
     let mut ui = WorkbenchUiState::from_state(state);
     ui.command_palette_open = true;
     ui.command_query = "goal".to_string();
     ui
+}
+
+fn demo_branch_scope_report() -> BranchScopeReport {
+    let requirement = AffectedSpecItem {
+        kind: "requirement".to_string(),
+        id: "REQ-WORKBENCH-004".to_string(),
+        title: "Spec impact and branch scope visualization".to_string(),
+        document_path: Some("docs/syu/requirements/core/workbench.yaml".to_string()),
+        direct: true,
+    };
+    let spec_graph = AffectedSpecItem {
+        kind: "feature".to_string(),
+        id: "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+        title: "Spec Impact Graph".to_string(),
+        document_path: Some("docs/syu/features/workbench/branch-scope.yaml".to_string()),
+        direct: true,
+    };
+    let branch_lens = AffectedSpecItem {
+        kind: "feature".to_string(),
+        id: "FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string(),
+        title: "Branch Scope Lens".to_string(),
+        document_path: Some("docs/syu/features/workbench/branch-scope.yaml".to_string()),
+        direct: true,
+    };
+
+    BranchScopeReport::from_evidence(BranchScopeEvidence {
+        range: "origin/main...HEAD".to_string(),
+        changed_files: vec![
+            ChangedFileReport {
+                file: "crates/syu-app-ui/src/components/shell.rs".to_string(),
+                symbols: vec!["SpecImpactGraph".to_string(), "BranchScopeLens".to_string()],
+                owners: vec![spec_graph.clone(), branch_lens.clone()],
+                status: OwnershipStatus::Owned,
+                is_spec_file: false,
+            },
+            ChangedFileReport {
+                file: "crates/syu-app-ui/src/design/tokens.rs".to_string(),
+                symbols: vec!["SCOPE_AMBIGUOUS".to_string()],
+                owners: vec![spec_graph.clone()],
+                status: OwnershipStatus::Partial,
+                is_spec_file: false,
+            },
+            ChangedFileReport {
+                file: "examples/legacy-browser/index.ts".to_string(),
+                symbols: Vec::new(),
+                owners: Vec::new(),
+                status: OwnershipStatus::Unowned,
+                is_spec_file: false,
+            },
+        ],
+        trace_ownership: Vec::new(),
+        spec_items: vec![requirement, spec_graph, branch_lens],
+        required_tests: vec!["tests/workbench_smoke.rs".to_string()],
+        linked_tests: vec!["cargo test -p syu-code-intel branch_scope".to_string()],
+        include_patterns: vec![
+            "crates/syu-app-ui/src/**".to_string(),
+            "crates/syu-code-intel/src/branch_scope.rs".to_string(),
+        ],
+        exclude_patterns: vec!["examples/legacy-browser/**".to_string()],
+        allowed_ids: vec![
+            "REQ-WORKBENCH-004".to_string(),
+            "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+            "FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string(),
+        ],
+        unowned_files: vec!["examples/legacy-browser/index.ts".to_string()],
+        ambiguous_files: vec!["crates/syu-app-ui/src/design/tokens.rs".to_string()],
+        spec_files: Vec::new(),
+        out_of_scope_changes: vec![OutOfScopeChange {
+            file: "examples/legacy-browser/index.ts".to_string(),
+            allowed_ids: vec!["FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string()],
+            reason: "legacy browser surface is excluded by the Goal Plan".to_string(),
+        }],
+        direct_items: Vec::new(),
+        related_items: Vec::new(),
+        has_planned_features: true,
+    })
 }
 
 fn demo_request_artifact() -> RequestArtifact {

--- a/crates/syu-code-intel/src/branch_scope.rs
+++ b/crates/syu-code-intel/src/branch_scope.rs
@@ -104,6 +104,29 @@ pub struct SpecImpactReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecImpactGraphNode {
+    pub id: String,
+    pub label: String,
+    pub kind: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecImpactGraphEdge {
+    pub from: String,
+    pub to: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecImpactGraphReport {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub nodes: Vec<SpecImpactGraphNode>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub edges: Vec<SpecImpactGraphEdge>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TestInventoryReport {
     pub total_tests: usize,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -172,6 +195,7 @@ pub struct BranchScopeReport {
     pub changed_symbols: Vec<ChangedSymbolReport>,
     pub trace_ownership: TraceOwnershipReport,
     pub spec_impact: SpecImpactReport,
+    pub spec_impact_graph: SpecImpactGraphReport,
     pub test_inventory: TestInventoryReport,
     pub suggested_goal_split: SuggestedGoalSplit,
     pub repo_risk: RepoRiskSummary,
@@ -259,6 +283,8 @@ impl BranchScopeReport {
             required_tests: evidence.required_tests.clone(),
             linked_tests: evidence.linked_tests.clone(),
         };
+        let spec_impact_graph =
+            build_spec_impact_graph(&changed_files, &spec_impact, &test_inventory);
 
         let suggested_goal_split = SuggestedGoalSplit {
             confidence: confidence.label().to_string(),
@@ -285,12 +311,98 @@ impl BranchScopeReport {
             changed_symbols,
             trace_ownership,
             spec_impact,
+            spec_impact_graph,
             test_inventory,
             suggested_goal_split,
             repo_risk,
             warnings,
         }
     }
+}
+
+fn build_spec_impact_graph(
+    changed_files: &[ChangedFileReport],
+    spec_impact: &SpecImpactReport,
+    test_inventory: &TestInventoryReport,
+) -> SpecImpactGraphReport {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut previous_spec_id: Option<String> = None;
+
+    for item in &spec_impact.affected_items {
+        let state = match item.kind.as_str() {
+            "philosophy" => "spec-linked",
+            "policy" => "spec-linked",
+            "requirement" => "scope-in",
+            "feature" => "scope-in",
+            _ => "spec-linked",
+        };
+        nodes.push(SpecImpactGraphNode {
+            id: item.id.clone(),
+            label: item.title.clone(),
+            kind: item.kind.clone(),
+            state: state.to_string(),
+        });
+        if let Some(previous) = &previous_spec_id {
+            edges.push(SpecImpactGraphEdge {
+                from: previous.clone(),
+                to: item.id.clone(),
+                state: "spec-linked".to_string(),
+            });
+        }
+        previous_spec_id = Some(item.id.clone());
+    }
+
+    for file in changed_files {
+        let state = match file.status {
+            OwnershipStatus::Owned => "ownership-known",
+            OwnershipStatus::Partial => "ownership-ambiguous",
+            OwnershipStatus::Unowned => "ownership-missing",
+        };
+        nodes.push(SpecImpactGraphNode {
+            id: file.file.clone(),
+            label: file.file.clone(),
+            kind: if file.symbols.is_empty() {
+                "file".to_string()
+            } else {
+                "file/symbol".to_string()
+            },
+            state: state.to_string(),
+        });
+        if let Some(owner) = file
+            .owners
+            .first()
+            .or_else(|| spec_impact.affected_items.first())
+        {
+            edges.push(SpecImpactGraphEdge {
+                from: owner.id.clone(),
+                to: file.file.clone(),
+                state: "code-linked".to_string(),
+            });
+        }
+    }
+
+    for test in test_inventory
+        .required_tests
+        .iter()
+        .chain(test_inventory.linked_tests.iter())
+    {
+        nodes.push(SpecImpactGraphNode {
+            id: test.clone(),
+            label: test.clone(),
+            kind: "test".to_string(),
+            state: "test-linked".to_string(),
+        });
+        if let Some(file) = changed_files.first() {
+            edges.push(SpecImpactGraphEdge {
+                from: file.file.clone(),
+                to: test.clone(),
+                state: "test-linked".to_string(),
+            });
+        }
+    }
+
+    SpecImpactGraphReport { nodes, edges }
 }
 
 fn build_split_reasons(
@@ -409,5 +521,70 @@ mod tests {
 
         assert_eq!(report.confidence, BranchScopeConfidence::Medium);
         assert!(report.spec_impact.out_of_scope_changes.is_empty());
+    }
+
+    #[test]
+    fn branch_scope_report_includes_typed_graph_nodes_and_edges() {
+        let report = BranchScopeReport::from_evidence(BranchScopeEvidence {
+            range: "main..HEAD".to_string(),
+            changed_files: vec![ChangedFileReport {
+                file: "src/workbench.rs".to_string(),
+                symbols: vec!["SpecImpactGraph".to_string()],
+                owners: vec![AffectedSpecItem {
+                    kind: "feature".to_string(),
+                    id: "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+                    title: "Spec Impact Graph".to_string(),
+                    document_path: None,
+                    direct: true,
+                }],
+                status: OwnershipStatus::Owned,
+                is_spec_file: false,
+            }],
+            trace_ownership: Vec::new(),
+            spec_items: vec![
+                AffectedSpecItem {
+                    kind: "requirement".to_string(),
+                    id: "REQ-WORKBENCH-004".to_string(),
+                    title: "Spec impact and branch scope visualization".to_string(),
+                    document_path: None,
+                    direct: true,
+                },
+                AffectedSpecItem {
+                    kind: "feature".to_string(),
+                    id: "FEAT-WORKBENCH-SPEC-GRAPH-001".to_string(),
+                    title: "Spec Impact Graph".to_string(),
+                    document_path: None,
+                    direct: true,
+                },
+            ],
+            required_tests: vec!["tests/workbench_smoke.rs".to_string()],
+            linked_tests: Vec::new(),
+            include_patterns: vec!["crates/syu-app-ui/src/**".to_string()],
+            exclude_patterns: Vec::new(),
+            allowed_ids: Vec::new(),
+            unowned_files: Vec::new(),
+            ambiguous_files: Vec::new(),
+            spec_files: Vec::new(),
+            out_of_scope_changes: Vec::new(),
+            direct_items: Vec::new(),
+            related_items: Vec::new(),
+            has_planned_features: true,
+        });
+
+        assert!(report.spec_impact_graph.nodes.iter().any(|node| {
+            node.id == "FEAT-WORKBENCH-SPEC-GRAPH-001" && node.state == "scope-in"
+        }));
+        assert!(
+            report
+                .spec_impact_graph
+                .nodes
+                .iter()
+                .any(|node| { node.id == "src/workbench.rs" && node.state == "ownership-known" })
+        );
+        assert!(report.spec_impact_graph.edges.iter().any(|edge| {
+            edge.from == "REQ-WORKBENCH-004"
+                && edge.to == "FEAT-WORKBENCH-SPEC-GRAPH-001"
+                && edge.state == "spec-linked"
+        }));
     }
 }

--- a/crates/syu-code-intel/src/lib.rs
+++ b/crates/syu-code-intel/src/lib.rs
@@ -10,6 +10,7 @@ pub mod branch_scope;
 pub use branch_scope::{
     AffectedSpecItem, AmbiguousOwnership, BranchScopeConfidence, BranchScopeEvidence,
     BranchScopeReport, ChangedFileReport, ChangedSymbolReport, OutOfScopeChange, RepoRiskSummary,
+    SpecImpactGraphEdge, SpecImpactGraphNode, SpecImpactGraphReport, SpecImpactReport,
     SuggestedGoalSplit, TestInventoryReport, TraceOwnershipReport, UnownedChange,
 };
 

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -2,7 +2,11 @@ use serde::Serialize;
 use std::{path::PathBuf, sync::OnceLock};
 
 pub use syu_actions::{HistoryResponse, ValidationReport};
-pub use syu_code_intel::{BranchScopeReport, OutOfScopeChange, SuggestedGoalSplit};
+pub use syu_code_intel::{
+    AffectedSpecItem, BranchScopeEvidence, BranchScopeReport, ChangedFileReport, OutOfScopeChange,
+    OwnershipStatus, SpecImpactGraphEdge, SpecImpactGraphNode, SpecImpactGraphReport,
+    SpecImpactReport, SuggestedGoalSplit,
+};
 pub use syu_task_model::{
     ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, RequestArtifact,
     RequestArtifactContext, ScaffoldPlan, ScopeOutcome, TaskTestSelectionPlan,
@@ -61,6 +65,10 @@ pub enum WorkbenchActionId {
     BranchInferGoal,
     #[serde(rename = "spec.impact")]
     SpecImpact,
+    #[serde(rename = "trace.range")]
+    TraceRange,
+    #[serde(rename = "relate.range")]
+    RelateRange,
     #[serde(rename = "validation.run")]
     ValidationRun,
     #[serde(rename = "history.show")]
@@ -84,6 +92,8 @@ impl WorkbenchActionId {
             Self::BranchScope => "branch.scope",
             Self::BranchInferGoal => "branch.infer_goal",
             Self::SpecImpact => "spec.impact",
+            Self::TraceRange => "trace.range",
+            Self::RelateRange => "relate.range",
             Self::ValidationRun => "validation.run",
             Self::HistoryShow => "history.show",
             Self::AssignmentCreate => "assignment.create",
@@ -102,6 +112,7 @@ pub enum WorkbenchActionFunction {
     SelectGoalTests,
     CheckGoalPlan,
     BranchScope,
+    TraceRange,
     InferGoalPlanFromDiff,
     RelateRange,
     ValidateWorkspace,
@@ -120,6 +131,7 @@ impl WorkbenchActionFunction {
             Self::SelectGoalTests => "select_goal_tests",
             Self::CheckGoalPlan => "check_goal_plan",
             Self::BranchScope => "branch.scope",
+            Self::TraceRange => "trace_range",
             Self::InferGoalPlanFromDiff => "infer_goal_plan_from_diff",
             Self::RelateRange => "relate_range",
             Self::ValidateWorkspace => "validate_workspace",
@@ -160,6 +172,7 @@ pub enum WorkbenchEvidenceKind {
     TaskTestSelectionPlan,
     GoalPlanCheckReport,
     BranchScopeReport,
+    SpecImpactReport,
     ValidationReport,
     HistoryResponse,
     AssignmentState,
@@ -177,6 +190,7 @@ impl WorkbenchEvidenceKind {
             Self::TaskTestSelectionPlan => "task_test_selection_plan",
             Self::GoalPlanCheckReport => "goal_plan_check_report",
             Self::BranchScopeReport => "branch_scope_report",
+            Self::SpecImpactReport => "spec_impact_report",
             Self::ValidationReport => "validation_report",
             Self::HistoryResponse => "history_response",
             Self::AssignmentState => "assignment_state",
@@ -276,6 +290,7 @@ pub enum WorkbenchActionResult {
     TaskTestSelectionPlan(TaskTestSelectionPlan),
     GoalPlanCheckReport(GoalPlanCheckReport),
     BranchScopeReport(BranchScopeReport),
+    SpecImpactReport(SpecImpactReport),
     ValidationReport(ValidationReport),
     HistoryResponse(HistoryResponse),
     AssignmentState(AssignmentState),
@@ -293,6 +308,7 @@ impl WorkbenchActionResult {
             Self::TaskTestSelectionPlan(_) => WorkbenchEvidenceKind::TaskTestSelectionPlan,
             Self::GoalPlanCheckReport(_) => WorkbenchEvidenceKind::GoalPlanCheckReport,
             Self::BranchScopeReport(_) => WorkbenchEvidenceKind::BranchScopeReport,
+            Self::SpecImpactReport(_) => WorkbenchEvidenceKind::SpecImpactReport,
             Self::ValidationReport(_) => WorkbenchEvidenceKind::ValidationReport,
             Self::HistoryResponse(_) => WorkbenchEvidenceKind::HistoryResponse,
             Self::AssignmentState(_) => WorkbenchEvidenceKind::AssignmentState,
@@ -584,6 +600,7 @@ impl WorkbenchState {
                     allowed_ids,
                 });
             }
+            WorkbenchActionResult::SpecImpactReport(_) => {}
             WorkbenchActionResult::ValidationReport(report) => {
                 self.workspace
                     .get_or_insert_with(WorkspaceSnapshot::default)
@@ -921,7 +938,35 @@ fn build_registry() -> Vec<WorkbenchAction> {
             risk: WorkbenchActionRisk::Low,
             function: WorkbenchActionFunction::RelateRange,
             output_event: WorkbenchActionOutputEvent::SpecImpactAssessed,
+            evidence_kind: WorkbenchEvidenceKind::SpecImpactReport,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::TraceRange,
+            title: "Trace range".to_string(),
+            description: "Trace changed files and symbols for the selected branch range."
+                .to_string(),
+            required_state: vec![WorkbenchStateRequirement::WorkspaceLoaded],
+            input_schema: WorkbenchActionInputSchema::BranchScope,
+            mutability: WorkbenchActionMutability::ReadOnly,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::TraceRange,
+            output_event: WorkbenchActionOutputEvent::BranchScoped,
             evidence_kind: WorkbenchEvidenceKind::BranchScopeReport,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::RelateRange,
+            title: "Relate range".to_string(),
+            description: "Relate the selected branch range to affected specs and tests."
+                .to_string(),
+            required_state: vec![WorkbenchStateRequirement::BranchScopeLoaded],
+            input_schema: WorkbenchActionInputSchema::BranchScope,
+            mutability: WorkbenchActionMutability::ReadOnly,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::RelateRange,
+            output_event: WorkbenchActionOutputEvent::SpecImpactAssessed,
+            evidence_kind: WorkbenchEvidenceKind::SpecImpactReport,
             ai_eligible: false,
         },
         WorkbenchAction {

--- a/docs/generated/site-spec/features/workbench/actions.md
+++ b/docs/generated/site-spec/features/workbench/actions.md
@@ -78,6 +78,11 @@ description: "Generated reference for docs/syu/features/workbench/actions.yaml"
           - WorkbenchState
           - request.scope
           - goal.test_select
+          - branch.scope
+          - branch.infer_goal
+          - spec.impact
+          - trace.range
+          - relate.range
 
 ## Source YAML
 
@@ -147,4 +152,9 @@ features:
             - WorkbenchState
             - request.scope
             - goal.test_select
+            - branch.scope
+            - branch.infer_goal
+            - spec.impact
+            - trace.range
+            - relate.range
 ```

--- a/docs/generated/site-spec/features/workbench/branch-scope.md
+++ b/docs/generated/site-spec/features/workbench/branch-scope.md
@@ -17,6 +17,72 @@ description: "Generated reference for docs/syu/features/workbench/branch-scope.y
 
 ### Features
 
+- **id**: FEAT-WORKBENCH-SPEC-GRAPH-001
+  - **title**: Spec Impact Graph
+  - **summary**: Render a simple typed graph that connects philosophy, policy, requirement, feature, changed file or symbol, and test nodes so request and branch impact can be inspected without a separate graph engine.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-WORKBENCH-004
+  - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-code-intel/src/branch_scope.rs
+        - **symbols**:
+          - SpecImpactGraphReport
+          - SpecImpactGraphNode
+          - SpecImpactGraphEdge
+          - BranchScopeReport
+      - **file**: crates/syu-app-ui/src/components/shell.rs
+        - **symbols**:
+          - SpecImpactGraph
+          - GraphNode
+          - GraphEdge
+          - ScopeLegend
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - spec_impact_graph_renders_typed_nodes_edges_and_legend
+    - **markdown**:
+      - **file**: docs/guide/workbench.md
+        - **symbols**:
+          - scope
+          - branch scope
+          - scaffold preview
+- **id**: FEAT-WORKBENCH-BRANCH-SCOPE-001
+  - **title**: Branch Scope Lens
+  - **summary**: Show branch range, changed files, traced ownership, affected specs, out-of-scope changes, goal split suggestions, tests, and strict review status from typed Workbench Branch Scope data.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-WORKBENCH-004
+  - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-code-intel/src/branch_scope.rs
+        - **symbols**:
+          - BranchScopeReport
+          - BranchScopeEvidence
+          - SpecImpactReport
+      - **file**: crates/syu-workbench/src/lib.rs
+        - **symbols**:
+          - WorkbenchActionId
+          - WorkbenchEvidenceKind
+          - BranchScopeState
+      - **file**: crates/syu-app-ui/src/components/shell.rs
+        - **symbols**:
+          - BranchScopeLens
+          - ChangedFilesPanel
+          - OwnershipPanel
+          - OutOfScopePanel
+          - AffectedSpecPanel
+          - SuggestedGoalSplitPanel
+          - ImpactSummaryPanel
+          - OwnershipBadge
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - branch_scope_lens_renders_scope_ownership_and_tests
+    - **markdown**:
+      - **file**: docs/guide/workbench.md
+        - **symbols**:
+          - scope
+          - branch scope
+          - scaffold preview
 - **id**: FEAT-WORKBENCH-004
   - **title**: Spec impact and branch scope view
   - **summary**: Show the likely spec, file, and branch scope impact of a request before implementation begins so the user can refine scope early.
@@ -38,6 +104,72 @@ category: Workbench
 version: 1
 
 features:
+  - id: FEAT-WORKBENCH-SPEC-GRAPH-001
+    title: Spec Impact Graph
+    summary: Render a simple typed graph that connects philosophy, policy, requirement, feature, changed file or symbol, and test nodes so request and branch impact can be inspected without a separate graph engine.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-004
+    implementations:
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - SpecImpactGraphReport
+            - SpecImpactGraphNode
+            - SpecImpactGraphEdge
+            - BranchScopeReport
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - SpecImpactGraph
+            - GraphNode
+            - GraphEdge
+            - ScopeLegend
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - spec_impact_graph_renders_typed_nodes_edges_and_legend
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - scope
+            - branch scope
+            - scaffold preview
+  - id: FEAT-WORKBENCH-BRANCH-SCOPE-001
+    title: Branch Scope Lens
+    summary: Show branch range, changed files, traced ownership, affected specs, out-of-scope changes, goal split suggestions, tests, and strict review status from typed Workbench Branch Scope data.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-004
+    implementations:
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - BranchScopeReport
+            - BranchScopeEvidence
+            - SpecImpactReport
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - WorkbenchActionId
+            - WorkbenchEvidenceKind
+            - BranchScopeState
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - BranchScopeLens
+            - ChangedFilesPanel
+            - OwnershipPanel
+            - OutOfScopePanel
+            - AffectedSpecPanel
+            - SuggestedGoalSplitPanel
+            - ImpactSummaryPanel
+            - OwnershipBadge
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - branch_scope_lens_renders_scope_ownership_and_tests
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - scope
+            - branch scope
+            - scaffold preview
   - id: FEAT-WORKBENCH-004
     title: Spec impact and branch scope view
     summary: Show the likely spec, file, and branch scope impact of a request before implementation begins so the user can refine scope early.

--- a/docs/generated/site-spec/features/workbench/branch-scope.md
+++ b/docs/generated/site-spec/features/workbench/branch-scope.md
@@ -72,6 +72,7 @@ description: "Generated reference for docs/syu/features/workbench/branch-scope.y
           - OutOfScopePanel
           - AffectedSpecPanel
           - SuggestedGoalSplitPanel
+          - GoalScopeComparisonPanel
           - ImpactSummaryPanel
           - OwnershipBadge
       - **file**: tests/workbench_smoke.rs
@@ -159,6 +160,7 @@ features:
             - OutOfScopePanel
             - AffectedSpecPanel
             - SuggestedGoalSplitPanel
+            - GoalScopeComparisonPanel
             - ImpactSummaryPanel
             - OwnershipBadge
         - file: tests/workbench_smoke.rs

--- a/docs/generated/site-spec/features/workbench/design-tokens.md
+++ b/docs/generated/site-spec/features/workbench/design-tokens.md
@@ -36,8 +36,15 @@ description: "Generated reference for docs/syu/features/workbench/design-tokens.
           - COMMAND_ACTIVE
           - GOAL
           - GOAL_ACTIVE
+          - SPEC_LINKED
+          - CODE_LINKED
+          - TEST_LINKED
           - SCOPE_IN
           - SCOPE_OUT
+          - SCOPE_AMBIGUOUS
+          - OWNERSHIP_KNOWN
+          - OWNERSHIP_MISSING
+          - OWNERSHIP_AMBIGUOUS
           - EVIDENCE_PASS
           - EVIDENCE_WARN
           - EVIDENCE_FAIL
@@ -80,8 +87,15 @@ features:
             - COMMAND_ACTIVE
             - GOAL
             - GOAL_ACTIVE
+            - SPEC_LINKED
+            - CODE_LINKED
+            - TEST_LINKED
             - SCOPE_IN
             - SCOPE_OUT
+            - SCOPE_AMBIGUOUS
+            - OWNERSHIP_KNOWN
+            - OWNERSHIP_MISSING
+            - OWNERSHIP_AMBIGUOUS
             - EVIDENCE_PASS
             - EVIDENCE_WARN
             - EVIDENCE_FAIL

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -126,13 +126,19 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
       The Workbench MUST show which specifications, files, and branch scope are
       likely to change before the user commits to implementation. It SHOULD
       make the impact of a request visible early enough that the user can
-      refine scope before work starts.
+      refine scope before work starts. Scope status MUST distinguish in-scope,
+      out-of-scope, ambiguous, owned, unowned, and ownership-ambiguous states,
+      and visual graph state MUST use named Workbench tokens rather than
+      arbitrary styling. Spec impact and branch scope reports SHOULD stay
+      compatible with future evidence timeline records.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
     - POL-005
   - **linked_features**:
     - FEAT-WORKBENCH-004
+    - FEAT-WORKBENCH-SPEC-GRAPH-001
+    - FEAT-WORKBENCH-BRANCH-SCOPE-001
   - **tests**:
     - **markdown**:
       - **file**: docs/guide/workbench.md
@@ -140,6 +146,14 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
           - scope
           - branch scope
           - scaffold preview
+    - **rust**:
+      - **file**: crates/syu-code-intel/src/branch_scope.rs
+        - **symbols**:
+          - branch_scope_report_includes_typed_graph_nodes_and_edges
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - branch_scope_lens_renders_scope_ownership_and_tests
+          - spec_impact_graph_renders_typed_nodes_edges_and_legend
 - **id**: REQ-WORKBENCH-005
   - **title**: Human and AI assignment with explicit scope and evidence
   - **description**:
@@ -319,13 +333,19 @@ requirements:
       The Workbench MUST show which specifications, files, and branch scope are
       likely to change before the user commits to implementation. It SHOULD
       make the impact of a request visible early enough that the user can
-      refine scope before work starts.
+      refine scope before work starts. Scope status MUST distinguish in-scope,
+      out-of-scope, ambiguous, owned, unowned, and ownership-ambiguous states,
+      and visual graph state MUST use named Workbench tokens rather than
+      arbitrary styling. Spec impact and branch scope reports SHOULD stay
+      compatible with future evidence timeline records.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-004
+      - FEAT-WORKBENCH-SPEC-GRAPH-001
+      - FEAT-WORKBENCH-BRANCH-SCOPE-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -333,6 +353,14 @@ requirements:
             - scope
             - branch scope
             - scaffold preview
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - branch_scope_report_includes_typed_graph_nodes_and_edges
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - branch_scope_lens_renders_scope_ownership_and_tests
+            - spec_impact_graph_renders_typed_nodes_edges_and_legend
   - id: REQ-WORKBENCH-005
     title: Human and AI assignment with explicit scope and evidence
     description: |

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -10,12 +10,12 @@
 - Philosophies: 3
 - Policies: 8
 - Requirements: 39
-- Features: 51
+- Features: 53
 
 ## Traceability
 
-- Requirement-to-test traceability: 171/171
-- Feature-to-implementation traceability: 187/187
+- Requirement-to-test traceability: 173/173
+- Feature-to-implementation traceability: 196/196
 
 ## Issues
 

--- a/docs/guide/workbench.md
+++ b/docs/guide/workbench.md
@@ -54,6 +54,21 @@ Goal Plan YAML exported from the Workbench must stay compatible with
 - Completion check: compare the result against the goal plan and required
   evidence before closing the loop.
 
+## Spec Impact and Branch Scope
+
+Spec Impact Graph shows how philosophy, policy, requirement, feature, changed
+file or symbol, and test nodes connect. Branch Scope Lens shows the selected
+Git range, changed files, traced owners, unowned files, ambiguous ownership,
+out-of-scope files, affected spec IDs, suggested goal split, test
+recommendations, and strict review status.
+
+The action surface for this view is `branch.scope`, `branch.infer_goal`,
+`spec.impact`, `trace.range`, and `relate.range`. Graph nodes, edges, badges,
+and evidence states must use Workbench token names such as `spec-linked`,
+`code-linked`, `test-linked`, `scope-in`, `scope-out`, `scope-ambiguous`,
+`ownership-known`, `ownership-missing`, `ownership-ambiguous`,
+`evidence-pass`, `evidence-warn`, `evidence-fail`, and `evidence-pending`.
+
 ## Command palette registry
 
 The Workbench UI should render actions from a registry instead of hardcoding

--- a/docs/syu/features/workbench/actions.yaml
+++ b/docs/syu/features/workbench/actions.yaml
@@ -63,3 +63,8 @@ features:
             - WorkbenchState
             - request.scope
             - goal.test_select
+            - branch.scope
+            - branch.infer_goal
+            - spec.impact
+            - trace.range
+            - relate.range

--- a/docs/syu/features/workbench/branch-scope.yaml
+++ b/docs/syu/features/workbench/branch-scope.yaml
@@ -2,6 +2,72 @@ category: Workbench
 version: 1
 
 features:
+  - id: FEAT-WORKBENCH-SPEC-GRAPH-001
+    title: Spec Impact Graph
+    summary: Render a simple typed graph that connects philosophy, policy, requirement, feature, changed file or symbol, and test nodes so request and branch impact can be inspected without a separate graph engine.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-004
+    implementations:
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - SpecImpactGraphReport
+            - SpecImpactGraphNode
+            - SpecImpactGraphEdge
+            - BranchScopeReport
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - SpecImpactGraph
+            - GraphNode
+            - GraphEdge
+            - ScopeLegend
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - spec_impact_graph_renders_typed_nodes_edges_and_legend
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - scope
+            - branch scope
+            - scaffold preview
+  - id: FEAT-WORKBENCH-BRANCH-SCOPE-001
+    title: Branch Scope Lens
+    summary: Show branch range, changed files, traced ownership, affected specs, out-of-scope changes, goal split suggestions, tests, and strict review status from typed Workbench Branch Scope data.
+    status: implemented
+    linked_requirements:
+      - REQ-WORKBENCH-004
+    implementations:
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - BranchScopeReport
+            - BranchScopeEvidence
+            - SpecImpactReport
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - WorkbenchActionId
+            - WorkbenchEvidenceKind
+            - BranchScopeState
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - BranchScopeLens
+            - ChangedFilesPanel
+            - OwnershipPanel
+            - OutOfScopePanel
+            - AffectedSpecPanel
+            - SuggestedGoalSplitPanel
+            - ImpactSummaryPanel
+            - OwnershipBadge
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - branch_scope_lens_renders_scope_ownership_and_tests
+      markdown:
+        - file: docs/guide/workbench.md
+          symbols:
+            - scope
+            - branch scope
+            - scaffold preview
   - id: FEAT-WORKBENCH-004
     title: Spec impact and branch scope view
     summary: Show the likely spec, file, and branch scope impact of a request before implementation begins so the user can refine scope early.

--- a/docs/syu/features/workbench/branch-scope.yaml
+++ b/docs/syu/features/workbench/branch-scope.yaml
@@ -57,6 +57,7 @@ features:
             - OutOfScopePanel
             - AffectedSpecPanel
             - SuggestedGoalSplitPanel
+            - GoalScopeComparisonPanel
             - ImpactSummaryPanel
             - OwnershipBadge
         - file: tests/workbench_smoke.rs

--- a/docs/syu/features/workbench/design-tokens.yaml
+++ b/docs/syu/features/workbench/design-tokens.yaml
@@ -21,8 +21,15 @@ features:
             - COMMAND_ACTIVE
             - GOAL
             - GOAL_ACTIVE
+            - SPEC_LINKED
+            - CODE_LINKED
+            - TEST_LINKED
             - SCOPE_IN
             - SCOPE_OUT
+            - SCOPE_AMBIGUOUS
+            - OWNERSHIP_KNOWN
+            - OWNERSHIP_MISSING
+            - OWNERSHIP_AMBIGUOUS
             - EVIDENCE_PASS
             - EVIDENCE_WARN
             - EVIDENCE_FAIL

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -106,13 +106,19 @@ requirements:
       The Workbench MUST show which specifications, files, and branch scope are
       likely to change before the user commits to implementation. It SHOULD
       make the impact of a request visible early enough that the user can
-      refine scope before work starts.
+      refine scope before work starts. Scope status MUST distinguish in-scope,
+      out-of-scope, ambiguous, owned, unowned, and ownership-ambiguous states,
+      and visual graph state MUST use named Workbench tokens rather than
+      arbitrary styling. Spec impact and branch scope reports SHOULD stay
+      compatible with future evidence timeline records.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-004
+      - FEAT-WORKBENCH-SPEC-GRAPH-001
+      - FEAT-WORKBENCH-BRANCH-SCOPE-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -120,6 +126,14 @@ requirements:
             - scope
             - branch scope
             - scaffold preview
+      rust:
+        - file: crates/syu-code-intel/src/branch_scope.rs
+          symbols:
+            - branch_scope_report_includes_typed_graph_nodes_and_edges
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - branch_scope_lens_renders_scope_ownership_and_tests
+            - spec_impact_graph_renders_typed_nodes_edges_and_legend
   - id: REQ-WORKBENCH-005
     title: Human and AI assignment with explicit scope and evidence
     description: |

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -1,7 +1,8 @@
 use dioxus::prelude::*;
 use dioxus_ssr::render_element;
 use syu_app_ui::{
-    AppShell, EvidencePanel, GoalCanvas, GoalPlanExportPanel, WorkbenchUiState, build_demo_state,
+    AppShell, BranchScopeLens, EvidencePanel, GoalCanvas, GoalPlanExportPanel, SpecImpactGraph,
+    WorkbenchUiState, build_demo_state,
 };
 use syu_workbench::{
     WorkbenchActionId, WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchState,
@@ -156,4 +157,44 @@ fn goal_plan_export_panel_marks_yaml_as_temporary_artifact() {
     assert!(html.contains(".syu/workbench/goals/GOAL-WB-REQUEST-001.yaml"));
     assert!(html.contains("completion:"));
     assert!(html.contains("cargo test --test workbench_smoke"));
+}
+
+#[test]
+fn branch_scope_lens_renders_scope_ownership_and_tests() {
+    let ui = build_demo_state();
+
+    let html = render_element(rsx! {
+        BranchScopeLens {
+            ui,
+            on_run_action: None
+        }
+    });
+
+    assert!(html.contains("Branch Scope Lens"));
+    assert!(html.contains("origin/main...HEAD"));
+    assert!(html.contains("Changed Files"));
+    assert!(html.contains("ownership-known"));
+    assert!(html.contains("ownership-missing"));
+    assert!(html.contains("Out Of Scope"));
+    assert!(html.contains("Affected Specs"));
+    assert!(html.contains("FEAT-WORKBENCH-BRANCH-SCOPE-001"));
+    assert!(html.contains("Suggested Goal Split"));
+    assert!(html.contains("tests/workbench_smoke.rs"));
+}
+
+#[test]
+fn spec_impact_graph_renders_typed_nodes_edges_and_legend() {
+    let ui = build_demo_state();
+
+    let html = render_element(rsx! {
+        SpecImpactGraph { ui }
+    });
+
+    assert!(html.contains("Spec Impact Graph"));
+    assert!(html.contains("spec-linked"));
+    assert!(html.contains("code-linked"));
+    assert!(html.contains("test-linked"));
+    assert!(html.contains("scope-ambiguous"));
+    assert!(html.contains("FEAT-WORKBENCH-SPEC-GRAPH-001"));
+    assert!(html.contains("crates/syu-app-ui/src/components/shell.rs"));
 }

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -179,6 +179,12 @@ fn branch_scope_lens_renders_scope_ownership_and_tests() {
     assert!(html.contains("Affected Specs"));
     assert!(html.contains("FEAT-WORKBENCH-BRANCH-SCOPE-001"));
     assert!(html.contains("Suggested Goal Split"));
+    assert!(html.contains("Goal Scope Comparison"));
+    assert!(html.contains("files included by Goal"));
+    assert!(html.contains("files excluded by Goal"));
+    assert!(html.contains("changed files not covered by Goal"));
+    assert!(html.contains("tests required by Goal"));
+    assert!(html.contains("tests detected from code ownership"));
     assert!(html.contains("tests/workbench_smoke.rs"));
 }
 
@@ -197,4 +203,6 @@ fn spec_impact_graph_renders_typed_nodes_edges_and_legend() {
     assert!(html.contains("scope-ambiguous"));
     assert!(html.contains("FEAT-WORKBENCH-SPEC-GRAPH-001"));
     assert!(html.contains("crates/syu-app-ui/src/components/shell.rs"));
+    assert!(html.contains("role=\"button\""));
+    assert!(html.contains("border-command-active"));
 }


### PR DESCRIPTION
Summary:
- Add typed Spec Impact Graph nodes and edges to Branch Scope reports, including ownership/test/spec-linked state concepts.
- Add Branch Scope Lens and Spec Impact Graph Dioxus views that reuse Workbench tokens, panels, badges, and action registry data.
- Register branch/spec/trace/relate action metadata and update Workbench specs, guide, generated docs, and smoke coverage.

Validation:
- cargo test -p syu-code-intel branch_scope
- cargo test -p syu-workbench
- cargo test --test workbench_smoke
- cargo test -p syu-app-ui
- scripts/ci/check-generated-docs-freshness.sh
- pre-commit/pre-push hooks: syu-validate-changed, syu-quality-gates, syu-goal-tests

Closes #740
