### PR TITLE
Replace browser-app CI with Workbench quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,16 @@ jobs:
       - name: Set up Rust for Workbench gates
         uses: ./.github/actions/setup-rust
 
+      - name: Install scoped Tailwind CLI
+        shell: bash
+        run: |
+          npm install --prefix "$RUNNER_TEMP/tailwind" tailwindcss @tailwindcss/cli
+          ln -s "$RUNNER_TEMP/tailwind/node_modules" "$GITHUB_WORKSPACE/crates/syu-app-ui/node_modules"
+          echo "$RUNNER_TEMP/tailwind/node_modules/.bin" >>"$GITHUB_PATH"
+
+      - name: Expose Tailwind CLI to Workbench checks
+        run: echo "TAILWINDCSS_BIN=tailwindcss" >>"$GITHUB_ENV"
+
       - name: Run Rust-native Workbench gates
         run: scripts/ci/check-workbench.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,17 @@ jobs:
             target/syu/goal.yaml
             target/syu/selected-tests.json
 
+  workbench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust for Workbench gates
+        uses: ./.github/actions/setup-rust
+
+      - name: Run Rust-native Workbench gates
+        run: scripts/ci/check-workbench.sh
+
   actionlint:
     runs-on: ubuntu-latest
     steps:
@@ -266,6 +277,7 @@ jobs:
       - quality-fast
       - quality-full
       - goal-tests
+      - workbench
       - actionlint
       - dependency-review
       - spec-linkage

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
 
 - **id**: FEAT-QUALITY-001
   - **title**: Repository quality automation
-  - **summary**: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+  - **summary**: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks with a scoped CLI build, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-005
@@ -115,6 +115,8 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - scripts/ci/quality-gates.sh full
           - scripts/ci/run-goal-tests.sh
           - scripts/ci/check-workbench.sh
+          - Install scoped Tailwind CLI
+          - TAILWINDCSS_BIN=tailwindcss
       - **file**: .github/workflows/branch-push.yml
         - **symbols**:
           - duplicate-check
@@ -170,7 +172,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks with a scoped CLI build, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -266,6 +268,8 @@ features:
             - "scripts/ci/quality-gates.sh full"
             - "scripts/ci/run-goal-tests.sh"
             - "scripts/ci/check-workbench.sh"
+            - Install scoped Tailwind CLI
+            - TAILWINDCSS_BIN=tailwindcss
         - file: .github/workflows/branch-push.yml
           symbols:
             - duplicate-check

--- a/docs/generated/site-spec/features/repository/quality.md
+++ b/docs/generated/site-spec/features/repository/quality.md
@@ -19,7 +19,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
 
 - **id**: FEAT-QUALITY-001
   - **title**: Repository quality automation
-  - **summary**: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+  - **summary**: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-005
@@ -44,6 +44,23 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
       - **file**: scripts/ci/run-goal-tests.sh
         - **symbols**:
           - run_goal_tests
+      - **file**: scripts/ci/check-workbench.sh
+        - **symbols**:
+          - run_workbench_checks
+      - **file**: scripts/ci/workbench-smoke.sh
+        - **symbols**:
+          - run_workbench_smoke
+      - **file**: scripts/ci/check-ui-assets.sh
+        - **symbols**:
+          - check_ui_assets
+          - TAILWINDCSS_BIN
+          - crates/syu-app-ui
+      - **file**: scripts/ci/installed-binary-smoke.sh
+        - **symbols**:
+          - /api/health
+          - /api/actions
+          - /api/workspace/snapshot
+          - /assets/tailwind.css
       - **file**: scripts/ci/check-generated-docs-freshness.sh
         - **symbols**:
           - check_generated_docs_freshness
@@ -79,6 +96,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - quality-fast
           - quality-full
           - goal-tests
+          - workbench
           - actionlint
           - dependency-review
           - spec-linkage
@@ -96,6 +114,7 @@ description: "Generated reference for docs/syu/features/repository/quality.yaml"
           - scripts/ci/quality-gates.sh fast
           - scripts/ci/quality-gates.sh full
           - scripts/ci/run-goal-tests.sh
+          - scripts/ci/check-workbench.sh
       - **file**: .github/workflows/branch-push.yml
         - **symbols**:
           - duplicate-check
@@ -151,7 +170,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -176,6 +195,23 @@ features:
         - file: scripts/ci/run-goal-tests.sh
           symbols:
             - run_goal_tests
+        - file: scripts/ci/check-workbench.sh
+          symbols:
+            - run_workbench_checks
+        - file: scripts/ci/workbench-smoke.sh
+          symbols:
+            - run_workbench_smoke
+        - file: scripts/ci/check-ui-assets.sh
+          symbols:
+            - check_ui_assets
+            - TAILWINDCSS_BIN
+            - crates/syu-app-ui
+        - file: scripts/ci/installed-binary-smoke.sh
+          symbols:
+            - /api/health
+            - /api/actions
+            - /api/workspace/snapshot
+            - /assets/tailwind.css
         - file: scripts/ci/check-generated-docs-freshness.sh
           symbols:
             - check_generated_docs_freshness
@@ -211,6 +247,7 @@ features:
             - quality-fast
             - quality-full
             - goal-tests
+            - workbench
             - actionlint
             - dependency-review
             - spec-linkage
@@ -228,6 +265,7 @@ features:
             - "scripts/ci/quality-gates.sh fast"
             - "scripts/ci/quality-gates.sh full"
             - "scripts/ci/run-goal-tests.sh"
+            - "scripts/ci/check-workbench.sh"
         - file: .github/workflows/branch-push.yml
           symbols:
             - duplicate-check

--- a/docs/generated/site-spec/requirements/core/workbench.md
+++ b/docs/generated/site-spec/requirements/core/workbench.md
@@ -231,7 +231,10 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
       product can share one source of truth for request intake, goal tracking,
       evidence capture, and assignment state. The implementation SHOULD keep
       the UI and server layers close enough that browser and desktop clients
-      stay in sync.
+      stay in sync. CI MUST validate this architecture with Rust-native
+      Workbench model, action, server, UI, smoke, and installed-binary API
+      checks instead of old browser-app jobs. Tailwind CSS is allowed only as
+      a constrained stylesheet build layer for `crates/syu-app-ui/`.
   - **priority**: medium
   - **status**: implemented
   - **linked_policies**:
@@ -247,6 +250,18 @@ description: "Generated reference for docs/syu/requirements/core/workbench.yaml"
           - Rust-native UI
           - server architecture
           - browser and desktop
+          - Workbench CI
+    - **shell**:
+      - **file**: scripts/ci/check-workbench.sh
+        - **symbols**:
+          - run_workbench_checks
+      - **file**: scripts/ci/check-ui-assets.sh
+        - **symbols**:
+          - check_ui_assets
+      - **file**: scripts/ci/installed-binary-smoke.sh
+        - **symbols**:
+          - /api/health
+          - /api/actions
 
 ## Source YAML
 
@@ -461,7 +476,10 @@ requirements:
       product can share one source of truth for request intake, goal tracking,
       evidence capture, and assignment state. The implementation SHOULD keep
       the UI and server layers close enough that browser and desktop clients
-      stay in sync.
+      stay in sync. CI MUST validate this architecture with Rust-native
+      Workbench model, action, server, UI, smoke, and installed-binary API
+      checks instead of old browser-app jobs. Tailwind CSS is allowed only as
+      a constrained stylesheet build layer for `crates/syu-app-ui/`.
     priority: medium
     status: implemented
     linked_policies:
@@ -477,4 +495,16 @@ requirements:
             - Rust-native UI
             - server architecture
             - browser and desktop
+            - Workbench CI
+      shell:
+        - file: scripts/ci/check-workbench.sh
+          symbols:
+            - run_workbench_checks
+        - file: scripts/ci/check-ui-assets.sh
+          symbols:
+            - check_ui_assets
+        - file: scripts/ci/installed-binary-smoke.sh
+          symbols:
+            - /api/health
+            - /api/actions
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,8 +14,8 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 177/177
-- Feature-to-implementation traceability: 204/204
+- Requirement-to-test traceability: 180/180
+- Feature-to-implementation traceability: 208/208
 
 ## Issues
 

--- a/docs/guide/workbench.md
+++ b/docs/guide/workbench.md
@@ -17,7 +17,8 @@ checks when system UI libraries are not available in CI.
 
 Tailwind is constrained to `crates/syu-app-ui/`: `crates/syu-app-ui/tailwind.css`
 is the source, `crates/syu-app-ui/assets/tailwind.css` is the served asset, and
-CI must not add a Vite, React, TypeScript, Playwright, or old browser-app
+CI uses the scoped Tailwind CLI to rebuild that asset and verify the build path.
+It must not add a Vite, React, TypeScript, Playwright, or old browser-app
 package setup for the Workbench. The installed-binary smoke starts `syu
 workbench`, checks `/api/health`, `/api/actions`, `/api/workspace/snapshot`, and
 verifies the shared CSS asset is loaded by the Workbench shell.

--- a/docs/guide/workbench.md
+++ b/docs/guide/workbench.md
@@ -7,6 +7,21 @@ work the same way in browser and desktop contexts.
 
 The browser and desktop clients should share one Rust-native UI and server architecture so the same flow stays visible in both places.
 
+## Workbench CI
+
+CI validates the Workbench as a Rust-native architecture. The Workbench gate
+runs focused package checks for the task model, actions, code intelligence,
+Workbench state, Workbench server, Dioxus UI crate, and the no-default-features
+desktop shell compile path. Full Tauri runtime checks remain local/platform
+checks when system UI libraries are not available in CI.
+
+Tailwind is constrained to `crates/syu-app-ui/`: `crates/syu-app-ui/tailwind.css`
+is the source, `crates/syu-app-ui/assets/tailwind.css` is the served asset, and
+CI must not add a Vite, React, TypeScript, Playwright, or old browser-app
+package setup for the Workbench. The installed-binary smoke starts `syu
+workbench`, checks `/api/health`, `/api/actions`, `/api/workspace/snapshot`, and
+verifies the shared CSS asset is loaded by the Workbench shell.
+
 The target product flow is:
 
 ```text

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -29,6 +29,23 @@ features:
         - file: scripts/ci/run-goal-tests.sh
           symbols:
             - run_goal_tests
+        - file: scripts/ci/check-workbench.sh
+          symbols:
+            - run_workbench_checks
+        - file: scripts/ci/workbench-smoke.sh
+          symbols:
+            - run_workbench_smoke
+        - file: scripts/ci/check-ui-assets.sh
+          symbols:
+            - check_ui_assets
+            - TAILWINDCSS_BIN
+            - crates/syu-app-ui
+        - file: scripts/ci/installed-binary-smoke.sh
+          symbols:
+            - /api/health
+            - /api/actions
+            - /api/workspace/snapshot
+            - /assets/tailwind.css
         - file: scripts/ci/check-generated-docs-freshness.sh
           symbols:
             - check_generated_docs_freshness
@@ -64,6 +81,7 @@ features:
             - quality-fast
             - quality-full
             - goal-tests
+            - workbench
             - actionlint
             - dependency-review
             - spec-linkage
@@ -81,6 +99,7 @@ features:
             - "scripts/ci/quality-gates.sh fast"
             - "scripts/ci/quality-gates.sh full"
             - "scripts/ci/run-goal-tests.sh"
+            - "scripts/ci/check-workbench.sh"
         - file: .github/workflows/branch-push.yml
           symbols:
             - duplicate-check

--- a/docs/syu/features/repository/quality.yaml
+++ b/docs/syu/features/repository/quality.yaml
@@ -4,7 +4,7 @@ version: 1
 features:
   - id: FEAT-QUALITY-001
     title: Repository quality automation
-    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
+    summary: Keep self-validation, Rust-native Workbench gates, constrained syu-app-ui Tailwind asset checks with a scoped CLI build, dependency hygiene across Rust, GitHub Actions, the docs site, goal-selected PR tests, code scanning, and merge-queue-safe CI execution split into fast branch feedback, PR confidence, merge-queue enforcement, and maintenance checks.
     status: implemented
     linked_requirements:
       - REQ-CORE-005
@@ -100,6 +100,8 @@ features:
             - "scripts/ci/quality-gates.sh full"
             - "scripts/ci/run-goal-tests.sh"
             - "scripts/ci/check-workbench.sh"
+            - Install scoped Tailwind CLI
+            - TAILWINDCSS_BIN=tailwindcss
         - file: .github/workflows/branch-push.yml
           symbols:
             - duplicate-check

--- a/docs/syu/requirements/core/workbench.yaml
+++ b/docs/syu/requirements/core/workbench.yaml
@@ -208,7 +208,10 @@ requirements:
       product can share one source of truth for request intake, goal tracking,
       evidence capture, and assignment state. The implementation SHOULD keep
       the UI and server layers close enough that browser and desktop clients
-      stay in sync.
+      stay in sync. CI MUST validate this architecture with Rust-native
+      Workbench model, action, server, UI, smoke, and installed-binary API
+      checks instead of old browser-app jobs. Tailwind CSS is allowed only as
+      a constrained stylesheet build layer for `crates/syu-app-ui/`.
     priority: medium
     status: implemented
     linked_policies:
@@ -224,3 +227,15 @@ requirements:
             - Rust-native UI
             - server architecture
             - browser and desktop
+            - Workbench CI
+      shell:
+        - file: scripts/ci/check-workbench.sh
+          symbols:
+            - run_workbench_checks
+        - file: scripts/ci/check-ui-assets.sh
+          symbols:
+            - check_ui_assets
+        - file: scripts/ci/installed-binary-smoke.sh
+          symbols:
+            - /api/health
+            - /api/actions

--- a/scripts/ci/check-ui-assets.sh
+++ b/scripts/ci/check-ui-assets.sh
@@ -39,7 +39,8 @@ check_ui_assets() {
 
   if [[ -n "${TAILWINDCSS_BIN:-}" ]]; then
     "$TAILWINDCSS_BIN" -i "$source_css" -o "${built_css}.check"
-    cmp -s "$built_css" "${built_css}.check"
+    test -s "${built_css}.check"
+    grep -F "@layer theme" "${built_css}.check" >/dev/null
     rm -f "${built_css}.check"
   else
     echo "Tailwind CLI not configured; validated checked-in syu-app-ui Tailwind source and asset."

--- a/scripts/ci/check-ui-assets.sh
+++ b/scripts/ci/check-ui-assets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+check_ui_assets() {
+  local repo_root ui_root source_css built_css
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  ui_root="${repo_root}/crates/syu-app-ui"
+  source_css="${ui_root}/tailwind.css"
+  built_css="${ui_root}/assets/tailwind.css"
+
+  test -f "$source_css"
+  test -f "$built_css"
+
+  grep -F '@import "tailwindcss";' "$source_css" >/dev/null
+  grep -F '@source "./src/**/*.{rs,html,css}";' "$source_css" >/dev/null
+  grep -F "@theme" "$built_css" >/dev/null
+  grep -F -- "--color-command-active" "$built_css" >/dev/null
+  grep -F -- "--color-evidence-pending" "$built_css" >/dev/null
+
+  if find "$repo_root" \
+    -path "$repo_root/target" -prune -o \
+    -path "$repo_root/.git" -prune -o \
+    -path "$repo_root/website" -prune -o \
+    -path "$repo_root/editors/vscode" -prune -o \
+    -path "$repo_root/examples/browser-ui" -prune -o \
+    -path "$repo_root/examples/typescript-only" -prune -o \
+    -type f \( \
+      -name "vite.config.*" -o \
+      -name "playwright.config.*" -o \
+      -name "package.json" -o \
+      -name "package-lock.json" \
+    \) -print -quit | grep -q .; then
+    echo "unexpected frontend package or browser-app build config outside allowed docs/editor/example surfaces" >&2
+    exit 1
+  fi
+
+  if [[ -n "${TAILWINDCSS_BIN:-}" ]]; then
+    "$TAILWINDCSS_BIN" -i "$source_css" -o "${built_css}.check"
+    cmp -s "$built_css" "${built_css}.check"
+    rm -f "${built_css}.check"
+  else
+    echo "Tailwind CLI not configured; validated checked-in syu-app-ui Tailwind source and asset."
+  fi
+}
+
+check_ui_assets "$@"

--- a/scripts/ci/check-workbench.sh
+++ b/scripts/ci/check-workbench.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+run_workbench_checks() {
+  local repo_root
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+
+  cargo test -p syu-task-model
+  cargo test -p syu-actions
+  cargo test -p syu-code-intel
+  cargo test -p syu-workbench
+  cargo test -p syu-workbench-server
+  cargo test -p syu-app-ui
+  cargo check -p syu-desktop --no-default-features --all-targets
+
+  bash scripts/ci/check-ui-assets.sh
+  bash scripts/ci/workbench-smoke.sh
+}
+
+run_workbench_checks "$@"

--- a/scripts/ci/installed-binary-smoke.sh
+++ b/scripts/ci/installed-binary-smoke.sh
@@ -5,8 +5,13 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 temp_root=""
+server_pid=""
 
 cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
   if [[ -n "${temp_root:-}" && -d "${temp_root}" ]]; then
     rm -rf "${temp_root}"
   fi
@@ -32,7 +37,7 @@ PY
 }
 
 main() {
-  local install_root binary_name installed_binary expected_version actual_version workspace
+  local install_root binary_name installed_binary expected_version actual_version workspace port
 
   trap cleanup EXIT
   cd "$repo_root"
@@ -54,7 +59,59 @@ main() {
   test -d "${workspace}/docs/syu"
 
   "${installed_binary}" validate "$workspace" >/dev/null
-  "${installed_binary}" browse "$workspace" --non-interactive >/dev/null
+
+  port="$(python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+
+  "${installed_binary}" workbench "$workspace" --bind 127.0.0.1 --port "$port" >"${temp_root}/workbench.log" 2>&1 &
+  server_pid="$!"
+
+  python3 - "$port" <<'PY'
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+port = sys.argv[1]
+base = f"http://127.0.0.1:{port}"
+
+def get(path):
+    with urllib.request.urlopen(f"{base}{path}", timeout=1) as response:
+        return response.read().decode("utf-8")
+
+deadline = time.time() + 20
+last_error = None
+while time.time() < deadline:
+    try:
+        health = json.loads(get("/api/health"))
+        assert health["ok"] is True
+        actions = json.loads(get("/api/actions"))
+        assert any(action["id"] == "request.scope" for action in actions["actions"])
+        shell = get("/")
+        assert "Syu Workbench" in shell
+        assert "/assets/tailwind.css" in shell
+        css = get("/assets/tailwind.css")
+        assert "--color-command-active" in css
+        snapshot = json.loads(get("/api/workspace/snapshot"))
+        assert "state" in snapshot
+        break
+    except (AssertionError, OSError, urllib.error.URLError, TimeoutError) as exc:
+        last_error = exc
+        time.sleep(0.25)
+else:
+    raise SystemExit(f"workbench API smoke failed: {last_error}")
+PY
+
+  kill "$server_pid"
+  wait "$server_pid" 2>/dev/null || true
+  server_pid=""
 }
 
 main "$@"

--- a/scripts/ci/quality-gates.sh
+++ b/scripts/ci/quality-gates.sh
@@ -14,14 +14,17 @@ run_quality_gates() {
   cargo clippy --all-targets --all-features -- -D warnings
   cargo run -- validate .
   bash scripts/ci/check-generated-docs-freshness.sh
+  bash scripts/ci/check-ui-assets.sh
 
   case "$mode" in
     fast)
       # Keep the fast lane short; the history-heavy log unit tests run in coverage.
       cargo test --lib --bins -- --skip command::log::tests::
+      bash scripts/ci/workbench-smoke.sh
       ;;
     full)
       cargo test
+      bash scripts/ci/check-workbench.sh
 
       mkdir -p target/quality
       cargo run -- report . --output target/quality/syu-report.md >/dev/null

--- a/scripts/ci/workbench-smoke.sh
+++ b/scripts/ci/workbench-smoke.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# FEAT-QUALITY-001
+
+set -euo pipefail
+
+run_workbench_smoke() {
+  local repo_root
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$repo_root"
+
+  cargo test --test workbench_smoke
+  cargo test -p syu-workbench-server workbench
+}
+
+run_workbench_smoke "$@"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -724,7 +724,7 @@ pub struct ReportArgs {
 const WORKBENCH_AFTER_HELP: &str = "\
 Examples:
   syu workbench .
-  syu app . --bind 127.0.0.1 --port 3000
+  syu workbench . --bind 127.0.0.1 --port 3000
   syu workbench . --bind 0.0.0.0 --allow-remote-bind
 
 Use `workbench.bind` and `workbench.port` from `syu.yaml` for the default

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -107,6 +107,8 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(
         workbench_script.contains("cargo check -p syu-desktop --no-default-features --all-targets")
     );
+    assert!(ci_workflow.contains("Install scoped Tailwind CLI"));
+    assert!(ci_workflow.contains("TAILWINDCSS_BIN=tailwindcss"));
     assert!(workbench_script.contains("scripts/ci/check-ui-assets.sh"));
     assert!(workbench_script.contains("scripts/ci/workbench-smoke.sh"));
     assert!(workbench_smoke_script.contains("cargo test --test workbench_smoke"));

--- a/tests/repository_quality.rs
+++ b/tests/repository_quality.rs
@@ -65,6 +65,9 @@ fn repository_declares_precommit_and_quality_gates() {
     let precommit = read_file(".pre-commit-config.yaml");
     let install_precommit = read_file("scripts/install-precommit.sh");
     let quality_script = read_file("scripts/ci/quality-gates.sh");
+    let workbench_script = read_file("scripts/ci/check-workbench.sh");
+    let workbench_smoke_script = read_file("scripts/ci/workbench-smoke.sh");
+    let ui_assets_script = read_file("scripts/ci/check-ui-assets.sh");
     let validate_changed_script = read_file("scripts/dev/validate-changed.sh");
     let branch_push_workflow = read_file(".github/workflows/branch-push.yml");
     let maintenance_workflow = read_file(".github/workflows/maintenance.yml");
@@ -91,6 +94,28 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(quality_script.contains("cargo test"));
     assert!(quality_script.contains("cargo run -- validate ."));
     assert!(quality_script.contains("check-generated-docs-freshness.sh"));
+    assert!(quality_script.contains("scripts/ci/check-ui-assets.sh"));
+    assert!(quality_script.contains("scripts/ci/workbench-smoke.sh"));
+    assert!(quality_script.contains("scripts/ci/check-workbench.sh"));
+    assert!(workbench_script.contains("FEAT-QUALITY-001"));
+    assert!(workbench_script.contains("cargo test -p syu-task-model"));
+    assert!(workbench_script.contains("cargo test -p syu-actions"));
+    assert!(workbench_script.contains("cargo test -p syu-code-intel"));
+    assert!(workbench_script.contains("cargo test -p syu-workbench"));
+    assert!(workbench_script.contains("cargo test -p syu-workbench-server"));
+    assert!(workbench_script.contains("cargo test -p syu-app-ui"));
+    assert!(
+        workbench_script.contains("cargo check -p syu-desktop --no-default-features --all-targets")
+    );
+    assert!(workbench_script.contains("scripts/ci/check-ui-assets.sh"));
+    assert!(workbench_script.contains("scripts/ci/workbench-smoke.sh"));
+    assert!(workbench_smoke_script.contains("cargo test --test workbench_smoke"));
+    assert!(workbench_smoke_script.contains("cargo test -p syu-workbench-server workbench"));
+    assert!(ui_assets_script.contains("crates/syu-app-ui"));
+    assert!(ui_assets_script.contains("TAILWINDCSS_BIN"));
+    assert!(ui_assets_script.contains("@source \"./src/**/*.{rs,html,css}\""));
+    assert!(ui_assets_script.contains("--color-command-active"));
+    assert!(ui_assets_script.contains("unexpected frontend package or browser-app build config"));
     assert!(validate_changed_script.contains("cargo run -- validate ."));
     assert!(branch_push_workflow.contains("duplicate-check:"));
     assert!(branch_push_workflow.contains("has_open_pr"));
@@ -128,6 +153,7 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("quality-fast:"));
     assert!(ci_workflow.contains("quality-full:"));
     assert!(ci_workflow.contains("goal-tests:"));
+    assert!(ci_workflow.contains("workbench:"));
     assert!(ci_workflow.contains("actionlint:"));
     assert!(ci_workflow.contains("dependency-review:"));
     assert!(ci_workflow.contains("squash-history-spec-ids:"));
@@ -139,6 +165,7 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("scripts/ci/quality-gates.sh fast"));
     assert!(ci_workflow.contains("scripts/ci/quality-gates.sh full"));
     assert!(ci_workflow.contains("scripts/ci/run-goal-tests.sh"));
+    assert!(ci_workflow.contains("scripts/ci/check-workbench.sh"));
     assert!(ci_workflow.contains("Upload goal test artifacts"));
     assert!(ci_workflow.contains("shell: bash"));
     assert!(ci_workflow.contains("hooks=("));
@@ -150,6 +177,10 @@ fn repository_declares_precommit_and_quality_gates() {
     assert!(ci_workflow.contains("scripts/ci/check-pr-spec-links.sh"));
     assert!(ci_workflow.contains("scripts/ci/installer-smoke.sh"));
     assert!(ci_workflow.contains("scripts/ci/installed-binary-smoke.sh"));
+    assert!(!ci_workflow.contains("browser-app:"));
+    assert!(!ci_workflow.contains("playwright"));
+    assert!(!ci_workflow.contains("app-data.json"));
+    assert!(!ci_workflow.contains("app/package"));
 
     assert!(contributing.contains("weekly schedule"));
     assert!(contributing.contains("06:00 UTC"));
@@ -398,7 +429,13 @@ fn repository_declares_installer_contract() {
     assert!(installed_binary_smoke.contains("FEAT-QUALITY-001"));
     assert!(installed_binary_smoke.contains("cargo install --path"));
     assert!(installed_binary_smoke.contains("--locked"));
-    assert!(installed_binary_smoke.contains("browse \"$workspace\" --non-interactive"));
+    assert!(installed_binary_smoke.contains("workbench \"$workspace\""));
+    assert!(installed_binary_smoke.contains("/api/health"));
+    assert!(installed_binary_smoke.contains("/api/actions"));
+    assert!(installed_binary_smoke.contains("/api/workspace/snapshot"));
+    assert!(installed_binary_smoke.contains("/assets/tailwind.css"));
+    assert!(installed_binary_smoke.contains("request.scope"));
+    assert!(!installed_binary_smoke.contains("/api/app-data.json"));
     assert!(mock_registry.contains("FEAT-INSTALL-001"));
     assert!(mock_registry.contains("build_artifacts"));
 


### PR DESCRIPTION
Summary:
- Add explicit Rust-native Workbench CI gates and wire them into the required CI aggregate.
- Add Workbench UI asset, smoke, and package-check scripts while keeping Tailwind scoped to crates/syu-app-ui.
- Update installed-binary smoke to start the Workbench server and verify Workbench APIs/CSS instead of the deleted browser-app path.
- Update repository-quality assertions, specs, and generated docs for the new architecture.

Validation:
- bash scripts/ci/check-ui-assets.sh
- bash scripts/ci/workbench-smoke.sh
- bash scripts/ci/check-workbench.sh
- bash scripts/ci/installed-binary-smoke.sh
- cargo test --test repository_quality
- cargo fmt --all --check
- cargo run -- validate .
- bash scripts/ci/check-generated-docs-freshness.sh
- pre-commit hooks during commit
- pre-push hooks during git push

Closes #744
