### PR TITLE
Add goal-scoped evidence timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ name = "syu-workbench"
 version = "0.0.1-alpha.0"
 dependencies = [
  "serde",
+ "serde_json",
  "syu-actions",
  "syu-code-intel",
  "syu-task-model",

--- a/crates/syu-app-ui/src/components/mod.rs
+++ b/crates/syu-app-ui/src/components/mod.rs
@@ -2,14 +2,17 @@ mod primitives;
 mod shell;
 
 pub use primitives::{
-    Button, CommandItem, DetailDrawer, EmptyState, EvidenceBadge, EvidenceLogRow, GoalCard,
-    IconButton, Panel, ScopeChip, StatusDot,
+    AgentEvidenceView, Button, CommandItem, CommandOutputView, DetailDrawer, EmptyState,
+    EvidenceBadge, EvidenceDetailDrawer, EvidenceLogRow, EvidenceRecordCard, GoalCard, IconButton,
+    ManualDecisionEvidenceView, Panel, ScopeChip, ScopeEvidenceView, StatusDot, TestEvidenceView,
+    ValidationEvidenceView,
 };
 pub use shell::{
     AffectedSpecPanel, AppShell, BranchScopeLens, ChangedFilesPanel, CommandPalette, EvidencePanel,
-    GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel,
-    GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel, OutOfScopePanel, OwnershipBadge,
-    OwnershipPanel, RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas,
-    RequestScopePanel, ScaffoldPreviewPanel, ScopeLegend, SpecImpactGraph, StatusBar,
-    SuggestedGoalSplitPanel, TestRecommendationPanel, WorkspacePulse,
+    EvidenceTimeline, GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel,
+    GoalRail, GoalScopePanel, GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel,
+    OutOfScopePanel, OwnershipBadge, OwnershipPanel, RequestClassificationPanel,
+    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel,
+    ScopeLegend, SpecImpactGraph, StatusBar, SuggestedGoalSplitPanel, TestRecommendationPanel,
+    WorkspacePulse,
 };

--- a/crates/syu-app-ui/src/components/primitives.rs
+++ b/crates/syu-app-ui/src/components/primitives.rs
@@ -74,7 +74,7 @@ pub fn CommandOutputView(
     attachment: Option<EvidenceAttachment>,
 ) -> Element {
     rsx! {
-        section { class: "rounded-xl border border-border bg-background/40 p-3",
+        section { class: "mt-3 rounded-lg bg-background/30 p-3",
             div { class: "flex items-center justify-between gap-3",
                 p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "{title}" }
                 if let Some(command) = &command {
@@ -136,6 +136,7 @@ pub fn EvidenceRecordCard(record: EvidenceRecord) -> Element {
     let tone_class = evidence_status_tone(record.status);
     let source_label = record_source_label(&record);
     let attachment = record.attachments.first().cloned();
+    let timestamp_label = format_timestamp_ms(record.timestamp);
     rsx! {
         article { class: classes::EVIDENCE_CARD,
             div { class: "flex items-start justify-between gap-3",
@@ -152,7 +153,7 @@ pub fn EvidenceRecordCard(record: EvidenceRecord) -> Element {
                         p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "{source_label}" }
                     }
                 }
-                p { class: "shrink-0 text-xs text-foreground/45", "{record.timestamp}" }
+                p { class: "shrink-0 text-xs text-foreground/45", "{timestamp_label}" }
             }
             if let Some(command) = &record.command {
                 CommandOutputView {
@@ -171,6 +172,41 @@ pub fn EvidenceRecordCard(record: EvidenceRecord) -> Element {
             }
         }
     }
+}
+
+fn format_timestamp_ms(timestamp_ms: u64) -> String {
+    const MILLIS_PER_SECOND: i64 = 1_000;
+    const SECONDS_PER_MINUTE: i64 = 60;
+    const MINUTES_PER_HOUR: i64 = 60;
+    const HOURS_PER_DAY: i64 = 24;
+    const SECONDS_PER_DAY: i64 = SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY;
+
+    let total_seconds = (timestamp_ms / MILLIS_PER_SECOND as u64) as i64;
+    let seconds_of_day = total_seconds.rem_euclid(SECONDS_PER_DAY);
+    let days = total_seconds.div_euclid(SECONDS_PER_DAY);
+
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / (SECONDS_PER_MINUTE * MINUTES_PER_HOUR);
+    let minute = (seconds_of_day % (SECONDS_PER_MINUTE * MINUTES_PER_HOUR)) / SECONDS_PER_MINUTE;
+    let second = seconds_of_day % SECONDS_PER_MINUTE;
+
+    format!(
+        "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} UTC"
+    )
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let days = days + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let doe = days - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let mut year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    year += if month <= 2 { 1 } else { 0 };
+    (year, month, day)
 }
 
 #[component]

--- a/crates/syu-app-ui/src/components/primitives.rs
+++ b/crates/syu-app-ui/src/components/primitives.rs
@@ -190,9 +190,7 @@ fn format_timestamp_ms(timestamp_ms: u64) -> String {
     let minute = (seconds_of_day % (SECONDS_PER_MINUTE * MINUTES_PER_HOUR)) / SECONDS_PER_MINUTE;
     let second = seconds_of_day % SECONDS_PER_MINUTE;
 
-    format!(
-        "{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} UTC"
-    )
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} UTC")
 }
 
 fn civil_from_days(days: i64) -> (i64, i64, i64) {

--- a/crates/syu-app-ui/src/components/primitives.rs
+++ b/crates/syu-app-ui/src/components/primitives.rs
@@ -1,7 +1,9 @@
 use crate::design::classes;
 use crate::model::CommandPaletteEntry;
 use dioxus::prelude::*;
-use syu_workbench::{EvidenceEntry, WorkbenchEvidenceKind};
+use syu_workbench::{
+    EvidenceAttachment, EvidenceCommand, EvidenceRecord, EvidenceStatus, WorkbenchEvidenceKind,
+};
 
 #[component]
 pub fn Panel(class: &'static str, children: Element) -> Element {
@@ -61,6 +63,148 @@ pub fn EvidenceBadge(kind: WorkbenchEvidenceKind) -> Element {
         span { class: "{classes::CHIP} {tone}",
             "{kind.label()}"
         }
+    }
+}
+
+#[component]
+pub fn CommandOutputView(
+    title: String,
+    summary: String,
+    command: Option<EvidenceCommand>,
+    attachment: Option<EvidenceAttachment>,
+) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/40 p-3",
+            div { class: "flex items-center justify-between gap-3",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "{title}" }
+                if let Some(command) = &command {
+                    ScopeChip { label: command.command.clone() }
+                }
+            }
+            p { class: "mt-2 text-sm text-foreground/75", "{summary}" }
+            if let Some(command) = &command {
+                if !command.args.is_empty() {
+                    p { class: "mt-2 text-xs text-foreground/55", "{command.args.join(\" \")}" }
+                }
+            }
+            if let Some(attachment) = attachment {
+                if let Some(summary) = attachment.summary {
+                    p { class: "mt-2 text-xs uppercase tracking-[0.18em] text-foreground/55", "{summary}" }
+                }
+                if let Some(content) = attachment.content {
+                    pre { class: "mt-2 max-h-40 overflow-auto rounded-lg border border-border bg-panel-muted p-2 text-xs text-foreground/70",
+                        "{content}"
+                    }
+                }
+                if attachment.truncated {
+                    p { class: "mt-2 text-xs text-evidence-warn", "attachment truncated for the card view" }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn EvidenceDetailDrawer(record: EvidenceRecord) -> Element {
+    rsx! {
+        section { class: classes::DRAWER,
+            div { class: "flex items-center justify-between gap-3",
+                h3 { class: "text-sm font-semibold", "{record.summary}" }
+                EvidenceBadge { kind: record.kind }
+            }
+            p { class: "mt-2 text-xs uppercase tracking-[0.18em] text-foreground/60", "{record.status.label()}" }
+            if let Some(goal_id) = &record.goal_id {
+                p { class: "mt-2 text-sm text-foreground/80", "Goal: {goal_id}" }
+            }
+            if let Some(command) = &record.command {
+                p { class: "mt-2 text-sm text-foreground/75", "Command: {command.command}" }
+            }
+            if let Some(attachment) = record.attachments.first() {
+                CommandOutputView {
+                    title: "Evidence attachment".to_string(),
+                    summary: record.summary.clone(),
+                    command: record.command.clone(),
+                    attachment: Some(attachment.clone()),
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn EvidenceRecordCard(record: EvidenceRecord) -> Element {
+    let tone_class = evidence_status_tone(record.status);
+    let source_label = record_source_label(&record);
+    let attachment = record.attachments.first().cloned();
+    rsx! {
+        article { class: classes::EVIDENCE_CARD,
+            div { class: "flex items-start justify-between gap-3",
+                div { class: "min-w-0 space-y-2",
+                    div { class: "flex flex-wrap items-center gap-2",
+                        StatusDot { tone_class: tone_class, label: record.status.label().to_string() }
+                        EvidenceBadge { kind: record.kind }
+                        if let Some(goal_id) = &record.goal_id {
+                            ScopeChip { label: goal_id.clone() }
+                        }
+                    }
+                    p { class: "text-sm font-medium text-foreground", "{record.summary}" }
+                    if let Some(source_label) = source_label {
+                        p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "{source_label}" }
+                    }
+                }
+                p { class: "shrink-0 text-xs text-foreground/45", "{record.timestamp}" }
+            }
+            if let Some(command) = &record.command {
+                CommandOutputView {
+                    title: "Command output".to_string(),
+                    summary: record.summary.clone(),
+                    command: Some(command.clone()),
+                    attachment: attachment.clone(),
+                }
+            } else if let Some(attachment) = attachment {
+                CommandOutputView {
+                    title: "Evidence attachment".to_string(),
+                    summary: record.summary.clone(),
+                    command: None,
+                    attachment: Some(attachment),
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ValidationEvidenceView(record: EvidenceRecord) -> Element {
+    rsx! {
+        EvidenceRecordCard { record }
+    }
+}
+
+#[component]
+pub fn TestEvidenceView(record: EvidenceRecord) -> Element {
+    rsx! {
+        EvidenceRecordCard { record }
+    }
+}
+
+#[component]
+pub fn ScopeEvidenceView(record: EvidenceRecord) -> Element {
+    rsx! {
+        EvidenceRecordCard { record }
+    }
+}
+
+#[component]
+pub fn AgentEvidenceView(record: EvidenceRecord) -> Element {
+    rsx! {
+        EvidenceRecordCard { record }
+    }
+}
+
+#[component]
+pub fn ManualDecisionEvidenceView(record: EvidenceRecord) -> Element {
+    rsx! {
+        EvidenceRecordCard { record }
     }
 }
 
@@ -142,7 +286,7 @@ pub fn DetailDrawer(title: String, body: String, evidence: String) -> Element {
 }
 
 #[component]
-pub fn EvidenceLogRow(entry: EvidenceEntry) -> Element {
+pub fn EvidenceLogRow(entry: EvidenceRecord) -> Element {
     rsx! {
         article { class: classes::EVIDENCE_CARD,
             div { class: "flex items-center justify-between gap-3",
@@ -166,5 +310,34 @@ fn evidence_tone(kind: WorkbenchEvidenceKind) -> &'static str {
         WorkbenchEvidenceKind::AssignmentState => "text-goal",
         WorkbenchEvidenceKind::JobState => "text-evidence-fail",
         _ => "text-foreground/70",
+    }
+}
+
+fn evidence_status_tone(status: EvidenceStatus) -> &'static str {
+    match status {
+        EvidenceStatus::Pass => "bg-evidence-pass",
+        EvidenceStatus::Warn => "bg-evidence-warn",
+        EvidenceStatus::Fail => "bg-evidence-fail",
+        EvidenceStatus::Pending => "bg-evidence-pending",
+        EvidenceStatus::Skipped => "bg-foreground/30",
+        EvidenceStatus::Unknown => "bg-foreground/30",
+    }
+}
+
+fn record_source_label(record: &EvidenceRecord) -> Option<String> {
+    match &record.source {
+        Some(syu_workbench::EvidenceSource::Action { action_label, .. }) => action_label
+            .as_ref()
+            .map(|label| format!("source: {label}")),
+        Some(syu_workbench::EvidenceSource::Command { command }) => {
+            Some(format!("source: command {command}"))
+        }
+        Some(syu_workbench::EvidenceSource::Manual { actor }) => {
+            Some(format!("source: manual {actor}"))
+        }
+        Some(syu_workbench::EvidenceSource::System { component }) => {
+            Some(format!("source: {component}"))
+        }
+        None => None,
     }
 }

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -1,6 +1,7 @@
 use crate::components::{
-    Button, CommandItem, DetailDrawer, EmptyState, EvidenceBadge, EvidenceLogRow, GoalCard,
-    IconButton, Panel, ScopeChip, StatusDot,
+    AgentEvidenceView, Button, CommandItem, DetailDrawer, EmptyState, EvidenceBadge,
+    EvidenceDetailDrawer, EvidenceRecordCard, GoalCard, IconButton, ManualDecisionEvidenceView,
+    Panel, ScopeChip, ScopeEvidenceView, StatusDot, TestEvidenceView, ValidationEvidenceView,
 };
 use crate::design::classes;
 use crate::model::{WorkbenchUiState, WorkspacePulseSummary};
@@ -10,7 +11,7 @@ use syu_task_model::{
     GoalPlanArtifact, GoalPlanConfidence, GoalPlanPersistentItem, GoalPlanScopeInclude,
     ScaffoldAction, ScaffoldUpdateKind,
 };
-use syu_workbench::WorkbenchActionId;
+use syu_workbench::{EvidenceRecord, WorkbenchActionId};
 
 const GRAPH_COLUMNS: usize = 4;
 const GRAPH_COLUMN_WIDTH: i32 = 210;
@@ -1012,21 +1013,80 @@ pub fn GoalPlanExportPanel(plan: GoalPlanArtifact) -> Element {
 }
 
 #[component]
+pub fn EvidenceTimeline(entries: Vec<EvidenceRecord>, goal_id: Option<String>) -> Element {
+    let filtered_entries = goal_id
+        .as_ref()
+        .map(|goal_id| {
+            entries
+                .iter()
+                .filter(|entry| entry.goal_id.as_ref() == Some(goal_id))
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .filter(|entries| !entries.is_empty())
+        .unwrap_or(entries);
+
+    rsx! {
+        div { class: "space-y-3",
+            if filtered_entries.is_empty() {
+                EmptyState {
+                    title: "Evidence timeline".to_string(),
+                    body: "Append evidence by running goal checks, test selection, or validation.".to_string()
+                }
+            } else {
+                for record in filtered_entries {
+                    { render_evidence_timeline_record(record) }
+                }
+            }
+        }
+    }
+}
+
+fn render_evidence_timeline_record(record: EvidenceRecord) -> Element {
+    match record.kind {
+        syu_workbench::WorkbenchEvidenceKind::ValidationReport => {
+            rsx! { ValidationEvidenceView { record } }
+        }
+        syu_workbench::WorkbenchEvidenceKind::TaskTestSelectionPlan => {
+            rsx! { TestEvidenceView { record } }
+        }
+        syu_workbench::WorkbenchEvidenceKind::BranchScopeReport
+        | syu_workbench::WorkbenchEvidenceKind::SpecImpactReport => {
+            rsx! { ScopeEvidenceView { record } }
+        }
+        syu_workbench::WorkbenchEvidenceKind::JobState => {
+            rsx! { AgentEvidenceView { record } }
+        }
+        syu_workbench::WorkbenchEvidenceKind::AssignmentState => {
+            rsx! { ManualDecisionEvidenceView { record } }
+        }
+        _ => rsx! { EvidenceRecordCard { record } },
+    }
+}
+
+#[component]
 pub fn EvidencePanel(ui: WorkbenchUiState) -> Element {
+    let active_goal = ui.payload.state.goals.active_goal().cloned();
+    let goal_id = active_goal.as_ref().map(|goal| goal.goal_id.clone());
+    let latest = ui.payload.state.evidence_timeline.entries.last().cloned();
     rsx! {
         Panel { class: classes::PANEL,
             div { class: classes::PANEL_INNER,
                 div { class: classes::SECTION_HEADER,
-                    h2 { class: classes::SECTION_TITLE, "Evidence" }
-                    ScopeChip { label: format!("{} entries", ui.payload.state.evidence_timeline.entries.len()) }
+                    h2 { class: classes::SECTION_TITLE, "Evidence Timeline" }
+                    if let Some(goal) = &active_goal {
+                        ScopeChip { label: format!("goal {}", goal.goal_id) }
+                    } else {
+                        ScopeChip { label: "workspace".to_string() }
+                    }
+                }
+                if let Some(record) = latest {
+                    EvidenceDetailDrawer { record }
                 }
                 div { class: classes::SECTION_BODY,
-                    if ui.payload.state.evidence_timeline.entries.is_empty() {
-                        EmptyState { title: "Evidence placeholder".to_string(), body: "The first implementation keeps proof visible here.".to_string() }
-                    } else {
-                        for entry in &ui.payload.state.evidence_timeline.entries {
-                            EvidenceLogRow { entry: entry.clone() }
-                        }
+                    EvidenceTimeline {
+                        entries: ui.payload.state.evidence_timeline.entries.clone(),
+                        goal_id: goal_id.clone(),
                     }
                 }
             }

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -1014,17 +1014,7 @@ pub fn GoalPlanExportPanel(plan: GoalPlanArtifact) -> Element {
 
 #[component]
 pub fn EvidenceTimeline(entries: Vec<EvidenceRecord>, goal_id: Option<String>) -> Element {
-    let filtered_entries = goal_id
-        .as_ref()
-        .map(|goal_id| {
-            entries
-                .iter()
-                .filter(|entry| entry.goal_id.as_ref() == Some(goal_id))
-                .cloned()
-                .collect::<Vec<_>>()
-        })
-        .filter(|entries| !entries.is_empty())
-        .unwrap_or(entries);
+    let filtered_entries = scoped_evidence_entries(entries, goal_id.as_deref());
 
     rsx! {
         div { class: "space-y-3",
@@ -1068,7 +1058,10 @@ fn render_evidence_timeline_record(record: EvidenceRecord) -> Element {
 pub fn EvidencePanel(ui: WorkbenchUiState) -> Element {
     let active_goal = ui.payload.state.goals.active_goal().cloned();
     let goal_id = active_goal.as_ref().map(|goal| goal.goal_id.clone());
-    let latest = ui.payload.state.evidence_timeline.entries.last().cloned();
+    let latest = latest_scoped_evidence(
+        &ui.payload.state.evidence_timeline.entries,
+        goal_id.as_deref(),
+    );
     rsx! {
         Panel { class: classes::PANEL,
             div { class: classes::PANEL_INNER,
@@ -1091,6 +1084,33 @@ pub fn EvidencePanel(ui: WorkbenchUiState) -> Element {
                 }
             }
         }
+    }
+}
+
+fn scoped_evidence_entries(
+    entries: Vec<EvidenceRecord>,
+    goal_id: Option<&str>,
+) -> Vec<EvidenceRecord> {
+    match goal_id {
+        Some(goal_id) => entries
+            .into_iter()
+            .filter(|entry| entry.goal_id.as_deref() == Some(goal_id))
+            .collect(),
+        None => entries,
+    }
+}
+
+fn latest_scoped_evidence(
+    entries: &[EvidenceRecord],
+    goal_id: Option<&str>,
+) -> Option<EvidenceRecord> {
+    match goal_id {
+        Some(goal_id) => entries
+            .iter()
+            .rev()
+            .find(|entry| entry.goal_id.as_deref() == Some(goal_id))
+            .cloned(),
+        None => entries.last().cloned(),
     }
 }
 

--- a/crates/syu-app-ui/src/lib.rs
+++ b/crates/syu-app-ui/src/lib.rs
@@ -7,12 +7,15 @@ pub mod model;
 use dioxus::prelude::{Asset, asset};
 
 pub use components::{
-    AffectedSpecPanel, AppShell, BranchScopeLens, ChangedFilesPanel, CommandPalette, EvidencePanel,
-    GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel,
-    GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel, OutOfScopePanel, OwnershipBadge,
-    OwnershipPanel, RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas,
-    RequestScopePanel, ScaffoldPreviewPanel, ScopeLegend, SpecImpactGraph, StatusBar,
-    SuggestedGoalSplitPanel, TestRecommendationPanel, WorkspacePulse,
+    AffectedSpecPanel, AgentEvidenceView, AppShell, BranchScopeLens, ChangedFilesPanel,
+    CommandOutputView, CommandPalette, EvidenceDetailDrawer, EvidencePanel, EvidenceRecordCard,
+    EvidenceTimeline, GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel,
+    GoalRail, GoalScopePanel, GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel,
+    ManualDecisionEvidenceView, OutOfScopePanel, OwnershipBadge, OwnershipPanel,
+    RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas, RequestScopePanel,
+    ScaffoldPreviewPanel, ScopeEvidenceView, ScopeLegend, SpecImpactGraph, StatusBar,
+    SuggestedGoalSplitPanel, TestEvidenceView, TestRecommendationPanel, ValidationEvidenceView,
+    WorkspacePulse,
 };
 pub use model::{
     CommandPaletteEntry, WorkbenchActionRunPreview, WorkbenchUiState, build_demo_state,

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -10,9 +10,11 @@ use syu_task_model::{
 };
 use syu_workbench::{
     ActiveGoalState, ActiveRequestState, AffectedSpecItem, BranchScopeEvidence, BranchScopeReport,
-    ChangedFileReport, EvidenceEntry, GoalListState, OutOfScopeChange, OwnershipStatus,
-    WorkbenchAction, WorkbenchActionAvailability, WorkbenchActionId, WorkbenchActionMutability,
-    WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchEvidenceKind, WorkbenchState,
+    ChangedFileReport, EvidenceCommand, EvidenceEntry, EvidenceRecord, EvidenceSeverity,
+    EvidenceSource, EvidenceStatus, EvidenceSubject, GoalListState, OutOfScopeChange,
+    OwnershipStatus, WorkbenchAction, WorkbenchActionAvailability, WorkbenchActionId,
+    WorkbenchActionMutability, WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchEvidenceKind,
+    WorkbenchState,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -359,16 +361,79 @@ pub fn build_demo_state() -> WorkbenchUiState {
         }),
         ..WorkbenchState::default()
     };
-    state.evidence_timeline.entries.push(EvidenceEntry {
-        kind: WorkbenchEvidenceKind::ValidationReport,
-        summary: "validation passed".to_string(),
-        action_id: None,
-    });
-    state.evidence_timeline.entries.push(EvidenceEntry {
-        kind: WorkbenchEvidenceKind::BranchScopeReport,
-        summary: "branch.scope connected specs, code, tests, and ownership".to_string(),
-        action_id: Some(WorkbenchActionId::BranchScope),
-    });
+    state.evidence_timeline.append(
+        EvidenceRecord::new(
+            WorkbenchEvidenceKind::ValidationReport,
+            EvidenceStatus::Pass,
+            "validation passed",
+            Some(EvidenceSource::Command {
+                command: "syu validate".to_string(),
+            }),
+        )
+        .with_subject(EvidenceSubject::Workspace)
+        .with_severity(EvidenceSeverity::Low)
+        .with_command(EvidenceCommand {
+            command: "validation.run".to_string(),
+            args: Vec::new(),
+        }),
+    );
+    state.evidence_timeline.append(
+        EvidenceRecord::new(
+            WorkbenchEvidenceKind::BranchScopeReport,
+            EvidenceStatus::Pass,
+            "branch.scope connected specs, code, tests, and ownership",
+            Some(EvidenceSource::Action {
+                action_id: Some(WorkbenchActionId::BranchScope),
+                action_label: Some("branch.scope".to_string()),
+            }),
+        )
+        .with_action_id(WorkbenchActionId::BranchScope)
+        .with_subject(EvidenceSubject::Branch)
+        .with_severity(EvidenceSeverity::Low)
+        .with_command(EvidenceCommand {
+            command: "branch.scope".to_string(),
+            args: Vec::new(),
+        })
+        .with_goal_id(Some("GOAL-WB-REQUEST-001".to_string())),
+    );
+    state.evidence_timeline.append(
+        EvidenceRecord::new(
+            WorkbenchEvidenceKind::TaskTestSelectionPlan,
+            EvidenceStatus::Pass,
+            "test selection covers the active goal",
+            Some(EvidenceSource::Action {
+                action_id: Some(WorkbenchActionId::GoalTestSelect),
+                action_label: Some("goal.test_select".to_string()),
+            }),
+        )
+        .with_action_id(WorkbenchActionId::GoalTestSelect)
+        .with_goal_id(Some("GOAL-WB-REQUEST-001".to_string()))
+        .with_subject(EvidenceSubject::Goal)
+        .with_severity(EvidenceSeverity::Low)
+        .with_command(EvidenceCommand {
+            command: "goal.test_select".to_string(),
+            args: Vec::new(),
+        }),
+    );
+    state.evidence_timeline.append(
+        EvidenceRecord::new(
+            WorkbenchEvidenceKind::GoalPlanCheckReport,
+            EvidenceStatus::Pass,
+            "goal check passed for origin/main...HEAD",
+            Some(EvidenceSource::Action {
+                action_id: Some(WorkbenchActionId::GoalCheck),
+                action_label: Some("goal.check".to_string()),
+            }),
+        )
+        .with_action_id(WorkbenchActionId::GoalCheck)
+        .with_goal_id(Some("GOAL-WB-REQUEST-001".to_string()))
+        .with_subject(EvidenceSubject::Goal)
+        .with_severity(EvidenceSeverity::Low)
+        .with_command(EvidenceCommand {
+            command: "goal.check".to_string(),
+            args: Vec::new(),
+        }),
+    );
     let mut ui = WorkbenchUiState::from_state(state);
     ui.command_palette_open = true;
     ui.command_query = "goal".to_string();

--- a/crates/syu-workbench-server/src/lib.rs
+++ b/crates/syu-workbench-server/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Component, Path as FsPath, PathBuf},
     sync::{Arc, OnceLock},
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use syu_code_intel::{
     BranchScopeEvidence, BranchScopeReport, ChangedFileReport, OwnershipStatus,
@@ -45,6 +45,48 @@ use tokio_stream::wrappers::BroadcastStream;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum EvidenceStatus {
+    Pending,
+    Pass,
+    Warn,
+    Fail,
+    Skipped,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSource {
+    Action {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_label: Option<String>,
+    },
+    Command {
+        command: String,
+    },
+    System {
+        component: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct EvidenceAttachment {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum WorkbenchEvidenceKind {
     RequestArtifact,
     ClassificationOutcome,
@@ -58,6 +100,10 @@ pub enum WorkbenchEvidenceKind {
     HistoryResponse,
     AssignmentState,
     JobState,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -209,15 +255,79 @@ impl Default for JobState {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct EvidenceEntry {
     pub kind: WorkbenchEvidenceKind,
+    pub status: EvidenceStatus,
     pub summary: String,
+    pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<EvidenceSource>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<EvidenceAttachment>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 pub struct EvidenceTimelineState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entries: Vec<EvidenceEntry>,
+}
+
+impl EvidenceTimelineState {
+    fn append(&mut self, entry: EvidenceEntry) {
+        self.entries.push(entry);
+    }
+}
+
+fn evidence_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn json_attachment<T: Serialize>(value: &T) -> EvidenceAttachment {
+    let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string());
+    const MAX_ATTACHMENT_CHARS: usize = 4096;
+    let truncated = json.len() > MAX_ATTACHMENT_CHARS;
+    let content = if truncated {
+        Some(json.chars().take(MAX_ATTACHMENT_CHARS).collect())
+    } else {
+        Some(json)
+    };
+    EvidenceAttachment {
+        label: "result".to_string(),
+        mime_type: Some("application/json".to_string()),
+        summary: Some(if truncated {
+            "truncated JSON payload".to_string()
+        } else {
+            "JSON payload".to_string()
+        }),
+        content,
+        truncated,
+    }
+}
+
+fn evidence_entry(
+    kind: WorkbenchEvidenceKind,
+    status: EvidenceStatus,
+    summary: impl Into<String>,
+    goal_id: Option<String>,
+    action_id: Option<String>,
+    source: Option<EvidenceSource>,
+    attachments: Vec<EvidenceAttachment>,
+) -> EvidenceEntry {
+    EvidenceEntry {
+        kind,
+        status,
+        summary: summary.into(),
+        timestamp: evidence_timestamp(),
+        goal_id,
+        action_id,
+        source,
+        attachments,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
@@ -1004,6 +1114,22 @@ async fn goal_test_select(
         let mut state = server.inner.state.write().await;
         state.goals.active_goal_mut().goal_id = id.clone();
         state.goals.active_goal_mut().test_selection = Some(selection.clone());
+        state.evidence_timeline.append(evidence_entry(
+            WorkbenchEvidenceKind::TaskTestSelectionPlan,
+            EvidenceStatus::Pass,
+            format!(
+                "selected {} tests for {}",
+                selection.commands.len(),
+                selection.goal_id
+            ),
+            Some(id.clone()),
+            Some("goal.test_select".to_string()),
+            Some(EvidenceSource::Action {
+                action_id: Some("goal.test_select".to_string()),
+                action_label: Some("goal.test_select".to_string()),
+            }),
+            vec![json_attachment(&selection)],
+        ));
     }
     server
         .inner
@@ -1026,6 +1152,37 @@ async fn goal_check(
         let mut state = server.inner.state.write().await;
         state.goals.active_goal_mut().goal_id = id.clone();
         state.goals.active_goal_mut().check_report = Some(report.clone());
+        let status = if report
+            .issues
+            .iter()
+            .any(|issue| issue.severity == syu_domain::Severity::Error)
+        {
+            EvidenceStatus::Fail
+        } else if report
+            .issues
+            .iter()
+            .any(|issue| issue.severity == syu_domain::Severity::Warning)
+        {
+            EvidenceStatus::Warn
+        } else {
+            EvidenceStatus::Pass
+        };
+        state.evidence_timeline.append(evidence_entry(
+            WorkbenchEvidenceKind::GoalPlanCheckReport,
+            status,
+            if matches!(status, EvidenceStatus::Pass) {
+                format!("goal check passed for {}", report.plan_path)
+            } else {
+                format!("goal check found {} issues", report.issues.len())
+            },
+            Some(id.clone()),
+            Some("goal.check".to_string()),
+            Some(EvidenceSource::Action {
+                action_id: Some("goal.check".to_string()),
+                action_label: Some("goal.check".to_string()),
+            }),
+            vec![json_attachment(&report)],
+        ));
     }
     server
         .inner
@@ -1694,6 +1851,42 @@ async fn execute_action(
             let plan = serde_json::from_value::<GoalPlanArtifact>(body.clone())
                 .context("goal plan artifact required")?;
             let report = build_goal_check(server, &plan, "origin/main...HEAD").await;
+            {
+                let mut state = server.inner.state.write().await;
+                state.goals.active_goal_mut().goal_id = plan.goal.id.clone();
+                state.goals.active_goal_mut().check_report = Some(report.clone());
+                let status = if report
+                    .issues
+                    .iter()
+                    .any(|issue| issue.severity == syu_domain::Severity::Error)
+                {
+                    EvidenceStatus::Fail
+                } else if report
+                    .issues
+                    .iter()
+                    .any(|issue| issue.severity == syu_domain::Severity::Warning)
+                {
+                    EvidenceStatus::Warn
+                } else {
+                    EvidenceStatus::Pass
+                };
+                state.evidence_timeline.append(evidence_entry(
+                    WorkbenchEvidenceKind::GoalPlanCheckReport,
+                    status,
+                    if matches!(status, EvidenceStatus::Pass) {
+                        format!("goal check passed for {}", report.plan_path)
+                    } else {
+                        format!("goal check found {} issues", report.issues.len())
+                    },
+                    Some(plan.goal.id.clone()),
+                    Some(action_id.to_string()),
+                    Some(EvidenceSource::Action {
+                        action_id: Some(action_id.to_string()),
+                        action_label: Some(action_id.to_string()),
+                    }),
+                    vec![json_attachment(&report)],
+                ));
+            }
             ActionRunResponse {
                 action_id: action_id.to_string(),
                 event: WorkbenchEvent::GoalChecked {
@@ -1720,6 +1913,27 @@ async fn execute_action(
                 },
                 warnings: Vec::new(),
             };
+            {
+                let mut state = server.inner.state.write().await;
+                state.goals.active_goal_mut().goal_id = plan.goal.id.clone();
+                state.goals.active_goal_mut().test_selection = Some(selection.clone());
+                state.evidence_timeline.append(evidence_entry(
+                    WorkbenchEvidenceKind::TaskTestSelectionPlan,
+                    EvidenceStatus::Pass,
+                    format!(
+                        "selected {} tests for {}",
+                        selection.commands.len(),
+                        selection.goal_id
+                    ),
+                    Some(plan.goal.id.clone()),
+                    Some(action_id.to_string()),
+                    Some(EvidenceSource::Action {
+                        action_id: Some(action_id.to_string()),
+                        action_label: Some(action_id.to_string()),
+                    }),
+                    vec![json_attachment(&selection)],
+                ));
+            }
             ActionRunResponse {
                 action_id: action_id.to_string(),
                 event: WorkbenchEvent::GoalTestsSelected {
@@ -1796,8 +2010,28 @@ async fn execute_action(
         }
         "validation.run" => ActionRunResponse {
             action_id: action_id.to_string(),
-            event: WorkbenchEvent::ValidationUpdated {
-                summary: "validation snapshot refreshed".to_string(),
+            event: {
+                {
+                    let mut state = server.inner.state.write().await;
+                    state
+                        .workspace
+                        .get_or_insert_with(WorkspaceSnapshot::default)
+                        .validation_summary = Some("validation snapshot refreshed".to_string());
+                    state.evidence_timeline.append(evidence_entry(
+                        WorkbenchEvidenceKind::ValidationReport,
+                        EvidenceStatus::Pass,
+                        "validation snapshot refreshed",
+                        None,
+                        Some(action_id.to_string()),
+                        Some(EvidenceSource::Command {
+                            command: action_id.to_string(),
+                        }),
+                        vec![json_attachment(&serde_json::json!({"status": "ok"}))],
+                    ));
+                }
+                WorkbenchEvent::ValidationUpdated {
+                    summary: "validation snapshot refreshed".to_string(),
+                }
             },
             result: serde_json::json!({"status": "ok"}),
         },
@@ -2017,6 +2251,96 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["range"], "HEAD...HEAD");
         assert_eq!(json["plan_path"], "request.yaml");
+
+        let snapshot = server.inner.state.read().await.clone();
+        assert_eq!(snapshot.evidence_timeline.entries.len(), 1);
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].kind,
+            WorkbenchEvidenceKind::GoalPlanCheckReport
+        );
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].goal_id.as_deref(),
+            Some("goal-1")
+        );
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].status,
+            EvidenceStatus::Pass
+        );
+    }
+
+    #[tokio::test]
+    async fn goal_test_select_endpoint_records_evidence() {
+        let server = test_server();
+        let plan = goal_plan_from_request(
+            &server,
+            &RequestPlanRequest {
+                request: RequestArtifact {
+                    version: 1,
+                    request: "Select tests for the goal".to_string(),
+                    context: Default::default(),
+                },
+                request_path: Some("request.yaml".to_string()),
+            },
+        )
+        .await;
+        let body = serde_json::to_string(&plan).expect("plan json");
+        let (status, json) = json_response(
+            server.router(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/goals/goal-1/test-select")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("request"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["goal_id"], "goal-1");
+
+        let snapshot = server.inner.state.read().await.clone();
+        assert_eq!(snapshot.evidence_timeline.entries.len(), 1);
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].kind,
+            WorkbenchEvidenceKind::TaskTestSelectionPlan
+        );
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].goal_id.as_deref(),
+            Some("goal-1")
+        );
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].status,
+            EvidenceStatus::Pass
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_action_records_evidence() {
+        let server = test_server();
+        let (status, json) = json_response(
+            server.router(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/actions/validation.run/run")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .expect("request"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["result"]["status"], "ok");
+
+        let snapshot = server.inner.state.read().await.clone();
+        assert_eq!(snapshot.evidence_timeline.entries.len(), 1);
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].kind,
+            WorkbenchEvidenceKind::ValidationReport
+        );
+        assert_eq!(
+            snapshot.evidence_timeline.entries[0].status,
+            EvidenceStatus::Pass
+        );
     }
 
     #[tokio::test]

--- a/crates/syu-workbench-server/src/lib.rs
+++ b/crates/syu-workbench-server/src/lib.rs
@@ -252,7 +252,7 @@ impl Default for JobState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EvidenceEntry {
     pub kind: WorkbenchEvidenceKind,
     pub status: EvidenceStatus,
@@ -268,7 +268,7 @@ pub struct EvidenceEntry {
     pub attachments: Vec<EvidenceAttachment>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct EvidenceTimelineState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entries: Vec<EvidenceEntry>,

--- a/crates/syu-workbench/Cargo.toml
+++ b/crates/syu-workbench/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
 syu-actions = { path = "../syu-actions" }
 syu-code-intel = { path = "../syu-code-intel" }
 syu-task-model = { path = "../syu-task-model" }

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -1,5 +1,9 @@
-use serde::Serialize;
-use std::{path::PathBuf, sync::OnceLock};
+use serde::{Deserialize, Serialize};
+use std::{
+    path::PathBuf,
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 pub use syu_actions::{HistoryResponse, ValidationReport};
 pub use syu_code_intel::{
@@ -12,7 +16,7 @@ pub use syu_task_model::{
     RequestArtifactContext, ScaffoldPlan, ScopeOutcome, TaskTestSelectionPlan,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkbenchActionRisk {
     Low,
@@ -20,7 +24,7 @@ pub enum WorkbenchActionRisk {
     High,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkbenchActionMutability {
     ReadOnly,
@@ -43,7 +47,7 @@ impl WorkbenchActionMutability {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WorkbenchActionId {
     #[serde(rename = "request.new")]
     RequestNew,
@@ -102,7 +106,7 @@ impl WorkbenchActionId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkbenchActionFunction {
     ScaffoldRequest,
@@ -142,7 +146,7 @@ impl WorkbenchActionFunction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkbenchActionOutputEvent {
     RequestCreated,
@@ -161,7 +165,7 @@ pub enum WorkbenchActionOutputEvent {
     AgentRunQueued,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkbenchEvidenceKind {
     RequestArtifact,
@@ -197,6 +201,429 @@ impl WorkbenchEvidenceKind {
             Self::JobState => "job_state",
         }
     }
+}
+
+pub type EvidenceKind = WorkbenchEvidenceKind;
+pub type EvidenceSummary = String;
+pub type EvidenceTimeline = EvidenceTimelineState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceStatus {
+    Pending,
+    Pass,
+    Warn,
+    Fail,
+    Skipped,
+    Unknown,
+}
+
+impl EvidenceStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Pass => "pass",
+            Self::Warn => "warn",
+            Self::Fail => "fail",
+            Self::Skipped => "skipped",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSeverity {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSubject {
+    Workspace,
+    Request,
+    Goal,
+    Branch,
+    SpecItem,
+    File,
+    Test,
+    Assignment,
+    AgentRun,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct EvidenceCommand {
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct EvidenceAttachment {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSource {
+    Action {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_id: Option<WorkbenchActionId>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        action_label: Option<String>,
+    },
+    Command {
+        command: String,
+    },
+    Manual {
+        actor: String,
+    },
+    System {
+        component: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceRecord {
+    pub kind: EvidenceKind,
+    pub status: EvidenceStatus,
+    pub summary: EvidenceSummary,
+    pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<EvidenceSubject>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<EvidenceSeverity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<EvidenceSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<WorkbenchActionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<EvidenceCommand>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<EvidenceAttachment>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub related_spec_id: Option<String>,
+}
+
+pub type EvidenceEntry = EvidenceRecord;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct EvidenceTimelineFilter {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<EvidenceKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<EvidenceStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_action_id: Option<WorkbenchActionId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub related_spec_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since_timestamp: Option<u64>,
+}
+
+impl EvidenceRecord {
+    pub fn new(
+        kind: EvidenceKind,
+        status: EvidenceStatus,
+        summary: impl Into<String>,
+        source: Option<EvidenceSource>,
+    ) -> Self {
+        Self {
+            kind,
+            status,
+            summary: summary.into(),
+            timestamp: evidence_timestamp(),
+            goal_id: None,
+            subject: None,
+            severity: None,
+            source,
+            action_id: None,
+            command: None,
+            attachments: Vec::new(),
+            related_spec_id: None,
+        }
+    }
+
+    pub fn with_goal_id(mut self, goal_id: Option<String>) -> Self {
+        self.goal_id = goal_id;
+        self
+    }
+
+    pub fn with_subject(mut self, subject: EvidenceSubject) -> Self {
+        self.subject = Some(subject);
+        self
+    }
+
+    pub fn with_severity(mut self, severity: EvidenceSeverity) -> Self {
+        self.severity = Some(severity);
+        self
+    }
+
+    pub fn with_action_id(mut self, action_id: WorkbenchActionId) -> Self {
+        self.action_id = Some(action_id);
+        self
+    }
+
+    pub fn with_command(mut self, command: EvidenceCommand) -> Self {
+        self.command = Some(command);
+        self
+    }
+
+    pub fn with_related_spec_id(mut self, related_spec_id: Option<String>) -> Self {
+        self.related_spec_id = related_spec_id;
+        self
+    }
+
+    pub fn with_attachment(mut self, attachment: EvidenceAttachment) -> Self {
+        self.attachments.push(attachment);
+        self
+    }
+}
+
+impl EvidenceTimelineState {
+    pub fn append(&mut self, record: EvidenceRecord) {
+        self.entries.push(record);
+    }
+
+    pub fn append_action_result(
+        &mut self,
+        action_id: WorkbenchActionId,
+        goal_id: Option<String>,
+        result: &WorkbenchActionResult,
+    ) {
+        self.append(evidence_record_for_action(action_id, goal_id, result));
+    }
+}
+
+fn evidence_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn truncated_json<T: Serialize>(value: &T) -> EvidenceAttachment {
+    let json = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string());
+    const MAX_ATTACHMENT_CHARS: usize = 4096;
+    let truncated = json.len() > MAX_ATTACHMENT_CHARS;
+    let content = if truncated {
+        Some(json.chars().take(MAX_ATTACHMENT_CHARS).collect())
+    } else {
+        Some(json)
+    };
+
+    EvidenceAttachment {
+        label: "result".to_string(),
+        mime_type: Some("application/json".to_string()),
+        summary: Some(if truncated {
+            "truncated JSON payload".to_string()
+        } else {
+            "JSON payload".to_string()
+        }),
+        content,
+        truncated,
+    }
+}
+
+fn evidence_record_for_action(
+    action_id: WorkbenchActionId,
+    goal_id: Option<String>,
+    result: &WorkbenchActionResult,
+) -> EvidenceRecord {
+    let kind = result.evidence_kind();
+    let (status, severity, subject, summary) = match result {
+        WorkbenchActionResult::RequestArtifact(_) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Request),
+            "request artifact captured".to_string(),
+        ),
+        WorkbenchActionResult::ClassificationOutcome(outcome) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Request),
+            format!("request classified as {}", outcome.classification.label()),
+        ),
+        WorkbenchActionResult::ScopeOutcome(outcome) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Request),
+            format!(
+                "request scope identified {} requirements",
+                outcome.requirements.len()
+            ),
+        ),
+        WorkbenchActionResult::ScaffoldPlan(plan) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Request),
+            format!("scaffold preview includes {} updates", plan.updates.len()),
+        ),
+        WorkbenchActionResult::GoalPlanArtifact(plan) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Goal),
+            format!("goal plan generated for {}", plan.goal.id),
+        ),
+        WorkbenchActionResult::TaskTestSelectionPlan(plan) => (
+            if plan.commands.is_empty() {
+                EvidenceStatus::Pending
+            } else {
+                EvidenceStatus::Pass
+            },
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Goal),
+            format!(
+                "selected {} tests for {}",
+                plan.commands.len(),
+                plan.goal_id
+            ),
+        ),
+        WorkbenchActionResult::GoalPlanCheckReport(report) => (
+            if report.error_count() > 0 {
+                EvidenceStatus::Fail
+            } else if report.warning_count() > 0 {
+                EvidenceStatus::Warn
+            } else {
+                EvidenceStatus::Pass
+            },
+            Some(if report.error_count() > 0 {
+                EvidenceSeverity::High
+            } else if report.warning_count() > 0 {
+                EvidenceSeverity::Medium
+            } else {
+                EvidenceSeverity::Low
+            }),
+            Some(EvidenceSubject::Goal),
+            if report.passed() {
+                format!("goal check passed for {}", report.plan_path)
+            } else {
+                format!("goal check found {} issues", report.issues.len())
+            },
+        ),
+        WorkbenchActionResult::BranchScopeReport(report) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Branch),
+            format!(
+                "branch scope summarized {} files",
+                report.changed_files.len()
+            ),
+        ),
+        WorkbenchActionResult::SpecImpactReport(report) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::SpecItem),
+            format!(
+                "spec impact mapped {} affected items",
+                report.affected_items.len()
+            ),
+        ),
+        WorkbenchActionResult::ValidationReport(report) => (
+            if report.is_success() {
+                EvidenceStatus::Pass
+            } else {
+                EvidenceStatus::Fail
+            },
+            Some(if report.is_success() {
+                if report.issues.is_empty() {
+                    EvidenceSeverity::Low
+                } else {
+                    EvidenceSeverity::Medium
+                }
+            } else {
+                EvidenceSeverity::High
+            }),
+            Some(EvidenceSubject::Workspace),
+            if report.is_success() {
+                "workspace validation passed".to_string()
+            } else {
+                format!("workspace validation found {} issues", report.issues.len())
+            },
+        ),
+        WorkbenchActionResult::HistoryResponse(history) => (
+            EvidenceStatus::Pass,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Workspace),
+            format!("history loaded for {} {}", history.entity_kind, history.id),
+        ),
+        WorkbenchActionResult::AssignmentState(assignment) => (
+            EvidenceStatus::Pending,
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::Assignment),
+            match &assignment.goal_id {
+                Some(goal_id) => format!("assignment created for {goal_id}"),
+                None => "assignment created".to_string(),
+            },
+        ),
+        WorkbenchActionResult::JobState(job) => (
+            match job.status {
+                JobStatus::Idle | JobStatus::Queued | JobStatus::Running => EvidenceStatus::Pending,
+                JobStatus::Completed => EvidenceStatus::Pass,
+                JobStatus::Failed => EvidenceStatus::Fail,
+            },
+            Some(EvidenceSeverity::Low),
+            Some(EvidenceSubject::AgentRun),
+            job.message
+                .clone()
+                .unwrap_or_else(|| format!("job {}", job.status.label())),
+        ),
+    };
+
+    let source = Some(EvidenceSource::Action {
+        action_id: Some(action_id),
+        action_label: Some(action_id.label().to_string()),
+    });
+    let command = match result {
+        WorkbenchActionResult::ValidationReport(_) => Some(EvidenceCommand {
+            command: "validation.run".to_string(),
+            args: Vec::new(),
+        }),
+        WorkbenchActionResult::GoalPlanCheckReport(_) => Some(EvidenceCommand {
+            command: "goal.check".to_string(),
+            args: Vec::new(),
+        }),
+        WorkbenchActionResult::TaskTestSelectionPlan(_) => Some(EvidenceCommand {
+            command: "goal.test_select".to_string(),
+            args: Vec::new(),
+        }),
+        _ => None,
+    };
+    let attachment = truncated_json(result);
+
+    EvidenceRecord::new(kind, status, summary, source)
+        .with_goal_id(goal_id)
+        .with_subject(subject.expect("subject is always set"))
+        .with_severity(severity.expect("severity is always set"))
+        .with_action_id(action_id)
+        .with_related_spec_id(None)
+        .with_attachment(attachment)
+        .with_command(command.unwrap_or(EvidenceCommand {
+            command: action_id.label().to_string(),
+            args: Vec::new(),
+        }))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -445,6 +872,18 @@ pub enum JobStatus {
     Failed,
 }
 
+impl JobStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct JobState {
     pub status: JobStatus,
@@ -462,14 +901,6 @@ impl Default for JobState {
             message: None,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct EvidenceEntry {
-    pub kind: WorkbenchEvidenceKind,
-    pub summary: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub action_id: Option<WorkbenchActionId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
@@ -545,12 +976,21 @@ impl WorkbenchState {
     }
 
     pub fn apply_result(&mut self, action_id: WorkbenchActionId, result: &WorkbenchActionResult) {
-        let evidence_kind = result.evidence_kind();
-        self.evidence_timeline.entries.push(EvidenceEntry {
-            kind: evidence_kind,
-            summary: format!("{} produced {}", action_id.label(), evidence_kind.label()),
-            action_id: Some(action_id),
-        });
+        let active_goal_id = self.goals.active_goal().map(|goal| goal.goal_id.clone());
+        let evidence_goal_id = match result {
+            WorkbenchActionResult::GoalPlanArtifact(plan) => Some(plan.goal.id.clone()),
+            WorkbenchActionResult::TaskTestSelectionPlan(selection) => {
+                Some(selection.goal_id.clone())
+            }
+            WorkbenchActionResult::GoalPlanCheckReport(_) => active_goal_id.clone(),
+            WorkbenchActionResult::AssignmentState(assignment) => {
+                assignment.goal_id.clone().or(active_goal_id.clone())
+            }
+            WorkbenchActionResult::JobState(_) => active_goal_id.clone(),
+            _ => None,
+        };
+        self.evidence_timeline
+            .append_action_result(action_id, evidence_goal_id, result);
 
         match result {
             WorkbenchActionResult::RequestArtifact(artifact) => {
@@ -1222,6 +1662,75 @@ mod tests {
         assert_eq!(
             state.evidence_timeline.entries[0].kind,
             WorkbenchEvidenceKind::HistoryResponse
+        );
+    }
+
+    #[test]
+    fn evidence_record_serializes_with_goal_and_attachment() {
+        let record = EvidenceRecord::new(
+            WorkbenchEvidenceKind::GoalPlanCheckReport,
+            EvidenceStatus::Warn,
+            "goal check found issues",
+            Some(EvidenceSource::Action {
+                action_id: Some(WorkbenchActionId::GoalCheck),
+                action_label: Some("goal.check".to_string()),
+            }),
+        )
+        .with_goal_id(Some("goal-1".to_string()))
+        .with_action_id(WorkbenchActionId::GoalCheck)
+        .with_subject(EvidenceSubject::Goal)
+        .with_severity(EvidenceSeverity::Medium)
+        .with_command(EvidenceCommand {
+            command: "goal.check".to_string(),
+            args: Vec::new(),
+        })
+        .with_attachment(EvidenceAttachment {
+            label: "result".to_string(),
+            mime_type: Some("application/json".to_string()),
+            summary: Some("JSON payload".to_string()),
+            content: Some("{\"ok\":false}".to_string()),
+            truncated: false,
+        });
+
+        let json = serde_json::to_string(&record).expect("evidence record should serialize");
+        let roundtrip: EvidenceRecord =
+            serde_json::from_str(&json).expect("evidence record should roundtrip");
+
+        assert_eq!(roundtrip.goal_id.as_deref(), Some("goal-1"));
+        assert_eq!(roundtrip.action_id, Some(WorkbenchActionId::GoalCheck));
+        assert_eq!(roundtrip.status, EvidenceStatus::Warn);
+        assert_eq!(roundtrip.attachments.len(), 1);
+    }
+
+    #[test]
+    fn goal_check_appends_goal_scoped_evidence() {
+        let mut state = WorkbenchState::default();
+        state.goals.active.push(ActiveGoalState {
+            goal_id: "goal-1".to_string(),
+            ..ActiveGoalState::default()
+        });
+
+        state.apply_result(
+            WorkbenchActionId::GoalCheck,
+            &WorkbenchActionResult::GoalPlanCheckReport(GoalPlanCheckReport {
+                plan_path: "plan.yaml".to_string(),
+                range: "HEAD~1..HEAD".to_string(),
+                changed_files: vec!["src/lib.rs".to_string()],
+                issues: Vec::new(),
+            }),
+        );
+
+        assert_eq!(state.evidence_timeline.entries.len(), 1);
+        let entry = &state.evidence_timeline.entries[0];
+        assert_eq!(entry.goal_id.as_deref(), Some("goal-1"));
+        assert_eq!(entry.status, EvidenceStatus::Pass);
+        assert_eq!(entry.action_id, Some(WorkbenchActionId::GoalCheck));
+        assert_eq!(
+            entry
+                .command
+                .as_ref()
+                .map(|command| command.command.as_str()),
+            Some("goal.check")
         );
     }
 

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -321,7 +321,7 @@ pub struct EvidenceRecord {
 
 pub type EvidenceEntry = EvidenceRecord;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct EvidenceTimelineFilter {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub goal_id: Option<String>,
@@ -903,7 +903,7 @@ impl Default for JobState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct EvidenceTimelineState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entries: Vec<EvidenceEntry>,
@@ -1700,6 +1700,32 @@ mod tests {
         assert_eq!(roundtrip.action_id, Some(WorkbenchActionId::GoalCheck));
         assert_eq!(roundtrip.status, EvidenceStatus::Warn);
         assert_eq!(roundtrip.attachments.len(), 1);
+    }
+
+    #[test]
+    fn evidence_timeline_serializes_for_export() {
+        let mut timeline = EvidenceTimelineState::default();
+        timeline.append(
+            EvidenceRecord::new(
+                WorkbenchEvidenceKind::TaskTestSelectionPlan,
+                EvidenceStatus::Pass,
+                "selected tests for goal",
+                Some(EvidenceSource::Action {
+                    action_id: Some(WorkbenchActionId::GoalTestSelect),
+                    action_label: Some("goal.test_select".to_string()),
+                }),
+            )
+            .with_goal_id(Some("goal-1".to_string()))
+            .with_action_id(WorkbenchActionId::GoalTestSelect),
+        );
+
+        let json = serde_json::to_string(&timeline).expect("evidence timeline should serialize");
+        let roundtrip: EvidenceTimelineState =
+            serde_json::from_str(&json).expect("evidence timeline should roundtrip");
+
+        assert_eq!(roundtrip.entries.len(), 1);
+        assert_eq!(roundtrip.entries[0].goal_id.as_deref(), Some("goal-1"));
+        assert_eq!(roundtrip.entries[0].status, EvidenceStatus::Pass);
     }
 
     #[test]

--- a/docs/generated/site-spec/features/workbench/evidence.md
+++ b/docs/generated/site-spec/features/workbench/evidence.md
@@ -17,9 +17,9 @@ description: "Generated reference for docs/syu/features/workbench/evidence.yaml"
 
 ### Features
 
-- **id**: FEAT-WORKBENCH-005
+- **id**: FEAT-WORKBENCH-EVIDENCE-001
   - **title**: Evidence trail in the Workbench
-  - **summary**: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed.
+  - **summary**: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed through a goal-scoped evidence timeline.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-WORKBENCH-002
@@ -39,9 +39,9 @@ category: Workbench
 version: 1
 
 features:
-  - id: FEAT-WORKBENCH-005
+  - id: FEAT-WORKBENCH-EVIDENCE-001
     title: Evidence trail in the Workbench
-    summary: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed.
+    summary: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed through a goal-scoped evidence timeline.
     status: implemented
     linked_requirements:
       - REQ-WORKBENCH-002

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -69,7 +69,7 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
     - FEAT-WORKBENCH-COMMAND-PALETTE-001
     - FEAT-WORKBENCH-DESIGN-TOKENS-001
     - FEAT-WORKBENCH-003
-    - FEAT-WORKBENCH-005
+    - FEAT-WORKBENCH-EVIDENCE-001
   - **tests**:
     - **markdown**:
       - **file**: docs/guide/workbench.md
@@ -84,6 +84,7 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
           - filters_actions_by_query
           - read_only_action_returns_placeholder_preview
           - registry_loaded_from_server_payload
+          - evidence_panel_renders_goal_scoped_timeline
 - **id**: REQ-WORKBENCH-003
   - **title**: Goal splitting for large change requests
   - **description**:
@@ -167,7 +168,7 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
   - **linked_policies**:
     - POL-005
   - **linked_features**:
-    - FEAT-WORKBENCH-005
+    - FEAT-WORKBENCH-EVIDENCE-001
     - FEAT-WORKBENCH-006
   - **tests**:
     - **markdown**:
@@ -278,7 +279,7 @@ requirements:
       - FEAT-WORKBENCH-COMMAND-PALETTE-001
       - FEAT-WORKBENCH-DESIGN-TOKENS-001
       - FEAT-WORKBENCH-003
-      - FEAT-WORKBENCH-005
+      - FEAT-WORKBENCH-EVIDENCE-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -293,6 +294,7 @@ requirements:
             - filters_actions_by_query
             - read_only_action_returns_placeholder_preview
             - registry_loaded_from_server_payload
+            - evidence_panel_renders_goal_scoped_timeline
   - id: REQ-WORKBENCH-003
     title: Goal splitting for large change requests
     description: |
@@ -373,7 +375,7 @@ requirements:
     linked_policies:
       - POL-005
     linked_features:
-      - FEAT-WORKBENCH-005
+      - FEAT-WORKBENCH-EVIDENCE-001
       - FEAT-WORKBENCH-006
     tests:
       markdown:

--- a/docs/guide/workbench.md
+++ b/docs/guide/workbench.md
@@ -54,6 +54,11 @@ Goal Plan YAML exported from the Workbench must stay compatible with
 - Completion check: compare the result against the goal plan and required
   evidence before closing the loop.
 
+The Workbench evidence rail keeps a goal-scoped timeline of typed evidence
+records. Each record carries a status, source, timestamp, summary, and optional
+attachment so the panel can show validation, test selection, goal checks, and
+manual decisions without collapsing them into a single log blob.
+
 ## Spec Impact and Branch Scope
 
 Spec Impact Graph shows how philosophy, policy, requirement, feature, changed

--- a/docs/syu/features/workbench/evidence.yaml
+++ b/docs/syu/features/workbench/evidence.yaml
@@ -2,9 +2,9 @@ category: Workbench
 version: 1
 
 features:
-  - id: FEAT-WORKBENCH-005
+  - id: FEAT-WORKBENCH-EVIDENCE-001
     title: Evidence trail in the Workbench
-    summary: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed.
+    summary: Keep evidence attached to the active request and goal so progress, handoffs, and completion checks stay proof-backed through a goal-scoped evidence timeline.
     status: implemented
     linked_requirements:
       - REQ-WORKBENCH-002

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -51,7 +51,7 @@ requirements:
       - FEAT-WORKBENCH-COMMAND-PALETTE-001
       - FEAT-WORKBENCH-DESIGN-TOKENS-001
       - FEAT-WORKBENCH-003
-      - FEAT-WORKBENCH-005
+      - FEAT-WORKBENCH-EVIDENCE-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -66,6 +66,7 @@ requirements:
             - filters_actions_by_query
             - read_only_action_returns_placeholder_preview
             - registry_loaded_from_server_payload
+            - evidence_panel_renders_goal_scoped_timeline
   - id: REQ-WORKBENCH-003
     title: Goal splitting for large change requests
     description: |
@@ -146,7 +147,7 @@ requirements:
     linked_policies:
       - POL-005
     linked_features:
-      - FEAT-WORKBENCH-005
+      - FEAT-WORKBENCH-EVIDENCE-001
       - FEAT-WORKBENCH-006
     tests:
       markdown:

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -79,6 +79,7 @@ fn evidence_panel_renders_goal_scoped_timeline() {
     assert!(html.contains("goal GOAL-WB-REQUEST-001"));
     assert!(html.contains("goal.test_select"));
     assert!(html.contains("goal.check"));
+    assert!(!html.contains("validation passed"));
 }
 
 #[test]

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -63,7 +63,22 @@ fn evidence_panel_renders_placeholder_when_empty() {
         EvidencePanel { ui }
     });
 
-    assert!(html.contains("Evidence placeholder"));
+    assert!(html.contains("Evidence timeline"));
+    assert!(html.contains("Append evidence by running goal checks"));
+}
+
+#[test]
+fn evidence_panel_renders_goal_scoped_timeline() {
+    let ui = build_demo_state();
+
+    let html = render_element(rsx! {
+        EvidencePanel { ui }
+    });
+
+    assert!(html.contains("Evidence Timeline"));
+    assert!(html.contains("goal GOAL-WB-REQUEST-001"));
+    assert!(html.contains("goal.test_select"));
+    assert!(html.contains("goal.check"));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Added a typed evidence record model with status, source, timestamp, attachments, and goal scope.
- Reworked the Workbench evidence rail into a goal-scoped timeline with richer cards and latest-record details.
- Appended evidence from goal.check, goal.test_select, and validation actions in the UI model and server.

Validation:
- cargo test -p syu --test workbench_smoke
- cargo test -p syu-workbench --lib
- cargo test -p syu-workbench-server --lib
- cargo fmt --all
- git commit / git push hooks ran syu validate . successfully

Closes #741
