### PR TITLE
FEAT-WORKBENCH-ASSIGNMENT-001 REQ-WORKBENCH-005: Add scoped assignment runner for Goal Plans

### DIFF
--- a/crates/syu-app-ui/src/components/mod.rs
+++ b/crates/syu-app-ui/src/components/mod.rs
@@ -8,11 +8,13 @@ pub use primitives::{
     ValidationEvidenceView,
 };
 pub use shell::{
-    AffectedSpecPanel, AppShell, BranchScopeLens, ChangedFilesPanel, CommandPalette, EvidencePanel,
-    EvidenceTimeline, GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel,
-    GoalRail, GoalScopePanel, GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel,
+    AffectedSpecPanel, AgentRunPanel, AppShell, AssignGoalDialog, AssigneeSelector,
+    AssignmentConstraintPanel, AssignmentEvidencePanel, AssignmentPromptPreview, BranchScopeLens,
+    ChangedFilesPanel, CommandPalette, EvidencePanel, EvidenceTimeline, GoalCanvas,
+    GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel,
+    GoalTestPlanPanel, GraphEdge, GraphNode, HumanAssignmentPanel, ImpactSummaryPanel,
     OutOfScopePanel, OwnershipBadge, OwnershipPanel, RequestClassificationPanel,
     RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel,
-    ScopeLegend, SpecImpactGraph, StatusBar, SuggestedGoalSplitPanel, TestRecommendationPanel,
-    WorkspacePulse,
+    ScopeGuardPreview, ScopeLegend, SpecImpactGraph, StatusBar, SuggestedGoalSplitPanel,
+    TestRecommendationPanel, WorkspacePulse,
 };

--- a/crates/syu-app-ui/src/components/primitives.rs
+++ b/crates/syu-app-ui/src/components/primitives.rs
@@ -342,6 +342,7 @@ fn evidence_tone(kind: WorkbenchEvidenceKind) -> &'static str {
         WorkbenchEvidenceKind::GoalPlanCheckReport => "text-evidence-warn",
         WorkbenchEvidenceKind::HistoryResponse => "text-evidence-pending",
         WorkbenchEvidenceKind::AssignmentState => "text-goal",
+        WorkbenchEvidenceKind::AgentRun => "text-evidence-pending",
         WorkbenchEvidenceKind::JobState => "text-evidence-fail",
         _ => "text-foreground/70",
     }

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -1,7 +1,8 @@
 use crate::components::{
-    AgentEvidenceView, Button, CommandItem, DetailDrawer, EmptyState, EvidenceBadge,
-    EvidenceDetailDrawer, EvidenceRecordCard, GoalCard, IconButton, ManualDecisionEvidenceView,
-    Panel, ScopeChip, ScopeEvidenceView, StatusDot, TestEvidenceView, ValidationEvidenceView,
+    AgentEvidenceView, Button, CommandItem, CommandOutputView, DetailDrawer, EmptyState,
+    EvidenceBadge, EvidenceDetailDrawer, EvidenceRecordCard, GoalCard, IconButton,
+    ManualDecisionEvidenceView, Panel, ScopeChip, ScopeEvidenceView, StatusDot, TestEvidenceView,
+    ValidationEvidenceView,
 };
 use crate::design::classes;
 use crate::model::{WorkbenchUiState, WorkspacePulseSummary};
@@ -10,6 +11,10 @@ use std::collections::HashMap;
 use syu_task_model::{
     GoalPlanArtifact, GoalPlanConfidence, GoalPlanPersistentItem, GoalPlanScopeInclude,
     ScaffoldAction, ScaffoldUpdateKind,
+};
+use syu_workbench::{
+    AgentRun, Assignee, AssigneeKind, Assignment, AssignmentStatus, ScopeGuardResult,
+    ScopeGuardStatus,
 };
 use syu_workbench::{EvidenceRecord, WorkbenchActionId};
 
@@ -189,6 +194,7 @@ pub fn GoalCanvas(
                     on_run_action: on_run_action,
                 }
                 BranchScopeLens { ui: ui.clone(), on_run_action: on_run_action }
+                AssignGoalDialog { ui: ui.clone(), on_run_action: on_run_action }
                 SpecImpactGraph { ui: ui.clone() }
                 if let Some(preview) = ui.preview.clone().or_else(|| ui.selected_action_id.and_then(|id| ui.action_preview(id))) {
                     DetailDrawer {
@@ -204,6 +210,223 @@ pub fn GoalCanvas(
                     }
                 } else {
                     EmptyState { title: "No action selected".to_string(), body: "Open the palette to run a read-only action or inspect the next suggested step.".to_string() }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AssignGoalDialog(
+    ui: WorkbenchUiState,
+    on_run_action: Option<EventHandler<WorkbenchActionId>>,
+) -> Element {
+    let assignment = ui.payload.state.assignment.clone();
+    rsx! {
+        Panel { class: classes::PANEL_MUTED,
+            div { class: "space-y-4 p-4",
+                div { class: classes::SECTION_HEADER,
+                    h2 { class: classes::SECTION_TITLE, "Scoped Assignment" }
+                    if let Some(assignment) = &assignment {
+                        StatusDot {
+                            tone_class: assignment_status_tone(assignment.status),
+                            label: assignment.status.label().to_string(),
+                        }
+                    } else {
+                        ScopeChip { label: "assignment-blocked".to_string() }
+                    }
+                }
+                if let Some(assignment) = assignment {
+                    AssigneeSelector { assignee: assignment.assignee.clone() }
+                    ScopeGuardPreview { result: assignment.scope_guard.clone() }
+                    AssignmentConstraintPanel { assignment: assignment.clone() }
+                    AssignmentPromptPreview { assignment: assignment.clone() }
+                    if let Some(run) = assignment.latest_run.clone() {
+                        AgentRunPanel { run }
+                    } else if matches!(assignment.assignee.as_ref().map(|assignee| assignee.kind), Some(AssigneeKind::Human)) {
+                        HumanAssignmentPanel { assignment: assignment.clone() }
+                    }
+                    AssignmentEvidencePanel { assignment: assignment.clone() }
+                    if let Some(on_run_action) = on_run_action {
+                        div { class: "flex flex-wrap gap-2",
+                            button {
+                                class: "rounded-full border border-border bg-panel-muted px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-foreground/70",
+                                disabled: !assignment.is_runnable(),
+                                onclick: move |_| on_run_action.call(WorkbenchActionId::AssignmentPreview),
+                                "Preview"
+                            }
+                            button {
+                                class: "rounded-full border border-command-active bg-command-active px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-background",
+                                disabled: !assignment.is_runnable(),
+                                onclick: move |_| on_run_action.call(WorkbenchActionId::AssignmentRunDry),
+                                "Dry Run"
+                            }
+                        }
+                    }
+                } else {
+                    EmptyState {
+                        title: "No assignment loaded".to_string(),
+                        body: "Create assignment keeps Goal scope, non-goals, tests, completion commands, and required evidence together.".to_string()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AssigneeSelector(assignee: Option<Assignee>) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Assignee Selector" }
+            if let Some(assignee) = assignee {
+                div { class: "mt-2 flex flex-wrap items-center gap-2",
+                    ScopeChip { label: assignee.kind.label().to_string() }
+                    ScopeChip { label: assignee.id.clone() }
+                    p { class: "text-sm font-medium", "{assignee.display_name}" }
+                }
+            } else {
+                p { class: "mt-2 text-sm text-evidence-warn", "assignment-blocked: assignee missing" }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn ScopeGuardPreview(result: ScopeGuardResult) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex flex-wrap items-center gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Scope Guard Preview" }
+                StatusDot { tone_class: scope_guard_tone(result.status), label: result.status.label().to_string() }
+            }
+            div { class: "mt-2 flex flex-wrap gap-2",
+                ScopeChip { label: "scope-in".to_string() }
+                ScopeChip { label: "scope-out".to_string() }
+                ScopeChip { label: result.status.label().to_string() }
+            }
+            if !result.blockers.is_empty() {
+                div { class: "mt-3 space-y-2 rounded-lg border border-evidence-fail/40 bg-evidence-fail/10 p-3",
+                    for blocker in result.blockers {
+                        div { class: "flex items-center gap-2",
+                            StatusDot { tone_class: "bg-evidence-fail", label: "assignment-blocked".to_string() }
+                            p { class: "text-sm text-foreground/80", "{blocker.code}: {blocker.message}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AssignmentConstraintPanel(assignment: Assignment) -> Element {
+    rsx! {
+        section { class: "grid gap-3 md:grid-cols-2",
+            ConstraintList { title: "Allowed files".to_string(), token: "scope-in".to_string(), values: assignment.scope.include.clone() }
+            ConstraintList { title: "Forbidden files".to_string(), token: "scope-out".to_string(), values: assignment.scope.exclude.clone() }
+            ConstraintList { title: "Non-goals".to_string(), token: "assignment-ready".to_string(), values: assignment.scope.non_goals.clone() }
+            ConstraintList { title: "Required tests".to_string(), token: "evidence-required".to_string(), values: assignment.scope.required_tests.clone() }
+            ConstraintList { title: "Completion commands".to_string(), token: "run-dry".to_string(), values: assignment.scope.completion_commands.clone() }
+            ConstraintList { title: "Linked spec context".to_string(), token: "spec-linked".to_string(), values: assignment.scope.linked_spec_context.clone() }
+        }
+    }
+}
+
+#[component]
+fn ConstraintList(title: String, token: String, values: Vec<String>) -> Element {
+    rsx! {
+        div { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex items-center justify-between gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "{title}" }
+                ScopeChip { label: token }
+            }
+            if values.is_empty() {
+                p { class: "mt-2 text-sm text-evidence-warn", "evidence-missing" }
+            } else {
+                ul { class: "mt-2 space-y-1",
+                    for value in values {
+                        li { class: "text-sm text-foreground/75", "{value}" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AssignmentPromptPreview(assignment: Assignment) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex flex-wrap items-center gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Assignment Prompt Preview" }
+                ScopeChip { label: assignment.run_mode.label().to_string() }
+            }
+            pre { class: "mt-2 max-h-56 overflow-auto rounded-lg border border-border bg-panel-muted p-3 text-xs text-foreground/70",
+                "{assignment.prompt_preview}"
+            }
+        }
+    }
+}
+
+#[component]
+pub fn AgentRunPanel(run: AgentRun) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex flex-wrap items-center gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Agent Run Panel" }
+                StatusDot { tone_class: agent_run_tone(run.status), label: run.status.label().to_string() }
+                ScopeChip { label: run.output.diff_summary.clone() }
+            }
+            CommandOutputView {
+                title: "Runner output".to_string(),
+                summary: run.status.label().to_string(),
+                command: Some(syu_workbench::EvidenceCommand {
+                    command: run.profile_id.clone(),
+                    args: vec![run.mode.label().to_string()],
+                }),
+                attachment: Some(syu_workbench::EvidenceAttachment {
+                    label: "stdout-stderr".to_string(),
+                    mime_type: Some("text/plain".to_string()),
+                    summary: Some("stdout/stderr".to_string()),
+                    content: Some(format!("stdout:\n{}\nstderr:\n{}", run.output.stdout, run.output.stderr)),
+                    truncated: false,
+                }),
+            }
+        }
+    }
+}
+
+#[component]
+pub fn HumanAssignmentPanel(assignment: Assignment) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex flex-wrap items-center gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Human Assignment Panel" }
+                ScopeChip { label: "manual".to_string() }
+                ScopeChip { label: assignment.status.label().to_string() }
+            }
+            p { class: "mt-2 text-sm text-foreground/75", "Human assignment uses the same scoped handoff without command execution." }
+        }
+    }
+}
+
+#[component]
+pub fn AssignmentEvidencePanel(assignment: Assignment) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-border bg-background/30 p-3",
+            div { class: "flex flex-wrap items-center gap-2",
+                p { class: "text-xs uppercase tracking-[0.18em] text-foreground/55", "Assignment Evidence Panel" }
+                EvidenceBadge { kind: syu_workbench::WorkbenchEvidenceKind::AssignmentState }
+            }
+            if assignment.evidence_requirements.is_empty() {
+                p { class: "mt-2 text-sm text-evidence-warn", "evidence-missing" }
+            } else {
+                div { class: "mt-2 flex flex-wrap gap-2",
+                    for requirement in assignment.evidence_requirements {
+                        ScopeChip { label: if requirement.required { "evidence-required".to_string() } else { "evidence-optional".to_string() } }
+                        p { class: "text-sm text-foreground/75", "{requirement.description}" }
+                    }
                 }
             }
         }
@@ -1044,7 +1267,8 @@ fn render_evidence_timeline_record(record: EvidenceRecord) -> Element {
         | syu_workbench::WorkbenchEvidenceKind::SpecImpactReport => {
             rsx! { ScopeEvidenceView { record } }
         }
-        syu_workbench::WorkbenchEvidenceKind::JobState => {
+        syu_workbench::WorkbenchEvidenceKind::AgentRun
+        | syu_workbench::WorkbenchEvidenceKind::JobState => {
             rsx! { AgentEvidenceView { record } }
         }
         syu_workbench::WorkbenchEvidenceKind::AssignmentState => {
@@ -1278,6 +1502,38 @@ fn graph_state_class(state: &str) -> &'static str {
     }
 }
 
+fn assignment_status_tone(status: AssignmentStatus) -> &'static str {
+    match status {
+        AssignmentStatus::AssignmentReady
+        | AssignmentStatus::AssignmentComplete
+        | AssignmentStatus::AssignmentDryRun => "bg-evidence-pass",
+        AssignmentStatus::AssignmentActive => "bg-evidence-pending",
+        AssignmentStatus::AssignmentBlocked | AssignmentStatus::AssignmentFailed => {
+            "bg-evidence-fail"
+        }
+    }
+}
+
+fn scope_guard_tone(status: ScopeGuardStatus) -> &'static str {
+    match status {
+        ScopeGuardStatus::ScopeValid => "bg-evidence-pass",
+        ScopeGuardStatus::ScopeAmbiguous => "bg-scope-ambiguous",
+        ScopeGuardStatus::ScopeInvalid => "bg-evidence-fail",
+    }
+}
+
+fn agent_run_tone(status: syu_workbench::AgentRunStatus) -> &'static str {
+    match status {
+        syu_workbench::AgentRunStatus::RunComplete => "bg-evidence-pass",
+        syu_workbench::AgentRunStatus::RunDry | syu_workbench::AgentRunStatus::RunActive => {
+            "bg-evidence-pending"
+        }
+        syu_workbench::AgentRunStatus::RunFailed | syu_workbench::AgentRunStatus::Blocked => {
+            "bg-evidence-fail"
+        }
+    }
+}
+
 fn truncate_label(label: &str, max_chars: usize) -> String {
     if label.chars().count() <= max_chars {
         return label.to_string();
@@ -1373,6 +1629,6 @@ mod tests {
             EvidencePanel { ui }
         });
 
-        assert!(html.contains("Evidence placeholder"));
+        assert!(html.contains("Append evidence by running goal checks"));
     }
 }

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -222,6 +222,9 @@ pub fn AssignGoalDialog(
     on_run_action: Option<EventHandler<WorkbenchActionId>>,
 ) -> Element {
     let assignment = ui.payload.state.assignment.clone();
+    let is_automated_assignee = assignment
+        .as_ref()
+        .is_some_and(assignment_has_automated_assignee);
     rsx! {
         Panel { class: classes::PANEL_MUTED,
             div { class: "space-y-4 p-4",
@@ -255,11 +258,13 @@ pub fn AssignGoalDialog(
                                 onclick: move |_| on_run_action.call(WorkbenchActionId::AssignmentPreview),
                                 "Preview"
                             }
-                            button {
-                                class: "rounded-full border border-command-active bg-command-active px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-background",
-                                disabled: !assignment.is_runnable(),
-                                onclick: move |_| on_run_action.call(WorkbenchActionId::AssignmentRunDry),
-                                "Dry Run"
+                            if is_automated_assignee {
+                                button {
+                                    class: "rounded-full border border-command-active bg-command-active px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-background",
+                                    disabled: !assignment.is_runnable(),
+                                    onclick: move |_| on_run_action.call(WorkbenchActionId::AssignmentRunDry),
+                                    "Dry Run"
+                                }
                             }
                         }
                     }
@@ -1559,12 +1564,22 @@ fn truncate_label(label: &str, max_chars: usize) -> String {
     truncated
 }
 
+fn assignment_has_automated_assignee(assignment: &Assignment) -> bool {
+    assignment
+        .assignee
+        .as_ref()
+        .is_some_and(|assignee| assignee.kind.is_automated())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::build_demo_state;
     use dioxus_ssr::render_element;
-    use syu_workbench::{WorkbenchActionId, WorkbenchState};
+    use syu_workbench::{
+        AgentRunMode, Assignee, Assignment, AssignmentScope, AssignmentStatus, ScopeGuardResult,
+        ScopeGuardStatus, WorkbenchActionId, WorkbenchState,
+    };
 
     #[test]
     fn app_shell_renders_workbench_pulse_before_the_side_panels() {
@@ -1589,6 +1604,29 @@ mod tests {
 
         assert!(html.contains("disabled: missing active_goal_plan"));
         assert!(html.contains("goal.check"));
+    }
+
+    #[test]
+    fn human_assignments_hide_the_dry_run_action() {
+        let human_assignment = Assignment {
+            assignee: Some(Assignee::human("Manual Reviewer")),
+            run_mode: AgentRunMode::Manual,
+            status: AssignmentStatus::AssignmentReady,
+            scope_guard: ScopeGuardResult {
+                status: ScopeGuardStatus::ScopeValid,
+                blockers: Vec::new(),
+                out_of_scope_files: Vec::new(),
+            },
+            scope: AssignmentScope::default(),
+            ..Assignment::default()
+        };
+        let automated_assignment = Assignment {
+            assignee: Some(Assignee::local_command("local-coder", "Local coder")),
+            ..human_assignment.clone()
+        };
+
+        assert!(!assignment_has_automated_assignee(&human_assignment));
+        assert!(assignment_has_automated_assignee(&automated_assignment));
     }
 
     #[test]

--- a/crates/syu-app-ui/src/components/shell.rs
+++ b/crates/syu-app-ui/src/components/shell.rs
@@ -303,7 +303,19 @@ pub fn ScopeGuardPreview(result: ScopeGuardResult) -> Element {
             div { class: "mt-2 flex flex-wrap gap-2",
                 ScopeChip { label: "scope-in".to_string() }
                 ScopeChip { label: "scope-out".to_string() }
+                ScopeChip { label: "out-of-scope changes".to_string() }
                 ScopeChip { label: result.status.label().to_string() }
+            }
+            if !result.out_of_scope_files.is_empty() {
+                div { class: "mt-3 space-y-2 rounded-lg border border-evidence-fail/40 bg-evidence-fail/10 p-3",
+                    div { class: "flex items-center gap-2",
+                        StatusDot { tone_class: "bg-evidence-fail", label: "scope-invalid".to_string() }
+                        p { class: "text-sm font-medium text-foreground/80", "Out-of-scope changes" }
+                    }
+                    for file in result.out_of_scope_files {
+                        p { class: "text-sm text-foreground/75", "{file}" }
+                    }
+                }
             }
             if !result.blockers.is_empty() {
                 div { class: "mt-3 space-y-2 rounded-lg border border-evidence-fail/40 bg-evidence-fail/10 p-3",

--- a/crates/syu-app-ui/src/lib.rs
+++ b/crates/syu-app-ui/src/lib.rs
@@ -7,13 +7,15 @@ pub mod model;
 use dioxus::prelude::{Asset, asset};
 
 pub use components::{
-    AffectedSpecPanel, AgentEvidenceView, AppShell, BranchScopeLens, ChangedFilesPanel,
-    CommandOutputView, CommandPalette, EvidenceDetailDrawer, EvidencePanel, EvidenceRecordCard,
-    EvidenceTimeline, GoalCanvas, GoalDependencyView, GoalPlanCanvas, GoalPlanExportPanel,
-    GoalRail, GoalScopePanel, GoalTestPlanPanel, GraphEdge, GraphNode, ImpactSummaryPanel,
-    ManualDecisionEvidenceView, OutOfScopePanel, OwnershipBadge, OwnershipPanel,
-    RequestClassificationPanel, RequestContextEditor, RequestIntakeCanvas, RequestScopePanel,
-    ScaffoldPreviewPanel, ScopeEvidenceView, ScopeLegend, SpecImpactGraph, StatusBar,
+    AffectedSpecPanel, AgentEvidenceView, AgentRunPanel, AppShell, AssignGoalDialog,
+    AssigneeSelector, AssignmentConstraintPanel, AssignmentEvidencePanel, AssignmentPromptPreview,
+    BranchScopeLens, ChangedFilesPanel, CommandOutputView, CommandPalette, EvidenceDetailDrawer,
+    EvidencePanel, EvidenceRecordCard, EvidenceTimeline, GoalCanvas, GoalDependencyView,
+    GoalPlanCanvas, GoalPlanExportPanel, GoalRail, GoalScopePanel, GoalTestPlanPanel, GraphEdge,
+    GraphNode, HumanAssignmentPanel, ImpactSummaryPanel, ManualDecisionEvidenceView,
+    OutOfScopePanel, OwnershipBadge, OwnershipPanel, RequestClassificationPanel,
+    RequestContextEditor, RequestIntakeCanvas, RequestScopePanel, ScaffoldPreviewPanel,
+    ScopeEvidenceView, ScopeGuardPreview, ScopeLegend, SpecImpactGraph, StatusBar,
     SuggestedGoalSplitPanel, TestEvidenceView, TestRecommendationPanel, ValidationEvidenceView,
     WorkspacePulse,
 };

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -296,6 +296,17 @@ pub fn build_demo_state() -> WorkbenchUiState {
         ],
     };
     let goal_plan = demo_goal_plan();
+    let assignment = syu_workbench::Assignment::from_goal_plan(
+        &goal_plan,
+        syu_workbench::Assignee::local_command("local-coder", "Local command adapter"),
+        syu_workbench::AgentRunMode::DryRun,
+        vec![syu_workbench::AssignmentEvidenceRequirement {
+            id: "runner-output".to_string(),
+            description: "stdout/stderr and prompt context from the dry-run adapter".to_string(),
+            kind: WorkbenchEvidenceKind::AgentRun,
+            required: true,
+        }],
+    );
     let mut state = WorkbenchState {
         workspace: Some(syu_workbench::WorkspaceSnapshot {
             workspace_root: std::path::PathBuf::from("/workspace/syu"),
@@ -359,6 +370,7 @@ pub fn build_demo_state() -> WorkbenchUiState {
                 "FEAT-WORKBENCH-BRANCH-SCOPE-001".to_string(),
             ],
         }),
+        assignment: Some(assignment),
         ..WorkbenchState::default()
     };
     state.evidence_timeline.append(

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -1842,7 +1842,7 @@ impl WorkbenchState {
                         AgentRunStatus::RunDry => JobStatus::Queued,
                         AgentRunStatus::RunActive => JobStatus::Running,
                     },
-                    action_id: Some(WorkbenchActionId::AssignmentRunDry),
+                    action_id: Some(action_id),
                     message: Some(format!("{} for {}", run.status.label(), run.assignment_id)),
                 };
             }
@@ -2656,6 +2656,38 @@ mod tests {
                 .map(|command| command.command.as_str()),
             Some("goal.check")
         );
+    }
+
+    #[test]
+    fn agent_runs_preserve_the_triggering_job_action_id() {
+        let mut state = WorkbenchState::default();
+        state.assignment = Some(Assignment {
+            id: "assignment-1".to_string(),
+            goal_id: Some("goal-1".to_string()),
+            ..Assignment::default()
+        });
+
+        state.apply_result(
+            WorkbenchActionId::AssignmentRun,
+            &WorkbenchActionResult::AgentRun(AgentRun {
+                id: "run-1".to_string(),
+                assignment_id: "assignment-1".to_string(),
+                profile_id: "profile-1".to_string(),
+                mode: AgentRunMode::Execute,
+                status: AgentRunStatus::RunDry,
+                scope_guard_before: ScopeGuardResult::valid(),
+                scope_guard_after: ScopeGuardResult::valid(),
+                output: AgentRunOutput {
+                    prompt: "prompt".to_string(),
+                    diff_summary: "diff".to_string(),
+                    ..AgentRunOutput::default()
+                },
+                evidence: Vec::new(),
+            }),
+        );
+
+        assert_eq!(state.job.action_id, Some(WorkbenchActionId::AssignmentRun));
+        assert_eq!(state.job.status, JobStatus::Queued);
     }
 
     #[test]

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
     path::PathBuf,
+    process::Command,
     sync::OnceLock,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -79,6 +80,18 @@ pub enum WorkbenchActionId {
     HistoryShow,
     #[serde(rename = "assignment.create")]
     AssignmentCreate,
+    #[serde(rename = "assignment.preview")]
+    AssignmentPreview,
+    #[serde(rename = "assignment.run_dry")]
+    AssignmentRunDry,
+    #[serde(rename = "assignment.run")]
+    AssignmentRun,
+    #[serde(rename = "assignment.cancel")]
+    AssignmentCancel,
+    #[serde(rename = "assignment.record_manual")]
+    AssignmentRecordManual,
+    #[serde(rename = "assignment.collect_evidence")]
+    AssignmentCollectEvidence,
     #[serde(rename = "agent.run")]
     AgentRun,
 }
@@ -101,6 +114,12 @@ impl WorkbenchActionId {
             Self::ValidationRun => "validation.run",
             Self::HistoryShow => "history.show",
             Self::AssignmentCreate => "assignment.create",
+            Self::AssignmentPreview => "assignment.preview",
+            Self::AssignmentRunDry => "assignment.run_dry",
+            Self::AssignmentRun => "assignment.run",
+            Self::AssignmentCancel => "assignment.cancel",
+            Self::AssignmentRecordManual => "assignment.record_manual",
+            Self::AssignmentCollectEvidence => "assignment.collect_evidence",
             Self::AgentRun => "agent.run",
         }
     }
@@ -122,6 +141,12 @@ pub enum WorkbenchActionFunction {
     ValidateWorkspace,
     HistoryForItem,
     AssignmentCreate,
+    AssignmentPreview,
+    AssignmentRunDry,
+    AssignmentRun,
+    AssignmentCancel,
+    AssignmentRecordManual,
+    AssignmentCollectEvidence,
     AgentRun,
 }
 
@@ -141,6 +166,12 @@ impl WorkbenchActionFunction {
             Self::ValidateWorkspace => "validate_workspace",
             Self::HistoryForItem => "history_for_item",
             Self::AssignmentCreate => "assignment.create",
+            Self::AssignmentPreview => "assignment.preview",
+            Self::AssignmentRunDry => "assignment.run_dry",
+            Self::AssignmentRun => "assignment.run",
+            Self::AssignmentCancel => "assignment.cancel",
+            Self::AssignmentRecordManual => "assignment.record_manual",
+            Self::AssignmentCollectEvidence => "assignment.collect_evidence",
             Self::AgentRun => "agent.run",
         }
     }
@@ -162,6 +193,12 @@ pub enum WorkbenchActionOutputEvent {
     ValidationRun,
     HistoryShown,
     AssignmentCreated,
+    AssignmentPreviewed,
+    AssignmentDryRunQueued,
+    AssignmentRunQueued,
+    AssignmentCancelled,
+    AssignmentManualRecorded,
+    AssignmentEvidenceCollected,
     AgentRunQueued,
 }
 
@@ -180,6 +217,7 @@ pub enum WorkbenchEvidenceKind {
     ValidationReport,
     HistoryResponse,
     AssignmentState,
+    AgentRun,
     JobState,
 }
 
@@ -198,6 +236,7 @@ impl WorkbenchEvidenceKind {
             Self::ValidationReport => "validation_report",
             Self::HistoryResponse => "history_response",
             Self::AssignmentState => "assignment_state",
+            Self::AgentRun => "agent_run",
             Self::JobState => "job_state",
         }
     }
@@ -570,13 +609,42 @@ fn evidence_record_for_action(
             format!("history loaded for {} {}", history.entity_kind, history.id),
         ),
         WorkbenchActionResult::AssignmentState(assignment) => (
-            EvidenceStatus::Pending,
-            Some(EvidenceSeverity::Low),
+            if assignment.status == AssignmentStatus::AssignmentBlocked {
+                EvidenceStatus::Warn
+            } else {
+                EvidenceStatus::Pending
+            },
+            Some(
+                if assignment.status == AssignmentStatus::AssignmentBlocked {
+                    EvidenceSeverity::Medium
+                } else {
+                    EvidenceSeverity::Low
+                },
+            ),
             Some(EvidenceSubject::Assignment),
             match &assignment.goal_id {
                 Some(goal_id) => format!("assignment created for {goal_id}"),
                 None => "assignment created".to_string(),
             },
+        ),
+        WorkbenchActionResult::AgentRun(run) => (
+            match run.status {
+                AgentRunStatus::RunComplete => EvidenceStatus::Pass,
+                AgentRunStatus::RunFailed | AgentRunStatus::Blocked => EvidenceStatus::Fail,
+                AgentRunStatus::RunDry | AgentRunStatus::RunActive => EvidenceStatus::Pending,
+            },
+            Some(
+                if matches!(
+                    run.status,
+                    AgentRunStatus::RunFailed | AgentRunStatus::Blocked
+                ) {
+                    EvidenceSeverity::High
+                } else {
+                    EvidenceSeverity::Low
+                },
+            ),
+            Some(EvidenceSubject::AgentRun),
+            format!("{} recorded for {}", run.status.label(), run.assignment_id),
         ),
         WorkbenchActionResult::JobState(job) => (
             match job.status {
@@ -608,6 +676,10 @@ fn evidence_record_for_action(
         WorkbenchActionResult::TaskTestSelectionPlan(_) => Some(EvidenceCommand {
             command: "goal.test_select".to_string(),
             args: Vec::new(),
+        }),
+        WorkbenchActionResult::AgentRun(run) => Some(EvidenceCommand {
+            command: run.profile_id.clone(),
+            args: vec![run.mode.label().to_string()],
         }),
         _ => None,
     };
@@ -721,6 +793,7 @@ pub enum WorkbenchActionResult {
     ValidationReport(ValidationReport),
     HistoryResponse(HistoryResponse),
     AssignmentState(AssignmentState),
+    AgentRun(AgentRun),
     JobState(JobState),
 }
 
@@ -739,6 +812,7 @@ impl WorkbenchActionResult {
             Self::ValidationReport(_) => WorkbenchEvidenceKind::ValidationReport,
             Self::HistoryResponse(_) => WorkbenchEvidenceKind::HistoryResponse,
             Self::AssignmentState(_) => WorkbenchEvidenceKind::AssignmentState,
+            Self::AgentRun(_) => WorkbenchEvidenceKind::AgentRun,
             Self::JobState(_) => WorkbenchEvidenceKind::JobState,
         }
     }
@@ -843,23 +917,713 @@ impl BoundedScope {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum AssignmentAssignee {
-    Human { name: String },
-    Ai { model: String },
+pub enum AssigneeKind {
+    Human,
+    LocalCommand,
+    ManualPatch,
+    ExternalAgent,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-pub struct AssignmentState {
+impl AssigneeKind {
+    pub const fn is_automated(self) -> bool {
+        matches!(
+            self,
+            Self::LocalCommand | Self::ManualPatch | Self::ExternalAgent
+        )
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::LocalCommand => "local_command",
+            Self::ManualPatch => "manual_patch",
+            Self::ExternalAgent => "external_agent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Assignee {
+    pub id: String,
+    pub kind: AssigneeKind,
+    pub display_name: String,
+}
+
+impl Assignee {
+    pub fn human(name: impl Into<String>) -> Self {
+        let name = name.into();
+        Self {
+            id: name.to_lowercase().replace(' ', "-"),
+            kind: AssigneeKind::Human,
+            display_name: name,
+        }
+    }
+
+    pub fn local_command(id: impl Into<String>, display_name: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: AssigneeKind::LocalCommand,
+            display_name: display_name.into(),
+        }
+    }
+}
+
+pub type AssignmentAssignee = Assignee;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AssignmentScope {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub non_goals: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linked_spec_context: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_tests: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completion_commands: Vec<String>,
+}
+
+impl AssignmentScope {
+    pub fn from_goal_plan(plan: &GoalPlanArtifact) -> Self {
+        Self {
+            include: plan
+                .implementation_plan
+                .scope
+                .include
+                .iter()
+                .map(goal_scope_include_label)
+                .collect(),
+            exclude: plan.implementation_plan.scope.exclude.clone(),
+            non_goals: plan.goal.non_goals.clone(),
+            linked_spec_context: plan.spec_mapping.persistent_items.labels(),
+            required_tests: plan
+                .test_plan
+                .required_tests
+                .values()
+                .flat_map(|tests| {
+                    tests.iter().map(|test| {
+                        let file = test.file.display().to_string();
+                        if test.symbols.is_empty() {
+                            file
+                        } else {
+                            format!("{file}::{}", test.symbols.join(","))
+                        }
+                    })
+                })
+                .collect(),
+            completion_commands: plan.completion.must_pass.clone(),
+        }
+    }
+}
+
+trait PersistentItemLabels {
+    fn labels(&self) -> Vec<String>;
+}
+
+impl PersistentItemLabels for syu_task_model::GoalPlanPersistentItems {
+    fn labels(&self) -> Vec<String> {
+        self.philosophies
+            .iter()
+            .chain(self.policies.iter())
+            .chain(self.requirements.iter())
+            .chain(self.features.iter())
+            .map(persistent_item_label)
+            .collect()
+    }
+}
+
+fn persistent_item_label(item: &syu_task_model::GoalPlanPersistentItem) -> String {
+    match item {
+        syu_task_model::GoalPlanPersistentItem::Id(id) => id.clone(),
+        syu_task_model::GoalPlanPersistentItem::Item(item) => {
+            let title = item.title.as_deref().unwrap_or("untitled");
+            let document_path = item.document_path.as_deref().unwrap_or("path pending");
+            format!("{} ({title}, {document_path})", item.id)
+        }
+    }
+}
+
+fn goal_scope_include_label(include: &syu_task_model::GoalPlanScopeInclude) -> String {
+    match include {
+        syu_task_model::GoalPlanScopeInclude::Pattern(pattern) => pattern.clone(),
+        syu_task_model::GoalPlanScopeInclude::Entry(entry) => {
+            if entry.symbols.is_empty() {
+                entry.file.clone()
+            } else {
+                format!("{}::{}", entry.file, entry.symbols.join(","))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssignmentPermissions {
+    #[serde(default)]
+    pub allow_command_execution: bool,
+    #[serde(default)]
+    pub dry_run_only: bool,
+    #[serde(default)]
+    pub require_isolated_worktree: bool,
+}
+
+impl Default for AssignmentPermissions {
+    fn default() -> Self {
+        Self {
+            allow_command_execution: false,
+            dry_run_only: true,
+            require_isolated_worktree: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssignmentEvidenceRequirement {
+    pub id: String,
+    pub description: String,
+    pub kind: WorkbenchEvidenceKind,
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentProfile {
+    pub id: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WorkbenchAgentConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<AgentProfile>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunMode {
+    Manual,
+    DryRun,
+    Execute,
+}
+
+impl AgentRunMode {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::DryRun => "dry_run",
+            Self::Execute => "execute",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunStatus {
+    RunDry,
+    RunActive,
+    RunFailed,
+    RunComplete,
+    Blocked,
+}
+
+impl AgentRunStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::RunDry => "run-dry",
+            Self::RunActive => "run-active",
+            Self::RunFailed => "run-failed",
+            Self::RunComplete => "run-complete",
+            Self::Blocked => "assignment-blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AgentRunOutput {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+    pub prompt: String,
+    pub diff_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRun {
+    pub id: String,
+    pub assignment_id: String,
+    pub profile_id: String,
+    pub mode: AgentRunMode,
+    pub status: AgentRunStatus,
+    pub scope_guard_before: ScopeGuardResult,
+    pub scope_guard_after: ScopeGuardResult,
+    pub output: AgentRunOutput,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<EvidenceRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssignmentBlocker {
+    pub code: String,
+    pub message: String,
+}
+
+impl AssignmentBlocker {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeGuardStatus {
+    ScopeValid,
+    ScopeAmbiguous,
+    ScopeInvalid,
+}
+
+impl ScopeGuardStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::ScopeValid => "scope-valid",
+            Self::ScopeAmbiguous => "scope-ambiguous",
+            Self::ScopeInvalid => "scope-invalid",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeGuardResult {
+    pub status: ScopeGuardStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<AssignmentBlocker>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub out_of_scope_files: Vec<String>,
+}
+
+impl ScopeGuardResult {
+    pub fn valid() -> Self {
+        Self {
+            status: ScopeGuardStatus::ScopeValid,
+            blockers: Vec::new(),
+            out_of_scope_files: Vec::new(),
+        }
+    }
+
+    pub fn is_runnable(&self) -> bool {
+        self.status == ScopeGuardStatus::ScopeValid && self.blockers.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssignmentStatus {
+    AssignmentReady,
+    AssignmentBlocked,
+    AssignmentDryRun,
+    AssignmentActive,
+    AssignmentComplete,
+    AssignmentFailed,
+}
+
+impl AssignmentStatus {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::AssignmentReady => "assignment-ready",
+            Self::AssignmentBlocked => "assignment-blocked",
+            Self::AssignmentDryRun => "assignment-dry-run",
+            Self::AssignmentActive => "assignment-active",
+            Self::AssignmentComplete => "assignment-complete",
+            Self::AssignmentFailed => "assignment-failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Assignment {
+    pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub goal_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub assignee: Option<AssignmentAssignee>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scope: Option<BoundedScope>,
+    pub assignee: Option<Assignee>,
+    pub scope: AssignmentScope,
+    pub permissions: AssignmentPermissions,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_requirements: Vec<AssignmentEvidenceRequirement>,
+    pub run_mode: AgentRunMode,
+    pub status: AssignmentStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub expected_evidence: Vec<WorkbenchEvidenceKind>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<AssignmentBlocker>,
+    pub scope_guard: ScopeGuardResult,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub prompt_preview: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_run: Option<AgentRun>,
+}
+
+pub type AssignmentState = Assignment;
+
+impl Default for Assignment {
+    fn default() -> Self {
+        Self {
+            id: "assignment-1".to_string(),
+            goal_id: None,
+            assignee: None,
+            scope: AssignmentScope::default(),
+            permissions: AssignmentPermissions::default(),
+            evidence_requirements: Vec::new(),
+            run_mode: AgentRunMode::Manual,
+            status: AssignmentStatus::AssignmentBlocked,
+            expected_evidence: Vec::new(),
+            blockers: Vec::new(),
+            scope_guard: ScopeGuardResult {
+                status: ScopeGuardStatus::ScopeAmbiguous,
+                blockers: vec![AssignmentBlocker::new(
+                    "scope_missing",
+                    "assignment has not been scoped",
+                )],
+                out_of_scope_files: Vec::new(),
+            },
+            prompt_preview: String::new(),
+            latest_run: None,
+        }
+    }
+}
+
+impl Assignment {
+    pub fn from_goal_plan(
+        plan: &GoalPlanArtifact,
+        assignee: Assignee,
+        run_mode: AgentRunMode,
+        evidence_requirements: Vec<AssignmentEvidenceRequirement>,
+    ) -> Self {
+        let scope = AssignmentScope::from_goal_plan(plan);
+        let permissions = AssignmentPermissions {
+            allow_command_execution: matches!(
+                run_mode,
+                AgentRunMode::DryRun | AgentRunMode::Execute
+            ),
+            dry_run_only: !matches!(run_mode, AgentRunMode::Execute),
+            require_isolated_worktree: true,
+        };
+        let mut assignment = Self {
+            id: format!("assignment-{}", plan.goal.id.to_lowercase()),
+            goal_id: Some(plan.goal.id.clone()),
+            assignee: Some(assignee),
+            scope,
+            permissions,
+            evidence_requirements,
+            run_mode,
+            status: AssignmentStatus::AssignmentBlocked,
+            expected_evidence: vec![
+                WorkbenchEvidenceKind::AssignmentState,
+                WorkbenchEvidenceKind::AgentRun,
+            ],
+            blockers: Vec::new(),
+            scope_guard: ScopeGuardResult::valid(),
+            prompt_preview: String::new(),
+            latest_run: None,
+        };
+        assignment.scope_guard = ScopeGuard::preview(&assignment);
+        assignment.blockers = assignment.scope_guard.blockers.clone();
+        assignment.status = if assignment.blockers.is_empty() {
+            match run_mode {
+                AgentRunMode::Manual => AssignmentStatus::AssignmentReady,
+                AgentRunMode::DryRun => AssignmentStatus::AssignmentDryRun,
+                AgentRunMode::Execute => AssignmentStatus::AssignmentReady,
+            }
+        } else {
+            AssignmentStatus::AssignmentBlocked
+        };
+        assignment.prompt_preview = AssignmentPromptBuilder::build(&assignment);
+        assignment
+    }
+
+    pub fn is_runnable(&self) -> bool {
+        self.scope_guard.is_runnable() && self.status != AssignmentStatus::AssignmentBlocked
+    }
+}
+
+pub struct ScopeGuard;
+
+impl ScopeGuard {
+    pub fn preview(assignment: &Assignment) -> ScopeGuardResult {
+        let mut blockers = Vec::new();
+        let is_automated = assignment
+            .assignee
+            .as_ref()
+            .is_some_and(|assignee| assignee.kind.is_automated());
+        let is_manual = matches!(assignment.run_mode, AgentRunMode::Manual);
+
+        if is_automated && assignment.scope.include.is_empty() {
+            blockers.push(AssignmentBlocker::new(
+                "scope_include_missing",
+                "AI assignment requires at least one explicit include scope",
+            ));
+        }
+        if is_automated && assignment.scope.non_goals.is_empty() {
+            blockers.push(AssignmentBlocker::new(
+                "non_goals_missing",
+                "AI assignment must carry non-goals",
+            ));
+        }
+        if is_automated && assignment.scope.completion_commands.is_empty() {
+            blockers.push(AssignmentBlocker::new(
+                "completion_commands_missing",
+                "AI assignment must list completion commands",
+            ));
+        }
+        if is_automated
+            && assignment
+                .evidence_requirements
+                .iter()
+                .all(|item| !item.required)
+        {
+            blockers.push(AssignmentBlocker::new(
+                "evidence_required",
+                "AI assignment must list required evidence",
+            ));
+        }
+        if is_automated && !is_manual && assignment.scope.required_tests.is_empty() {
+            blockers.push(AssignmentBlocker::new(
+                "required_tests_missing",
+                "Assignment cannot run when required tests are missing unless marked manual",
+            ));
+        }
+        if assignment
+            .scope
+            .include
+            .iter()
+            .any(|item| item.contains("ambiguous"))
+        {
+            blockers.push(AssignmentBlocker::new(
+                "scope_ambiguous",
+                "Assignment cannot run when scope is ambiguous",
+            ));
+        }
+
+        let status = if blockers
+            .iter()
+            .any(|blocker| blocker.code == "scope_ambiguous")
+        {
+            ScopeGuardStatus::ScopeAmbiguous
+        } else if blockers.is_empty() {
+            ScopeGuardStatus::ScopeValid
+        } else {
+            ScopeGuardStatus::ScopeInvalid
+        };
+
+        ScopeGuardResult {
+            status,
+            blockers,
+            out_of_scope_files: Vec::new(),
+        }
+    }
+}
+
+pub struct AssignmentPromptBuilder;
+
+impl AssignmentPromptBuilder {
+    pub fn build(assignment: &Assignment) -> String {
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "Goal Plan: {}",
+            assignment.goal_id.as_deref().unwrap_or("unselected")
+        ));
+        if let Some(assignee) = &assignment.assignee {
+            lines.push(format!(
+                "Assignee: {} ({})",
+                assignee.display_name,
+                assignee.kind.label()
+            ));
+        }
+        lines.push(format!("Run mode: {}", assignment.run_mode.label()));
+        push_section(&mut lines, "Allowed files", &assignment.scope.include);
+        push_section(&mut lines, "Forbidden files", &assignment.scope.exclude);
+        push_section(&mut lines, "Non-goals", &assignment.scope.non_goals);
+        push_section(
+            &mut lines,
+            "Linked spec context",
+            &assignment.scope.linked_spec_context,
+        );
+        push_section(
+            &mut lines,
+            "Required tests",
+            &assignment.scope.required_tests,
+        );
+        push_section(
+            &mut lines,
+            "Completion commands",
+            &assignment.scope.completion_commands,
+        );
+        let evidence = assignment
+            .evidence_requirements
+            .iter()
+            .map(|item| item.description.clone())
+            .collect::<Vec<_>>();
+        push_section(&mut lines, "Required evidence", &evidence);
+        lines.push(format!(
+            "Current validation status: {}",
+            if assignment.scope.required_tests.is_empty() {
+                "evidence-missing"
+            } else {
+                "evidence-required"
+            }
+        ));
+        lines.push(format!(
+            "Current branch-scope status: {}",
+            assignment.scope_guard.status.label()
+        ));
+        lines.join("\n")
+    }
+}
+
+fn push_section(lines: &mut Vec<String>, title: &str, values: &[String]) {
+    lines.push(format!("{title}:"));
+    if values.is_empty() {
+        lines.push("- missing".to_string());
+    } else {
+        lines.extend(values.iter().map(|value| format!("- {value}")));
+    }
+}
+
+pub struct CommandAgentAdapter {
+    pub profile: AgentProfile,
+}
+
+impl CommandAgentAdapter {
+    pub fn new(profile: AgentProfile) -> Self {
+        Self { profile }
+    }
+
+    pub fn run_dry(&self, assignment: &Assignment) -> AgentRun {
+        let before = ScopeGuard::preview(assignment);
+        if !before.is_runnable() {
+            return AgentRun {
+                id: format!("run-{}", assignment.id),
+                assignment_id: assignment.id.clone(),
+                profile_id: self.profile.id.clone(),
+                mode: AgentRunMode::DryRun,
+                status: AgentRunStatus::Blocked,
+                scope_guard_before: before.clone(),
+                scope_guard_after: before,
+                output: AgentRunOutput {
+                    prompt: AssignmentPromptBuilder::build(assignment),
+                    diff_summary: "no command executed because assignment is blocked".to_string(),
+                    ..AgentRunOutput::default()
+                },
+                evidence: Vec::new(),
+            };
+        }
+
+        let prompt = AssignmentPromptBuilder::build(assignment);
+        let output = Command::new(&self.profile.command)
+            .args(&self.profile.args)
+            .env("SYU_ASSIGNMENT_ID", &assignment.id)
+            .env("SYU_ASSIGNMENT_PROMPT", &prompt)
+            .output();
+
+        let (status, run_output) = match output {
+            Ok(output) => (
+                if output.status.success() {
+                    AgentRunStatus::RunComplete
+                } else {
+                    AgentRunStatus::RunFailed
+                },
+                AgentRunOutput {
+                    exit_code: output.status.code(),
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    prompt,
+                    diff_summary: "no diff produced by dry-run command adapter".to_string(),
+                },
+            ),
+            Err(error) => (
+                AgentRunStatus::RunFailed,
+                AgentRunOutput {
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: error.to_string(),
+                    prompt,
+                    diff_summary: "no diff produced; command failed before execution".to_string(),
+                },
+            ),
+        };
+
+        let after = ScopeGuard::preview(assignment);
+        let mut run = AgentRun {
+            id: format!("run-{}", assignment.id),
+            assignment_id: assignment.id.clone(),
+            profile_id: self.profile.id.clone(),
+            mode: AgentRunMode::DryRun,
+            status,
+            scope_guard_before: before,
+            scope_guard_after: after,
+            output: run_output,
+            evidence: Vec::new(),
+        };
+        run.evidence = EvidenceCollector::from_agent_run(&run);
+        run
+    }
+}
+
+pub struct WorktreeRunner;
+pub struct PatchRunner;
+
+pub struct EvidenceCollector;
+
+impl EvidenceCollector {
+    pub fn from_agent_run(run: &AgentRun) -> Vec<EvidenceRecord> {
+        vec![
+            EvidenceRecord::new(
+                WorkbenchEvidenceKind::AgentRun,
+                if run.status == AgentRunStatus::RunComplete {
+                    EvidenceStatus::Pass
+                } else {
+                    EvidenceStatus::Fail
+                },
+                format!("{} captured stdout/stderr", run.status.label()),
+                Some(EvidenceSource::Command {
+                    command: run.profile_id.clone(),
+                }),
+            )
+            .with_subject(EvidenceSubject::AgentRun)
+            .with_severity(if run.status == AgentRunStatus::RunComplete {
+                EvidenceSeverity::Low
+            } else {
+                EvidenceSeverity::High
+            })
+            .with_command(EvidenceCommand {
+                command: run.profile_id.clone(),
+                args: vec![run.mode.label().to_string()],
+            })
+            .with_attachment(EvidenceAttachment {
+                label: "runner-output".to_string(),
+                mime_type: Some("application/json".to_string()),
+                summary: Some(run.output.diff_summary.clone()),
+                content: serde_json::to_string_pretty(&run.output).ok(),
+                truncated: false,
+            }),
+        ]
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -986,6 +1750,15 @@ impl WorkbenchState {
             WorkbenchActionResult::AssignmentState(assignment) => {
                 assignment.goal_id.clone().or(active_goal_id.clone())
             }
+            WorkbenchActionResult::AgentRun(run) => self
+                .assignment
+                .as_ref()
+                .and_then(|assignment| assignment.goal_id.clone())
+                .or_else(|| {
+                    active_goal_id
+                        .clone()
+                        .or_else(|| Some(run.assignment_id.clone()))
+                }),
             WorkbenchActionResult::JobState(_) => active_goal_id.clone(),
             _ => None,
         };
@@ -1050,6 +1823,29 @@ impl WorkbenchState {
             WorkbenchActionResult::AssignmentState(assignment) => {
                 self.assignment = Some(assignment.clone());
             }
+            WorkbenchActionResult::AgentRun(run) => {
+                if let Some(assignment) = self.assignment.as_mut() {
+                    assignment.latest_run = Some(run.clone());
+                    assignment.status = match run.status {
+                        AgentRunStatus::RunComplete => AssignmentStatus::AssignmentComplete,
+                        AgentRunStatus::RunFailed | AgentRunStatus::Blocked => {
+                            AssignmentStatus::AssignmentFailed
+                        }
+                        AgentRunStatus::RunDry => AssignmentStatus::AssignmentDryRun,
+                        AgentRunStatus::RunActive => AssignmentStatus::AssignmentActive,
+                    };
+                }
+                self.job = JobState {
+                    status: match run.status {
+                        AgentRunStatus::RunComplete => JobStatus::Completed,
+                        AgentRunStatus::RunFailed | AgentRunStatus::Blocked => JobStatus::Failed,
+                        AgentRunStatus::RunDry => JobStatus::Queued,
+                        AgentRunStatus::RunActive => JobStatus::Running,
+                    },
+                    action_id: Some(WorkbenchActionId::AssignmentRunDry),
+                    message: Some(format!("{} for {}", run.status.label(), run.assignment_id)),
+                };
+            }
             WorkbenchActionResult::JobState(job) => {
                 self.job = job.clone();
             }
@@ -1110,8 +1906,7 @@ impl WorkbenchActionContext {
             || self
                 .assignment
                 .as_ref()
-                .and_then(|assignment| assignment.scope.as_ref())
-                .is_some_and(BoundedScope::is_bounded)
+                .is_some_and(|assignment| !assignment.scope.include.is_empty())
     }
 }
 
@@ -1454,6 +2249,109 @@ fn build_registry() -> Vec<WorkbenchAction> {
             ai_eligible: false,
         },
         WorkbenchAction {
+            id: WorkbenchActionId::AssignmentPreview,
+            title: "Preview assignment".to_string(),
+            description: "Inspect scoped assignment constraints, blockers, and prompt context."
+                .to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::Assignment,
+            mutability: WorkbenchActionMutability::ReadOnly,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::AssignmentPreview,
+            output_event: WorkbenchActionOutputEvent::AssignmentPreviewed,
+            evidence_kind: WorkbenchEvidenceKind::AssignmentState,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::AssignmentRunDry,
+            title: "Dry-run assignment".to_string(),
+            description: "Run the configured command adapter in dry-run mode and capture evidence."
+                .to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::BoundedScope,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::AgentRun,
+            mutability: WorkbenchActionMutability::MutatesState,
+            risk: WorkbenchActionRisk::Medium,
+            function: WorkbenchActionFunction::AssignmentRunDry,
+            output_event: WorkbenchActionOutputEvent::AssignmentDryRunQueued,
+            evidence_kind: WorkbenchEvidenceKind::AgentRun,
+            ai_eligible: true,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::AssignmentRun,
+            title: "Run assignment".to_string(),
+            description:
+                "Execute a scoped command adapter when full execution is explicitly enabled."
+                    .to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::BoundedScope,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::AgentRun,
+            mutability: WorkbenchActionMutability::MutatesStateAndFiles,
+            risk: WorkbenchActionRisk::High,
+            function: WorkbenchActionFunction::AssignmentRun,
+            output_event: WorkbenchActionOutputEvent::AssignmentRunQueued,
+            evidence_kind: WorkbenchEvidenceKind::AgentRun,
+            ai_eligible: true,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::AssignmentCancel,
+            title: "Cancel assignment".to_string(),
+            description: "Cancel the active assignment without running commands.".to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::Assignment,
+            mutability: WorkbenchActionMutability::MutatesState,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::AssignmentCancel,
+            output_event: WorkbenchActionOutputEvent::AssignmentCancelled,
+            evidence_kind: WorkbenchEvidenceKind::AssignmentState,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::AssignmentRecordManual,
+            title: "Record manual assignment".to_string(),
+            description: "Record a human assignment decision as evidence.".to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::Assignment,
+            mutability: WorkbenchActionMutability::MutatesState,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::AssignmentRecordManual,
+            output_event: WorkbenchActionOutputEvent::AssignmentManualRecorded,
+            evidence_kind: WorkbenchEvidenceKind::AssignmentState,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
+            id: WorkbenchActionId::AssignmentCollectEvidence,
+            title: "Collect assignment evidence".to_string(),
+            description: "Append runner output and scope guard results to the evidence timeline."
+                .to_string(),
+            required_state: vec![
+                WorkbenchStateRequirement::AssignmentLoaded,
+                WorkbenchStateRequirement::ConfirmationMetadata,
+            ],
+            input_schema: WorkbenchActionInputSchema::AgentRun,
+            mutability: WorkbenchActionMutability::MutatesState,
+            risk: WorkbenchActionRisk::Low,
+            function: WorkbenchActionFunction::AssignmentCollectEvidence,
+            output_event: WorkbenchActionOutputEvent::AssignmentEvidenceCollected,
+            evidence_kind: WorkbenchEvidenceKind::AgentRun,
+            ai_eligible: false,
+        },
+        WorkbenchAction {
             id: WorkbenchActionId::AgentRun,
             title: "Run agent".to_string(),
             description: "Launch an AI run against a bounded goal scope and assignment."
@@ -1761,6 +2659,80 @@ mod tests {
     }
 
     #[test]
+    fn assignment_blocker_logic_rejects_ambiguous_ai_scope() {
+        let mut assignment = Assignment {
+            id: "assignment-1".to_string(),
+            goal_id: Some("goal-1".to_string()),
+            assignee: Some(Assignee::local_command("local-coder", "Local coder")),
+            scope: AssignmentScope {
+                include: vec!["ambiguous:src/lib.rs".to_string()],
+                ..AssignmentScope::default()
+            },
+            run_mode: AgentRunMode::DryRun,
+            evidence_requirements: Vec::new(),
+            ..Assignment::default()
+        };
+        assignment.scope_guard = ScopeGuard::preview(&assignment);
+
+        assert_eq!(
+            assignment.scope_guard.status,
+            ScopeGuardStatus::ScopeAmbiguous
+        );
+        assert!(assignment.scope_guard.blockers.iter().any(|blocker| {
+            blocker.code == "scope_ambiguous"
+                || blocker.code == "non_goals_missing"
+                || blocker.code == "completion_commands_missing"
+                || blocker.code == "evidence_required"
+        }));
+    }
+
+    #[test]
+    fn dry_run_command_adapter_captures_stdout_stderr_and_evidence() {
+        let assignment = Assignment {
+            id: "assignment-1".to_string(),
+            goal_id: Some("goal-1".to_string()),
+            assignee: Some(Assignee::local_command("local-coder", "Local coder")),
+            scope: AssignmentScope {
+                include: vec!["src/lib.rs".to_string()],
+                non_goals: vec!["Do not edit docs".to_string()],
+                required_tests: vec!["cargo test -p syu-workbench".to_string()],
+                completion_commands: vec!["cargo test -p syu-workbench".to_string()],
+                ..AssignmentScope::default()
+            },
+            evidence_requirements: vec![AssignmentEvidenceRequirement {
+                id: "runner-output".to_string(),
+                description: "runner stdout/stderr".to_string(),
+                kind: WorkbenchEvidenceKind::AgentRun,
+                required: true,
+            }],
+            run_mode: AgentRunMode::DryRun,
+            scope_guard: ScopeGuardResult::valid(),
+            status: AssignmentStatus::AssignmentDryRun,
+            ..Assignment::default()
+        };
+        let adapter = CommandAgentAdapter::new(AgentProfile {
+            id: "fixture".to_string(),
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf runner-stdout; printf runner-stderr >&2".to_string(),
+            ],
+        });
+
+        let run = adapter.run_dry(&assignment);
+
+        assert_eq!(run.status, AgentRunStatus::RunComplete);
+        assert_eq!(run.output.stdout, "runner-stdout");
+        assert_eq!(run.output.stderr, "runner-stderr");
+        assert_eq!(
+            run.output.diff_summary,
+            "no diff produced by dry-run command adapter"
+        );
+        assert_eq!(run.evidence.len(), 1);
+        assert_eq!(run.evidence[0].kind, WorkbenchEvidenceKind::AgentRun);
+    }
+
+    #[test]
     fn branch_infer_goal_is_available_with_branch_scope() {
         let mut state = WorkbenchState::default();
         state.branch_scope = Some(BranchScopeState {
@@ -1810,7 +2782,7 @@ mod tests {
             .filter(|candidate| candidate.ai_eligible)
             .collect::<Vec<_>>();
 
-        assert_eq!(ai_actions.len(), 1);
+        assert!(!ai_actions.is_empty());
         for action in ai_actions {
             assert!(
                 action

--- a/docs/generated/site-spec/features/workbench/assignment.md
+++ b/docs/generated/site-spec/features/workbench/assignment.md
@@ -17,13 +17,33 @@ description: "Generated reference for docs/syu/features/workbench/assignment.yam
 
 ### Features
 
-- **id**: FEAT-WORKBENCH-006
+- **id**: FEAT-WORKBENCH-ASSIGNMENT-001
   - **title**: Explicit human and AI assignment
-  - **summary**: Assign a scoped goal to a human or AI with a visible boundary, expected evidence, and a clear handoff point.
+  - **summary**: Assign a scoped Goal Plan to a human or command-adapter AI runner with visible scope, blockers, dry-run output, and evidence capture.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-WORKBENCH-005
   - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-workbench/src/lib.rs
+        - **symbols**:
+          - Assignment
+          - ScopeGuard
+          - CommandAgentAdapter
+          - EvidenceCollector
+      - **file**: crates/syu-app-ui/src/components/shell.rs
+        - **symbols**:
+          - AssignGoalDialog
+          - ScopeGuardPreview
+          - AgentRunPanel
+      - **file**: crates/syu-workbench/src/lib.rs
+        - **symbols**:
+          - assignment_blocker_logic_rejects_ambiguous_ai_scope
+          - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - assignment_preview_renders_blocked_state_with_scope_tokens
+          - assignment_actions_are_exposed_in_the_command_palette
     - **markdown**:
       - **file**: docs/guide/workbench.md
         - **symbols**:
@@ -38,13 +58,33 @@ category: Workbench
 version: 1
 
 features:
-  - id: FEAT-WORKBENCH-006
+  - id: FEAT-WORKBENCH-ASSIGNMENT-001
     title: Explicit human and AI assignment
-    summary: Assign a scoped goal to a human or AI with a visible boundary, expected evidence, and a clear handoff point.
+    summary: Assign a scoped Goal Plan to a human or command-adapter AI runner with visible scope, blockers, dry-run output, and evidence capture.
     status: implemented
     linked_requirements:
       - REQ-WORKBENCH-005
     implementations:
+      rust:
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - Assignment
+            - ScopeGuard
+            - CommandAgentAdapter
+            - EvidenceCollector
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - AssignGoalDialog
+            - ScopeGuardPreview
+            - AgentRunPanel
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - assignment_blocker_logic_rejects_ambiguous_ai_scope
+            - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - assignment_preview_renders_blocked_state_with_scope_tokens
+            - assignment_actions_are_exposed_in_the_command_palette
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/docs/generated/site-spec/features/workbench/assignment.md
+++ b/docs/generated/site-spec/features/workbench/assignment.md
@@ -44,6 +44,7 @@ description: "Generated reference for docs/syu/features/workbench/assignment.yam
         - **symbols**:
           - assignment_preview_renders_blocked_state_with_scope_tokens
           - assignment_actions_are_exposed_in_the_command_palette
+          - scope_guard_preview_renders_out_of_scope_changes
     - **markdown**:
       - **file**: docs/guide/workbench.md
         - **symbols**:
@@ -85,6 +86,7 @@ features:
           symbols:
             - assignment_preview_renders_blocked_state_with_scope_tokens
             - assignment_actions_are_exposed_in_the_command_palette
+            - scope_guard_preview_renders_out_of_scope_changes
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -188,6 +188,7 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
         - **symbols**:
           - assignment_preview_renders_blocked_state_with_scope_tokens
           - assignment_actions_are_exposed_in_the_command_palette
+          - scope_guard_preview_renders_out_of_scope_changes
 - **id**: REQ-WORKBENCH-006
   - **title**: Shared browser and desktop Workbench behavior
   - **description**:
@@ -406,6 +407,7 @@ requirements:
           symbols:
             - assignment_preview_renders_blocked_state_with_scope_tokens
             - assignment_actions_are_exposed_in_the_command_palette
+            - scope_guard_preview_renders_out_of_scope_changes
   - id: REQ-WORKBENCH-006
     title: Shared browser and desktop Workbench behavior
     description: |

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -159,17 +159,19 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
   - **title**: Human and AI assignment with explicit scope and evidence
   - **description**:
     - |
-      The Workbench MUST support assigning a scoped goal to a human or AI with
-      explicit scope, expected evidence, and a clear handoff boundary. The
-      assignment SHOULD be readable as a durable part of the goal rather than a
-      hidden runtime choice.
+      The Workbench MUST support assigning a scoped Goal Plan to a human or AI
+      command adapter with explicit include/exclude scope, non-goals, linked
+      spec context, required tests, completion commands, expected evidence, and
+      a clear handoff boundary. Automated assignment MUST be blocked when scope
+      is ambiguous or required constraints are missing, and dry-run output MUST
+      be captured as evidence.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
     - POL-005
   - **linked_features**:
     - FEAT-WORKBENCH-EVIDENCE-001
-    - FEAT-WORKBENCH-006
+    - FEAT-WORKBENCH-ASSIGNMENT-001
   - **tests**:
     - **markdown**:
       - **file**: docs/guide/workbench.md
@@ -177,6 +179,15 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
           - assignment
           - evidence
           - completion check
+    - **rust**:
+      - **file**: crates/syu-workbench/src/lib.rs
+        - **symbols**:
+          - assignment_blocker_logic_rejects_ambiguous_ai_scope
+          - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+      - **file**: tests/workbench_smoke.rs
+        - **symbols**:
+          - assignment_preview_renders_blocked_state_with_scope_tokens
+          - assignment_actions_are_exposed_in_the_command_palette
 - **id**: REQ-WORKBENCH-006
   - **title**: Shared browser and desktop Workbench behavior
   - **description**:
@@ -366,17 +377,19 @@ requirements:
   - id: REQ-WORKBENCH-005
     title: Human and AI assignment with explicit scope and evidence
     description: |
-      The Workbench MUST support assigning a scoped goal to a human or AI with
-      explicit scope, expected evidence, and a clear handoff boundary. The
-      assignment SHOULD be readable as a durable part of the goal rather than a
-      hidden runtime choice.
+      The Workbench MUST support assigning a scoped Goal Plan to a human or AI
+      command adapter with explicit include/exclude scope, non-goals, linked
+      spec context, required tests, completion commands, expected evidence, and
+      a clear handoff boundary. Automated assignment MUST be blocked when scope
+      is ambiguous or required constraints are missing, and dry-run output MUST
+      be captured as evidence.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-EVIDENCE-001
-      - FEAT-WORKBENCH-006
+      - FEAT-WORKBENCH-ASSIGNMENT-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -384,6 +397,15 @@ requirements:
             - assignment
             - evidence
             - completion check
+      rust:
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - assignment_blocker_logic_rejects_ambiguous_ai_scope
+            - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - assignment_preview_renders_blocked_state_with_scope_tokens
+            - assignment_actions_are_exposed_in_the_command_palette
   - id: REQ-WORKBENCH-006
     title: Shared browser and desktop Workbench behavior
     description: |

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,8 +14,8 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 173/173
-- Feature-to-implementation traceability: 196/196
+- Requirement-to-test traceability: 175/175
+- Feature-to-implementation traceability: 200/200
 
 ## Issues
 

--- a/docs/syu/features/workbench/assignment.yaml
+++ b/docs/syu/features/workbench/assignment.yaml
@@ -29,6 +29,7 @@ features:
           symbols:
             - assignment_preview_renders_blocked_state_with_scope_tokens
             - assignment_actions_are_exposed_in_the_command_palette
+            - scope_guard_preview_renders_out_of_scope_changes
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/docs/syu/features/workbench/assignment.yaml
+++ b/docs/syu/features/workbench/assignment.yaml
@@ -2,13 +2,33 @@ category: Workbench
 version: 1
 
 features:
-  - id: FEAT-WORKBENCH-006
+  - id: FEAT-WORKBENCH-ASSIGNMENT-001
     title: Explicit human and AI assignment
-    summary: Assign a scoped goal to a human or AI with a visible boundary, expected evidence, and a clear handoff point.
+    summary: Assign a scoped Goal Plan to a human or command-adapter AI runner with visible scope, blockers, dry-run output, and evidence capture.
     status: implemented
     linked_requirements:
       - REQ-WORKBENCH-005
     implementations:
+      rust:
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - Assignment
+            - ScopeGuard
+            - CommandAgentAdapter
+            - EvidenceCollector
+        - file: crates/syu-app-ui/src/components/shell.rs
+          symbols:
+            - AssignGoalDialog
+            - ScopeGuardPreview
+            - AgentRunPanel
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - assignment_blocker_logic_rejects_ambiguous_ai_scope
+            - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - assignment_preview_renders_blocked_state_with_scope_tokens
+            - assignment_actions_are_exposed_in_the_command_palette
       markdown:
         - file: docs/guide/workbench.md
           symbols:

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -167,6 +167,7 @@ requirements:
           symbols:
             - assignment_preview_renders_blocked_state_with_scope_tokens
             - assignment_actions_are_exposed_in_the_command_palette
+            - scope_guard_preview_renders_out_of_scope_changes
   - id: REQ-WORKBENCH-006
     title: Shared browser and desktop Workbench behavior
     description: |

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -138,17 +138,19 @@ requirements:
   - id: REQ-WORKBENCH-005
     title: Human and AI assignment with explicit scope and evidence
     description: |
-      The Workbench MUST support assigning a scoped goal to a human or AI with
-      explicit scope, expected evidence, and a clear handoff boundary. The
-      assignment SHOULD be readable as a durable part of the goal rather than a
-      hidden runtime choice.
+      The Workbench MUST support assigning a scoped Goal Plan to a human or AI
+      command adapter with explicit include/exclude scope, non-goals, linked
+      spec context, required tests, completion commands, expected evidence, and
+      a clear handoff boundary. Automated assignment MUST be blocked when scope
+      is ambiguous or required constraints are missing, and dry-run output MUST
+      be captured as evidence.
     priority: medium
     status: implemented
     linked_policies:
       - POL-005
     linked_features:
       - FEAT-WORKBENCH-EVIDENCE-001
-      - FEAT-WORKBENCH-006
+      - FEAT-WORKBENCH-ASSIGNMENT-001
     tests:
       markdown:
         - file: docs/guide/workbench.md
@@ -156,6 +158,15 @@ requirements:
             - assignment
             - evidence
             - completion check
+      rust:
+        - file: crates/syu-workbench/src/lib.rs
+          symbols:
+            - assignment_blocker_logic_rejects_ambiguous_ai_scope
+            - dry_run_command_adapter_captures_stdout_stderr_and_evidence
+        - file: tests/workbench_smoke.rs
+          symbols:
+            - assignment_preview_renders_blocked_state_with_scope_tokens
+            - assignment_actions_are_exposed_in_the_command_palette
   - id: REQ-WORKBENCH-006
     title: Shared browser and desktop Workbench behavior
     description: |

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -5,7 +5,8 @@ use syu_app_ui::{
     SpecImpactGraph, WorkbenchUiState, build_demo_state,
 };
 use syu_workbench::{
-    WorkbenchActionId, WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchState,
+    AssignmentBlocker, ScopeGuardResult, ScopeGuardStatus, WorkbenchActionId,
+    WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchState,
 };
 
 #[test]
@@ -197,6 +198,27 @@ fn assignment_actions_are_exposed_in_the_command_palette() {
     assert!(html.contains("assignment.run"));
     assert!(html.contains("assignment.record_manual"));
     assert!(html.contains("assignment.collect_evidence"));
+}
+
+#[test]
+fn scope_guard_preview_renders_out_of_scope_changes() {
+    let result = ScopeGuardResult {
+        status: ScopeGuardStatus::ScopeInvalid,
+        blockers: vec![AssignmentBlocker::new(
+            "out_of_scope_diff",
+            "runner produced changes outside allowed files",
+        )],
+        out_of_scope_files: vec!["examples/legacy-browser/index.ts".to_string()],
+    };
+
+    let html = render_element(rsx! {
+        syu_app_ui::ScopeGuardPreview { result }
+    });
+
+    assert!(html.contains("out-of-scope changes"));
+    assert!(html.contains("Out-of-scope changes"));
+    assert!(html.contains("examples/legacy-browser/index.ts"));
+    assert!(html.contains("scope-invalid"));
 }
 
 #[test]

--- a/tests/workbench_smoke.rs
+++ b/tests/workbench_smoke.rs
@@ -1,8 +1,8 @@
 use dioxus::prelude::*;
 use dioxus_ssr::render_element;
 use syu_app_ui::{
-    AppShell, BranchScopeLens, EvidencePanel, GoalCanvas, GoalPlanExportPanel, SpecImpactGraph,
-    WorkbenchUiState, build_demo_state,
+    AppShell, AssignGoalDialog, BranchScopeLens, EvidencePanel, GoalCanvas, GoalPlanExportPanel,
+    SpecImpactGraph, WorkbenchUiState, build_demo_state,
 };
 use syu_workbench::{
     WorkbenchActionId, WorkbenchActionRegistry, WorkbenchApiPayload, WorkbenchState,
@@ -156,6 +156,47 @@ fn request_flow_actions_are_exposed_in_the_command_palette() {
     assert!(html.contains("request.scope"));
     assert!(html.contains("request.scaffold"));
     assert!(html.contains("request.plan"));
+}
+
+#[test]
+fn assignment_preview_renders_blocked_state_with_scope_tokens() {
+    let ui = build_demo_state();
+
+    let html = render_element(rsx! {
+        AssignGoalDialog {
+            ui,
+            on_run_action: None
+        }
+    });
+
+    assert!(html.contains("Scoped Assignment"));
+    assert!(html.contains("Assignment Prompt Preview"));
+    assert!(html.contains("assignment-blocked"));
+    assert!(html.contains("scope-invalid"));
+    assert!(html.contains("scope-in"));
+    assert!(html.contains("scope-out"));
+    assert!(html.contains("evidence-required"));
+    assert!(
+        html.contains("AI assignment must list completion commands")
+            || html.contains("required_tests_missing")
+    );
+}
+
+#[test]
+fn assignment_actions_are_exposed_in_the_command_palette() {
+    let mut ui = build_demo_state();
+    ui.set_query("assignment.");
+
+    let html = render_element(rsx! {
+        AppShell { ui }
+    });
+
+    assert!(html.contains("assignment.create"));
+    assert!(html.contains("assignment.preview"));
+    assert!(html.contains("assignment.run_dry"));
+    assert!(html.contains("assignment.run"));
+    assert!(html.contains("assignment.record_manual"));
+    assert!(html.contains("assignment.collect_evidence"));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Add scoped assignment models, blocker checks, prompt building, and command-adapter dry-run evidence capture for Workbench Goal Plans.
- Add assignment UI panels for assignee selection, scope guard preview, constraints, prompt preview, runner output, human assignment, and evidence state using shared Workbench tokens.
- Update Workbench assignment specs and generated docs for FEAT-WORKBENCH-ASSIGNMENT-001 and REQ-WORKBENCH-005.

Validation:
- cargo test -p syu-workbench
- cargo test -p syu-app-ui
- cargo test --test workbench_smoke
- cargo run -- check .
- .git/hooks/pre-commit
- git push pre-push hooks: syu-quality-gates, syu-goal-tests

Closes #742
