### PR TITLE
REQ-CORE-001: Speed up validate coverage checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ syu validate . --id REQ-001
 syu validate . --warning-exit-code 3
 syu validate . --fix
 syu validate . --no-fix
+syu validate . --no-cache
 syu validate . --allow-planned=false
 syu validate . --require-reciprocal-links=false
 syu validate . --require-symbol-trace-coverage
@@ -446,6 +447,8 @@ Use `--severity`, `--genre`, `--rule`, and `--id` to narrow the rendered issue l
 without changing the underlying validation result or exit code.
 Use the validate override flags for one-off stricter or looser runs without
 editing `syu.yaml`.
+Use `--no-cache` to bypass in-memory file and symbol inspection caches while
+debugging validation behavior.
 By default, warning-only runs still exit 0. Add `--warning-exit-code <CODE>` when
 CI or shell automation needs a distinct non-zero status for warnings while
 keeping error-bearing runs on exit code 1.

--- a/docs/generated/site-spec/requirements/core/validation.md
+++ b/docs/generated/site-spec/requirements/core/validation.md
@@ -35,7 +35,8 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       both text and JSON output without changing the underlying validation
       result, MUST support a reviewer-friendly `--spec-only` mode that skips
       traced source checks while still validating the layered specification
-      itself, and `syu.yaml` MUST be able to disable reciprocal-link
+      itself, MUST provide `--no-cache` to bypass in-memory validation caches
+      without changing the validation result, and `syu.yaml` MUST be able to disable reciprocal-link
       enforcement without disabling missing-reference validation. `check` MAY
       remain as a compatibility alias, but `validate` is the canonical command
       name.
@@ -83,6 +84,7 @@ description: "Generated reference for docs/syu/requirements/core/validation.yaml
       - **file**: tests/help_command.rs
         - **symbols**:
           - validate_help_mentions_spec_only_mode
+          - validate_help_mentions_cache_bypass_mode
           - validate_help_mentions_dry_run_mode
       - **file**: src/command/check.rs
         - **symbols**:
@@ -289,7 +291,8 @@ requirements:
       both text and JSON output without changing the underlying validation
       result, MUST support a reviewer-friendly `--spec-only` mode that skips
       traced source checks while still validating the layered specification
-      itself, and `syu.yaml` MUST be able to disable reciprocal-link
+      itself, MUST provide `--no-cache` to bypass in-memory validation caches
+      without changing the validation result, and `syu.yaml` MUST be able to disable reciprocal-link
       enforcement without disabling missing-reference validation. `check` MAY
       remain as a compatibility alias, but `validate` is the canonical command
       name.
@@ -337,6 +340,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - validate_help_mentions_spec_only_mode
+            - validate_help_mentions_cache_bypass_mode
             - validate_help_mentions_dry_run_mode
         - file: src/command/check.rs
           symbols:

--- a/docs/syu/requirements/core/validation.yaml
+++ b/docs/syu/requirements/core/validation.yaml
@@ -18,7 +18,8 @@ requirements:
       both text and JSON output without changing the underlying validation
       result, MUST support a reviewer-friendly `--spec-only` mode that skips
       traced source checks while still validating the layered specification
-      itself, and `syu.yaml` MUST be able to disable reciprocal-link
+      itself, MUST provide `--no-cache` to bypass in-memory validation caches
+      without changing the validation result, and `syu.yaml` MUST be able to disable reciprocal-link
       enforcement without disabling missing-reference validation. `check` MAY
       remain as a compatibility alias, but `validate` is the canonical command
       name.
@@ -66,6 +67,7 @@ requirements:
         - file: tests/help_command.rs
           symbols:
             - validate_help_mentions_spec_only_mode
+            - validate_help_mentions_cache_bypass_mode
             - validate_help_mentions_dry_run_mode
         - file: src/command/check.rs
           symbols:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -637,6 +637,10 @@ pub struct ValidateArgs {
     #[arg(long, action = ArgAction::SetTrue)]
     pub spec_only: bool,
 
+    #[arg(help = "Disable in-memory validation caches for this run")]
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub no_cache: bool,
+
     #[arg(
         help = "Apply conservative autofixes for trace docs, graph links, and feature registry drift"
     )]

--- a/src/command/check.rs
+++ b/src/command/check.rs
@@ -16,8 +16,8 @@ use crate::{
     command::shell_quote_path,
     config::{SyuConfig, TraceOwnershipMode},
     coverage::{
-        normalize_relative_path, normalized_symbol_trace_coverage_ignored_paths,
-        path_matches_ignored_generated_directory, validate_symbol_trace_coverage,
+        collect_symbol_trace_coverage_issues, normalize_relative_path,
+        normalized_symbol_trace_coverage_ignored_paths, path_matches_ignored_generated_directory,
     },
     history::{HistoricalIdIndex, build_historical_id_index},
     inspect::{
@@ -73,8 +73,9 @@ struct RequirementValidationIndex<'a> {
     features_by_id: &'a HashMap<&'a str, &'a Feature>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct TraceValidationCache {
+    enabled: bool,
     file_contents: HashMap<PathBuf, Result<String, String>>,
     rich_inspections: HashMap<TraceInspectionCacheKey, TraceInspectionCacheEntry>,
 }
@@ -82,8 +83,25 @@ struct TraceValidationCache {
 type TraceInspectionCacheKey = (String, PathBuf);
 type TraceInspectionCacheEntry = Result<Option<HashMap<String, SymbolInspection>>, String>;
 
+impl Default for TraceValidationCache {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
 impl TraceValidationCache {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            file_contents: HashMap::new(),
+            rich_inspections: HashMap::new(),
+        }
+    }
+
     fn read_file(&mut self, path: &Path) -> Result<&str, String> {
+        if !self.enabled {
+            self.file_contents.clear();
+        }
         let entry = self
             .file_contents
             .entry(path.to_path_buf())
@@ -99,6 +117,9 @@ impl TraceValidationCache {
         contents: &str,
         symbol: &str,
     ) -> Result<Option<SymbolInspection>, String> {
+        if !self.enabled {
+            self.rich_inspections.clear();
+        }
         let key = (language.to_string(), path.to_path_buf());
         let entry = self.rich_inspections.entry(key).or_insert_with(|| {
             inspect_file_symbols(language, config, path, contents)
@@ -515,8 +536,11 @@ pub fn run_check_command(args: &CheckArgs) -> Result<i32> {
             } else {
                 with_validate_overrides(workspace, args)
             };
-            let mut result =
-                collect_check_result_from_workspace_with_mode(&workspace, args.spec_only);
+            let mut result = collect_check_result_from_workspace_with_mode(
+                &workspace,
+                args.spec_only,
+                !args.no_cache,
+            );
             apply_cli_override_issue_guidance(&mut result, args);
             let text_summary =
                 TextReportSummary::from_config(&workspace.config, &result.definition_counts);
@@ -611,12 +635,13 @@ pub fn collect_check_result(workspace_path: &Path) -> CheckResult {
 }
 
 pub fn collect_check_result_from_workspace(workspace: &Workspace) -> CheckResult {
-    collect_check_result_from_workspace_with_mode(workspace, false)
+    collect_check_result_from_workspace_with_mode(workspace, false, true)
 }
 
 fn collect_check_result_from_workspace_with_mode(
     workspace: &Workspace,
     spec_only: bool,
+    cache_enabled: bool,
 ) -> CheckResult {
     let definition_counts = DefinitionCounts {
         philosophies: workspace.philosophies.len(),
@@ -691,43 +716,57 @@ fn collect_check_result_from_workspace_with_mode(
         policies_by_id: &policies_by_id,
         features_by_id: &features_by_id,
     };
-    let mut trace_cache = TraceValidationCache::default();
+    let mut trace_cache = TraceValidationCache::new(cache_enabled);
 
-    for philosophy in &workspace.philosophies {
-        validate_philosophy(philosophy, &policies_by_id, &workspace.config, &mut issues);
-    }
+    let coverage_issues = std::thread::scope(|scope| {
+        let coverage_handle = (!spec_only && !cfg!(test))
+            .then(|| scope.spawn(|| collect_symbol_trace_coverage_issues(workspace)));
 
-    for policy in &workspace.policies {
-        validate_policy(
-            policy,
-            &philosophies_by_id,
-            &requirements_by_id,
-            &workspace.config,
-            &mut issues,
-        );
-    }
+        for philosophy in &workspace.philosophies {
+            validate_philosophy(philosophy, &policies_by_id, &workspace.config, &mut issues);
+        }
 
-    for requirement in &workspace.requirements {
-        validate_requirement_with_cache(
-            requirement,
-            requirement_validation_index,
-            validation_resources,
-            &mut issues,
-            &mut trace_summary.requirement_traces,
-            &mut trace_cache,
-        );
-    }
+        for policy in &workspace.policies {
+            validate_policy(
+                policy,
+                &philosophies_by_id,
+                &requirements_by_id,
+                &workspace.config,
+                &mut issues,
+            );
+        }
 
-    for feature in &workspace.features {
-        validate_feature_with_cache(
-            feature,
-            &requirements_by_id,
-            validation_resources,
-            &mut issues,
-            &mut trace_summary.feature_traces,
-            &mut trace_cache,
-        );
-    }
+        for requirement in &workspace.requirements {
+            validate_requirement_with_cache(
+                requirement,
+                requirement_validation_index,
+                validation_resources,
+                &mut issues,
+                &mut trace_summary.requirement_traces,
+                &mut trace_cache,
+            );
+        }
+
+        for feature in &workspace.features {
+            validate_feature_with_cache(
+                feature,
+                &requirements_by_id,
+                validation_resources,
+                &mut issues,
+                &mut trace_summary.feature_traces,
+                &mut trace_cache,
+            );
+        }
+
+        let concurrent_issues = coverage_handle.map(|handle| {
+            handle
+                .join()
+                .expect("symbol trace coverage thread should not panic")
+        });
+        concurrent_issues.or_else(|| {
+            (!spec_only && cfg!(test)).then(|| collect_symbol_trace_coverage_issues(workspace))
+        })
+    });
 
     if let Some(historical_ids) = historical_ids.as_ref() {
         validate_historical_id_reuse(workspace, historical_ids, &mut issues);
@@ -746,8 +785,8 @@ fn collect_check_result_from_workspace_with_mode(
     }
 
     validate_orphaned_definitions(workspace, &mut issues);
-    if !spec_only {
-        validate_symbol_trace_coverage(workspace, &mut issues);
+    if let Some(coverage_issues) = coverage_issues {
+        issues.extend(coverage_issues);
     }
 
     issues.sort_by(|left, right| {
@@ -4374,6 +4413,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: false,
             dry_run: false,
             no_fix: false,
@@ -4404,6 +4444,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: true,
             dry_run: false,
             no_fix: false,
@@ -4440,6 +4481,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: false,
             dry_run: false,
             no_fix: false,
@@ -4515,6 +4557,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: true,
             dry_run: false,
             no_fix: false,
@@ -4547,6 +4590,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: true,
             dry_run: false,
             no_fix: false,
@@ -4604,6 +4648,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: false,
             dry_run: true,
             no_fix: false,

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1639,6 +1639,7 @@ mod tests {
             rule: Vec::new(),
             id: Vec::new(),
             spec_only: false,
+            no_cache: false,
             fix: false,
             dry_run: false,
             no_fix: false,

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -91,6 +91,12 @@ pub fn validate_symbol_trace_coverage(workspace: &Workspace, issues: &mut Vec<Is
     );
 }
 
+pub fn collect_symbol_trace_coverage_issues(workspace: &Workspace) -> Vec<Issue> {
+    let mut issues = Vec::new();
+    validate_symbol_trace_coverage(workspace, &mut issues);
+    issues
+}
+
 fn validate_symbol_trace_coverage_with(
     workspace: &Workspace,
     issues: &mut Vec<Issue>,
@@ -100,91 +106,41 @@ fn validate_symbol_trace_coverage_with(
         return;
     }
 
-    let mut targets = match (discoverers.rust)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            output.targets
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
+    let discoveries = [
+        discoverers.rust,
+        discoverers.python,
+        discoverers.ruby,
+        discoverers.go,
+        discoverers.java,
+        discoverers.csharp,
+        discoverers.kotlin,
+        discoverers.typescript,
+    ];
+    let results = if cfg!(test) {
+        discoveries.map(|discover| discover(&workspace.config, &workspace.root))
+    } else {
+        std::thread::scope(|scope| {
+            discoveries
+                .map(|discover| scope.spawn(move || discover(&workspace.config, &workspace.root)))
+                .map(|handle| {
+                    handle
+                        .join()
+                        .expect("coverage discovery thread should not panic")
+                })
+        })
     };
 
-    match (discoverers.python)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.ruby)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.go)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.java)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.csharp)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.kotlin)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
-        }
-    }
-
-    match (discoverers.typescript)(&workspace.config, &workspace.root) {
-        Ok(output) => {
-            issues.extend(output.issues);
-            targets.extend(output.targets);
-        }
-        Err(issue) => {
-            issues.push(*issue);
-            return;
+    let mut targets = Vec::new();
+    for result in results {
+        match result {
+            Ok(output) => {
+                issues.extend(output.issues);
+                targets.extend(output.targets);
+            }
+            Err(issue) => {
+                issues.push(*issue);
+                return;
+            }
         }
     }
 

--- a/tests/check_command.rs
+++ b/tests/check_command.rs
@@ -183,6 +183,28 @@ fn check_command_accepts_passing_workspace() {
 
 #[test]
 // REQ-CORE-001
+fn validate_no_cache_preserves_json_result() {
+    let workspace = fixture_path("passing");
+    let cached = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--format", "json"])
+        .arg(&workspace)
+        .output()
+        .expect("cached validation should run");
+    let uncached = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--format", "json", "--no-cache"])
+        .arg(&workspace)
+        .output()
+        .expect("uncached validation should run");
+
+    assert_eq!(cached.status.code(), uncached.status.code());
+    assert_eq!(cached.stdout, uncached.stdout);
+    assert_eq!(cached.stderr, uncached.stderr);
+}
+
+#[test]
+// REQ-CORE-001
 fn check_command_preserves_default_workspace_dot_in_next_steps() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")

--- a/tests/help_command.rs
+++ b/tests/help_command.rs
@@ -424,6 +424,21 @@ fn validate_help_mentions_spec_only_mode() {
 }
 
 #[test]
+fn validate_help_mentions_cache_bypass_mode() {
+    let output = Command::cargo_bin("syu")
+        .expect("binary should build")
+        .args(["validate", "--help"])
+        .output()
+        .expect("help should render");
+
+    assert!(output.status.success(), "validate help should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--no-cache"));
+    assert!(stdout.contains("Disable in-memory validation caches"));
+}
+
+#[test]
 fn init_help_lists_starter_templates() {
     let output = Command::cargo_bin("syu")
         .expect("binary should build")


### PR DESCRIPTION
Linked specification:
- REQ-CORE-001
- FEAT-CHECK-001

Summary:
- run independent validation coverage discovery and graph/trace validation concurrently while preserving deterministic issue ordering
- run per-language coverage discovery concurrently in normal builds
- add `syu validate --no-cache` to bypass in-memory file and symbol inspection caches without changing results
- document and trace the new option, with regression coverage for cached/uncached JSON equivalence

Performance:
- release-build median on this repository improved from about 0.53s to 0.40s (about 25%)
- `--no-cache` remains available for validation/debugging and produces identical JSON output

Validation:
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --quiet -- validate .`
- `bash scripts/ci/check-generated-docs-freshness.sh`
- `bash scripts/ci/check-ui-assets.sh`
- `cargo test --test check_command validate_no_cache_preserves_json_result`
- `cargo test --test help_command validate_help_mentions_cache_bypass_mode`
- `cargo test --lib coverage::tests:: -- --test-threads=1`

Local full-gate note:
- macOS pre-push full tests hit existing platform/environment failures: BSD `script` lacks Linux `-c`, and existing tests race on process-global cwd/PATH/LCOV state. Remote Linux CI is the authoritative full-gate result.
