### PR TITLE
REQ-CORE-034 FEAT-TASK-007: Add shared typed Work planner

### DIFF
--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -16,7 +16,8 @@ pub use syu::command::{
 pub use syu::model::CheckResult as ValidationReport;
 pub use syu_task_model::{
     ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, RequestArtifact, ScaffoldPlan,
-    ScopeOutcome, TaskTestSelectionPlan,
+    ScopeOutcome, TaskTestSelectionPlan, WorkIntent, WorkKind, WorkMode, WorkOperation, WorkPlan,
+    WorkSeed, WorkSurface,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -98,6 +99,269 @@ pub fn scope_request(
 ) -> Result<ScopeOutcome> {
     let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
     syu::command::task::scope_request(&workspace, request)
+}
+
+/// Build a UI-independent, typed Work plan from a natural-language request.
+///
+/// Explicit axes take precedence over inference. Related spec items are expanded through the
+/// existing workspace graph and annotated according to the selected WorkKind profile.
+pub fn plan_request_work(
+    workspace: impl AsRef<Path>,
+    request: &RequestArtifact,
+    explicit_kind: Option<WorkKind>,
+    explicit_operation: Option<WorkOperation>,
+    explicit_mode: Option<WorkMode>,
+) -> Result<WorkPlan> {
+    use syu_task_model::{
+        ImpactRole, ImpactedItem, WorkImpact, WorkMutation, WorkVerification, resolve_work_intent,
+        work_kind_profile,
+    };
+
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let scope = syu::command::task::scope_request(&workspace, request)?;
+    let seeds = request
+        .explicit_ids()
+        .into_iter()
+        .filter_map(|id| surface_for_spec_id(&id).map(|surface| WorkSeed { id, surface }))
+        .collect::<Vec<_>>();
+    let intent_text = std::iter::once(request.request.as_str())
+        .chain(request.context.affected_area.as_deref())
+        .chain(
+            request
+                .context
+                .repository_constraints
+                .iter()
+                .map(String::as_str),
+        )
+        .collect::<Vec<_>>()
+        .join("\n");
+    let intent = resolve_work_intent(
+        &intent_text,
+        explicit_kind,
+        explicit_operation,
+        explicit_mode,
+        seeds,
+    );
+    let profile = work_kind_profile(intent.kind);
+    let seed_ids = intent
+        .seeds
+        .iter()
+        .map(|seed| seed.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut candidates = Vec::new();
+    candidates.extend(
+        scope
+            .philosophies
+            .iter()
+            .map(|item| (item.id.clone(), WorkSurface::Philosophy)),
+    );
+    candidates.extend(
+        scope
+            .policies
+            .iter()
+            .map(|item| (item.id.clone(), WorkSurface::Policy)),
+    );
+    candidates.extend(
+        scope
+            .requirements
+            .iter()
+            .map(|item| (item.id.clone(), WorkSurface::Requirement)),
+    );
+    candidates.extend(
+        scope
+            .features
+            .iter()
+            .map(|item| (item.id.clone(), WorkSurface::Feature)),
+    );
+    candidates.extend(
+        intent
+            .seeds
+            .iter()
+            .map(|seed| (seed.id.clone(), seed.surface)),
+    );
+    let mut graph_items = candidates
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeMap<_, _>>();
+    // Traverse directionally so a feature seed reaches its upstream contract without pulling in
+    // unrelated sibling features from the same policy branch.
+    let seeded_features = intent
+        .seeds
+        .iter()
+        .filter(|seed| seed.surface == WorkSurface::Feature)
+        .map(|seed| seed.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    let seeded_requirements = intent
+        .seeds
+        .iter()
+        .filter(|seed| seed.surface == WorkSurface::Requirement)
+        .map(|seed| seed.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    for feature in &workspace.features {
+        if seeded_features.contains(feature.id.as_str()) {
+            for requirement_id in &feature.linked_requirements {
+                graph_items.insert(requirement_id.clone(), WorkSurface::Requirement);
+            }
+        }
+    }
+    if matches!(
+        intent.kind,
+        WorkKind::Deliver | WorkKind::Specify | WorkKind::Govern | WorkKind::Retire
+    ) {
+        for requirement in &workspace.requirements {
+            if seeded_requirements.contains(requirement.id.as_str())
+                || (intent.kind == WorkKind::Govern && graph_items.contains_key(&requirement.id))
+                || (intent.kind == WorkKind::Retire && graph_items.contains_key(&requirement.id))
+            {
+                for feature_id in &requirement.linked_features {
+                    graph_items.insert(feature_id.clone(), WorkSurface::Feature);
+                }
+            }
+        }
+    }
+    let reached_requirements = graph_items
+        .iter()
+        .filter(|(_, surface)| **surface == WorkSurface::Requirement)
+        .map(|(id, _)| id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    for requirement in &workspace.requirements {
+        if reached_requirements.contains(&requirement.id) {
+            for policy_id in &requirement.linked_policies {
+                graph_items.insert(policy_id.clone(), WorkSurface::Policy);
+            }
+        }
+    }
+    for policy in &workspace.policies {
+        if graph_items.contains_key(&policy.id) && intent.kind == WorkKind::Govern {
+            for requirement_id in &policy.linked_requirements {
+                graph_items.insert(requirement_id.clone(), WorkSurface::Requirement);
+            }
+        }
+    }
+    let reached_policies = graph_items
+        .iter()
+        .filter(|(_, surface)| **surface == WorkSurface::Policy)
+        .map(|(id, _)| id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    for philosophy in &workspace.philosophies {
+        if philosophy
+            .linked_policies
+            .iter()
+            .any(|id| reached_policies.contains(id))
+        {
+            graph_items.insert(philosophy.id.clone(), WorkSurface::Philosophy);
+        }
+    }
+    candidates = graph_items.into_iter().collect();
+    candidates.sort();
+    candidates.dedup();
+
+    let items = candidates
+        .into_iter()
+        .map(|(id, surface)| {
+            let role = if seed_ids.contains(id.as_str()) {
+                ImpactRole::Seed
+            } else {
+                impact_role(intent.kind, surface, &profile.direct_surfaces)
+            };
+            ImpactedItem {
+                reason: impact_reason(intent.kind, role).to_string(),
+                id,
+                surface,
+                role,
+            }
+        })
+        .collect::<Vec<_>>();
+    let mutations = if profile.mutation_forbidden || intent.mode == WorkMode::ReviewOnly {
+        Vec::new()
+    } else {
+        items
+            .iter()
+            .filter(|item| {
+                matches!(item.role, ImpactRole::Seed | ImpactRole::DirectChange)
+                    && matches!(
+                        item.surface,
+                        WorkSurface::Philosophy
+                            | WorkSurface::Policy
+                            | WorkSurface::Requirement
+                            | WorkSurface::Feature
+                    )
+            })
+            .map(|item| WorkMutation::SpecItem {
+                id: item.id.clone(),
+                operation: intent.operation,
+            })
+            .collect()
+    };
+    Ok(WorkPlan {
+        intent,
+        impact: WorkImpact {
+            items,
+            ..WorkImpact::default()
+        },
+        mutations,
+        verification: WorkVerification {
+            required_surfaces: profile.required_surfaces,
+            completion_commands: profile.default_completion,
+            cargo_test_fallback: profile.cargo_test_fallback,
+            mutation_forbidden: profile.mutation_forbidden,
+        },
+    })
+}
+
+fn surface_for_spec_id(id: &str) -> Option<WorkSurface> {
+    if id.starts_with("PHIL-") {
+        Some(WorkSurface::Philosophy)
+    } else if id.starts_with("POL-") {
+        Some(WorkSurface::Policy)
+    } else if id.starts_with("REQ-") {
+        Some(WorkSurface::Requirement)
+    } else if id.starts_with("FEAT-") {
+        Some(WorkSurface::Feature)
+    } else {
+        None
+    }
+}
+
+fn impact_role(
+    kind: WorkKind,
+    surface: WorkSurface,
+    direct_surfaces: &std::collections::BTreeSet<WorkSurface>,
+) -> syu_task_model::ImpactRole {
+    use syu_task_model::ImpactRole;
+    match kind {
+        WorkKind::Govern if matches!(surface, WorkSurface::Requirement | WorkSurface::Feature) => {
+            ImpactRole::FollowUp
+        }
+        WorkKind::Specify if matches!(surface, WorkSurface::Philosophy | WorkSurface::Policy) => {
+            ImpactRole::Context
+        }
+        WorkKind::Specify => ImpactRole::FollowUp,
+        WorkKind::Deliver if matches!(surface, WorkSurface::Philosophy | WorkSurface::Policy) => {
+            ImpactRole::Context
+        }
+        WorkKind::Review
+        | WorkKind::Maintain
+        | WorkKind::Verify
+        | WorkKind::Repair
+        | WorkKind::Adopt => ImpactRole::Context,
+        _ if direct_surfaces.contains(&surface) => ImpactRole::DirectChange,
+        _ => ImpactRole::Context,
+    }
+}
+
+fn impact_reason(kind: WorkKind, role: syu_task_model::ImpactRole) -> &'static str {
+    use syu_task_model::ImpactRole;
+    match role {
+        ImpactRole::Seed => "explicit request seed",
+        ImpactRole::DirectChange => "selected by the WorkKind direct-change profile",
+        ImpactRole::Context => "graph context required to assess the change",
+        ImpactRole::FollowUp if kind == WorkKind::Govern => {
+            "downstream contract affected by governance work"
+        }
+        ImpactRole::FollowUp => "linked contract may require a separate follow-up",
+        ImpactRole::Blocker => "unresolved condition blocks this work",
+    }
 }
 
 pub fn scaffold_request(
@@ -621,8 +885,12 @@ fn find_item(
 
 #[cfg(test)]
 mod tests {
-    use super::{LookupKind, search_items};
+    use super::{
+        LookupKind, RequestArtifact, WorkKind, WorkMode, WorkOperation, plan_request_work,
+        search_items,
+    };
     use std::path::PathBuf;
+    use syu_task_model::{ImpactRole, RequestArtifactContext};
 
     fn fixture_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -654,5 +922,68 @@ mod tests {
                 .to_string()
                 .contains("search query must not be empty or whitespace")
         );
+    }
+
+    #[test]
+    fn request_planner_expands_item_seed_through_the_spec_graph() {
+        let request = RequestArtifact {
+            version: 1,
+            request: "Implement FEAT-TRACE-002".to_string(),
+            context: RequestArtifactContext {
+                linked_ids: vec!["FEAT-TRACE-002".to_string()],
+                ..RequestArtifactContext::default()
+            },
+        };
+
+        let plan = plan_request_work(fixture_path("passing"), &request, None, None, None)
+            .expect("work plan");
+
+        assert_eq!(plan.intent.kind, WorkKind::Deliver);
+        assert_eq!(plan.intent.operation, WorkOperation::Modify);
+        assert!(
+            plan.impact
+                .items
+                .iter()
+                .any(|item| { item.id == "FEAT-TRACE-002" && item.role == ImpactRole::Seed })
+        );
+        assert!(
+            plan.impact
+                .items
+                .iter()
+                .any(|item| item.id.starts_with("REQ-"))
+        );
+        assert!(
+            !plan
+                .impact
+                .items
+                .iter()
+                .any(|item| item.id == "FEAT-TRACE-001")
+        );
+        assert!(plan.verification.cargo_test_fallback);
+    }
+
+    #[test]
+    fn review_override_produces_evidence_only_plan() {
+        let request = RequestArtifact {
+            version: 1,
+            request: "Inspect FEAT-TRACE-002".to_string(),
+            context: RequestArtifactContext {
+                linked_ids: vec!["FEAT-TRACE-002".to_string()],
+                ..RequestArtifactContext::default()
+            },
+        };
+
+        let plan = plan_request_work(
+            fixture_path("passing"),
+            &request,
+            Some(WorkKind::Review),
+            None,
+            Some(WorkMode::ReviewOnly),
+        )
+        .expect("review plan");
+
+        assert!(plan.mutations.is_empty());
+        assert!(plan.verification.mutation_forbidden);
+        assert!(!plan.verification.cargo_test_fallback);
     }
 }

--- a/crates/syu-actions/src/lib.rs
+++ b/crates/syu-actions/src/lib.rs
@@ -105,6 +105,85 @@ pub fn scope_request(
 ///
 /// Explicit axes take precedence over inference. Related spec items are expanded through the
 /// existing workspace graph and annotated according to the selected WorkKind profile.
+pub fn plan_request_work_with_constraints(
+    workspace: impl AsRef<Path>,
+    request: &RequestArtifact,
+    explicit_kind: Option<WorkKind>,
+    explicit_operation: Option<WorkOperation>,
+    explicit_mode: Option<WorkMode>,
+    constraints: syu_task_model::WorkConstraints,
+) -> Result<WorkPlan> {
+    use syu_task_model::{SourceRole, WorkGraphNode, WorkPlanningInput, plan_work};
+
+    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
+    let seeds = request
+        .explicit_ids()
+        .into_iter()
+        .map(|id| WorkSeed {
+            surface: surface_for_id(&id),
+            id,
+            source_role: SourceRole::Seed,
+        })
+        .collect();
+    let nodes = workspace
+        .philosophies
+        .iter()
+        .map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Philosophy,
+            document_path: None,
+            status: None,
+            linked_ids: item.linked_policies.clone(),
+            implementations: Vec::new(),
+            tests: Vec::new(),
+        })
+        .chain(workspace.policies.iter().map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Policy,
+            document_path: None,
+            status: None,
+            linked_ids: item.linked_requirements.clone(),
+            implementations: Vec::new(),
+            tests: Vec::new(),
+        }))
+        .chain(workspace.requirements.iter().map(|item| {
+            WorkGraphNode {
+                id: item.id.clone(),
+                surface: WorkSurface::Requirement,
+                document_path: None,
+                status: Some(item.status.clone()),
+                linked_ids: item
+                    .linked_policies
+                    .iter()
+                    .chain(&item.linked_features)
+                    .cloned()
+                    .collect(),
+                implementations: Vec::new(),
+                tests: trace_targets(&item.tests),
+            }
+        }))
+        .chain(workspace.features.iter().map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Feature,
+            document_path: None,
+            status: Some(item.status.clone()),
+            linked_ids: item.linked_requirements.clone(),
+            implementations: trace_targets(&item.implementations),
+            tests: Vec::new(),
+        }))
+        .collect();
+    Ok(plan_work(WorkPlanningInput {
+        request: syu_task_model::work_request_text(request),
+        explicit_kind,
+        explicit_operation,
+        explicit_mode,
+        seeds,
+        nodes,
+        constraints,
+        ..Default::default()
+    }))
+}
+
 pub fn plan_request_work(
     workspace: impl AsRef<Path>,
     request: &RequestArtifact,
@@ -112,256 +191,66 @@ pub fn plan_request_work(
     explicit_operation: Option<WorkOperation>,
     explicit_mode: Option<WorkMode>,
 ) -> Result<WorkPlan> {
-    use syu_task_model::{
-        ImpactRole, ImpactedItem, WorkImpact, WorkMutation, WorkVerification, resolve_work_intent,
-        work_kind_profile,
-    };
-
-    let workspace = syu::workspace::load_workspace(workspace.as_ref())?;
-    let scope = syu::command::task::scope_request(&workspace, request)?;
-    let seeds = request
-        .explicit_ids()
-        .into_iter()
-        .filter_map(|id| surface_for_spec_id(&id).map(|surface| WorkSeed { id, surface }))
-        .collect::<Vec<_>>();
-    let intent_text = std::iter::once(request.request.as_str())
-        .chain(request.context.affected_area.as_deref())
-        .chain(
-            request
-                .context
-                .repository_constraints
-                .iter()
-                .map(String::as_str),
-        )
-        .collect::<Vec<_>>()
-        .join("\n");
-    let intent = resolve_work_intent(
-        &intent_text,
+    plan_request_work_with_constraints(
+        workspace,
+        request,
         explicit_kind,
         explicit_operation,
         explicit_mode,
-        seeds,
-    );
-    let profile = work_kind_profile(intent.kind);
-    let seed_ids = intent
-        .seeds
-        .iter()
-        .map(|seed| seed.id.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-    let mut candidates = Vec::new();
-    candidates.extend(
-        scope
-            .philosophies
-            .iter()
-            .map(|item| (item.id.clone(), WorkSurface::Philosophy)),
-    );
-    candidates.extend(
-        scope
-            .policies
-            .iter()
-            .map(|item| (item.id.clone(), WorkSurface::Policy)),
-    );
-    candidates.extend(
-        scope
-            .requirements
-            .iter()
-            .map(|item| (item.id.clone(), WorkSurface::Requirement)),
-    );
-    candidates.extend(
-        scope
-            .features
-            .iter()
-            .map(|item| (item.id.clone(), WorkSurface::Feature)),
-    );
-    candidates.extend(
-        intent
-            .seeds
-            .iter()
-            .map(|seed| (seed.id.clone(), seed.surface)),
-    );
-    let mut graph_items = candidates
-        .iter()
-        .cloned()
-        .collect::<std::collections::BTreeMap<_, _>>();
-    // Traverse directionally so a feature seed reaches its upstream contract without pulling in
-    // unrelated sibling features from the same policy branch.
-    let seeded_features = intent
-        .seeds
-        .iter()
-        .filter(|seed| seed.surface == WorkSurface::Feature)
-        .map(|seed| seed.id.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-    let seeded_requirements = intent
-        .seeds
-        .iter()
-        .filter(|seed| seed.surface == WorkSurface::Requirement)
-        .map(|seed| seed.id.as_str())
-        .collect::<std::collections::BTreeSet<_>>();
-    for feature in &workspace.features {
-        if seeded_features.contains(feature.id.as_str()) {
-            for requirement_id in &feature.linked_requirements {
-                graph_items.insert(requirement_id.clone(), WorkSurface::Requirement);
-            }
-        }
-    }
-    if matches!(
-        intent.kind,
-        WorkKind::Deliver | WorkKind::Specify | WorkKind::Govern | WorkKind::Retire
-    ) {
-        for requirement in &workspace.requirements {
-            if seeded_requirements.contains(requirement.id.as_str())
-                || (intent.kind == WorkKind::Govern && graph_items.contains_key(&requirement.id))
-                || (intent.kind == WorkKind::Retire && graph_items.contains_key(&requirement.id))
-            {
-                for feature_id in &requirement.linked_features {
-                    graph_items.insert(feature_id.clone(), WorkSurface::Feature);
-                }
-            }
-        }
-    }
-    let reached_requirements = graph_items
-        .iter()
-        .filter(|(_, surface)| **surface == WorkSurface::Requirement)
-        .map(|(id, _)| id.clone())
-        .collect::<std::collections::BTreeSet<_>>();
-    for requirement in &workspace.requirements {
-        if reached_requirements.contains(&requirement.id) {
-            for policy_id in &requirement.linked_policies {
-                graph_items.insert(policy_id.clone(), WorkSurface::Policy);
-            }
-        }
-    }
-    for policy in &workspace.policies {
-        if graph_items.contains_key(&policy.id) && intent.kind == WorkKind::Govern {
-            for requirement_id in &policy.linked_requirements {
-                graph_items.insert(requirement_id.clone(), WorkSurface::Requirement);
-            }
-        }
-    }
-    let reached_policies = graph_items
-        .iter()
-        .filter(|(_, surface)| **surface == WorkSurface::Policy)
-        .map(|(id, _)| id.clone())
-        .collect::<std::collections::BTreeSet<_>>();
-    for philosophy in &workspace.philosophies {
-        if philosophy
-            .linked_policies
-            .iter()
-            .any(|id| reached_policies.contains(id))
-        {
-            graph_items.insert(philosophy.id.clone(), WorkSurface::Philosophy);
-        }
-    }
-    candidates = graph_items.into_iter().collect();
-    candidates.sort();
-    candidates.dedup();
-
-    let items = candidates
-        .into_iter()
-        .map(|(id, surface)| {
-            let role = if seed_ids.contains(id.as_str()) {
-                ImpactRole::Seed
-            } else {
-                impact_role(intent.kind, surface, &profile.direct_surfaces)
-            };
-            ImpactedItem {
-                reason: impact_reason(intent.kind, role).to_string(),
-                id,
-                surface,
-                role,
-            }
-        })
-        .collect::<Vec<_>>();
-    let mutations = if profile.mutation_forbidden || intent.mode == WorkMode::ReviewOnly {
-        Vec::new()
-    } else {
-        items
-            .iter()
-            .filter(|item| {
-                matches!(item.role, ImpactRole::Seed | ImpactRole::DirectChange)
-                    && matches!(
-                        item.surface,
-                        WorkSurface::Philosophy
-                            | WorkSurface::Policy
-                            | WorkSurface::Requirement
-                            | WorkSurface::Feature
-                    )
-            })
-            .map(|item| WorkMutation::SpecItem {
-                id: item.id.clone(),
-                operation: intent.operation,
-            })
-            .collect()
-    };
-    Ok(WorkPlan {
-        intent,
-        impact: WorkImpact {
-            items,
-            ..WorkImpact::default()
-        },
-        mutations,
-        verification: WorkVerification {
-            required_surfaces: profile.required_surfaces,
-            completion_commands: profile.default_completion,
-            cargo_test_fallback: profile.cargo_test_fallback,
-            mutation_forbidden: profile.mutation_forbidden,
-        },
-    })
+        Default::default(),
+    )
 }
 
-fn surface_for_spec_id(id: &str) -> Option<WorkSurface> {
+/// Plan from an Item seed through the same shared engine used for requests.
+pub fn plan_item_work(
+    workspace: impl AsRef<Path>,
+    item_id: &str,
+    explicit_kind: Option<WorkKind>,
+    explicit_operation: Option<WorkOperation>,
+    explicit_mode: Option<WorkMode>,
+) -> Result<WorkPlan> {
+    plan_request_work(
+        workspace,
+        &RequestArtifact {
+            version: 1,
+            request: format!("Plan work for {item_id}"),
+            context: syu_task_model::RequestArtifactContext {
+                linked_ids: vec![item_id.to_string()],
+                ..Default::default()
+            },
+        },
+        explicit_kind,
+        explicit_operation,
+        explicit_mode,
+    )
+}
+
+fn surface_for_id(id: &str) -> WorkSurface {
     if id.starts_with("PHIL-") {
-        Some(WorkSurface::Philosophy)
+        WorkSurface::Philosophy
     } else if id.starts_with("POL-") {
-        Some(WorkSurface::Policy)
-    } else if id.starts_with("REQ-") {
-        Some(WorkSurface::Requirement)
+        WorkSurface::Policy
     } else if id.starts_with("FEAT-") {
-        Some(WorkSurface::Feature)
+        WorkSurface::Feature
     } else {
-        None
+        WorkSurface::Requirement
     }
 }
 
-fn impact_role(
-    kind: WorkKind,
-    surface: WorkSurface,
-    direct_surfaces: &std::collections::BTreeSet<WorkSurface>,
-) -> syu_task_model::ImpactRole {
-    use syu_task_model::ImpactRole;
-    match kind {
-        WorkKind::Govern if matches!(surface, WorkSurface::Requirement | WorkSurface::Feature) => {
-            ImpactRole::FollowUp
-        }
-        WorkKind::Specify if matches!(surface, WorkSurface::Philosophy | WorkSurface::Policy) => {
-            ImpactRole::Context
-        }
-        WorkKind::Specify => ImpactRole::FollowUp,
-        WorkKind::Deliver if matches!(surface, WorkSurface::Philosophy | WorkSurface::Policy) => {
-            ImpactRole::Context
-        }
-        WorkKind::Review
-        | WorkKind::Maintain
-        | WorkKind::Verify
-        | WorkKind::Repair
-        | WorkKind::Adopt => ImpactRole::Context,
-        _ if direct_surfaces.contains(&surface) => ImpactRole::DirectChange,
-        _ => ImpactRole::Context,
-    }
-}
-
-fn impact_reason(kind: WorkKind, role: syu_task_model::ImpactRole) -> &'static str {
-    use syu_task_model::ImpactRole;
-    match role {
-        ImpactRole::Seed => "explicit request seed",
-        ImpactRole::DirectChange => "selected by the WorkKind direct-change profile",
-        ImpactRole::Context => "graph context required to assess the change",
-        ImpactRole::FollowUp if kind == WorkKind::Govern => {
-            "downstream contract affected by governance work"
-        }
-        ImpactRole::FollowUp => "linked contract may require a separate follow-up",
-        ImpactRole::Blocker => "unresolved condition blocks this work",
-    }
+fn trace_targets(
+    map: &BTreeMap<String, Vec<syu_domain::TraceReference>>,
+) -> Vec<syu_task_model::TraceTarget> {
+    map.iter()
+        .flat_map(|(language, references)| {
+            references
+                .iter()
+                .map(move |reference| syu_task_model::TraceTarget {
+                    language: language.clone(),
+                    file: reference.file.display().to_string(),
+                    symbols: reference.symbols.clone(),
+                })
+        })
+        .collect()
 }
 
 pub fn scaffold_request(
@@ -886,11 +775,11 @@ fn find_item(
 #[cfg(test)]
 mod tests {
     use super::{
-        LookupKind, RequestArtifact, WorkKind, WorkMode, WorkOperation, plan_request_work,
-        search_items,
+        LookupKind, RequestArtifact, WorkKind, WorkMode, WorkOperation, plan_item_work,
+        plan_request_work, search_items,
     };
     use std::path::PathBuf;
-    use syu_task_model::{ImpactRole, RequestArtifactContext};
+    use syu_task_model::{RequestArtifactContext, SourceRole};
 
     fn fixture_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -941,10 +830,9 @@ mod tests {
         assert_eq!(plan.intent.kind, WorkKind::Deliver);
         assert_eq!(plan.intent.operation, WorkOperation::Modify);
         assert!(
-            plan.impact
-                .items
-                .iter()
-                .any(|item| { item.id == "FEAT-TRACE-002" && item.role == ImpactRole::Seed })
+            plan.impact.items.iter().any(|item| {
+                item.id == "FEAT-TRACE-002" && item.source_role == SourceRole::Seed
+            })
         );
         assert!(
             plan.impact
@@ -985,5 +873,34 @@ mod tests {
         assert!(plan.mutations.is_empty());
         assert!(plan.verification.mutation_forbidden);
         assert!(!plan.verification.cargo_test_fallback);
+    }
+
+    #[test]
+    fn item_and_request_entry_points_have_planner_parity() {
+        let request = RequestArtifact {
+            version: 1,
+            request: "Plan work for FEAT-TRACE-002".to_string(),
+            context: RequestArtifactContext {
+                linked_ids: vec!["FEAT-TRACE-002".to_string()],
+                ..RequestArtifactContext::default()
+            },
+        };
+        let request_plan = plan_request_work(
+            fixture_path("passing"),
+            &request,
+            Some(WorkKind::Deliver),
+            Some(WorkOperation::Modify),
+            None,
+        )
+        .expect("request plan");
+        let item_plan = plan_item_work(
+            fixture_path("passing"),
+            "FEAT-TRACE-002",
+            Some(WorkKind::Deliver),
+            Some(WorkOperation::Modify),
+            None,
+        )
+        .expect("item plan");
+        assert_eq!(request_plan, item_plan);
     }
 }

--- a/crates/syu-app-ui/src/model.rs
+++ b/crates/syu-app-ui/src/model.rs
@@ -553,6 +553,7 @@ fn demo_goal_plan() -> GoalPlanArtifact {
         request_path: Some(".syu/workbench/requests/request-739.yaml".to_string()),
         request: Some("Add a Workbench request intake flow.".to_string()),
         classification: Some("requirement_change".to_string()),
+        work: None,
         source: GoalPlanSource {
             request_artifact: Some(".syu/workbench/requests/request-739.yaml".to_string()),
             classification: Some("requirement_change".to_string()),

--- a/crates/syu-task-model/src/lib.rs
+++ b/crates/syu-task-model/src/lib.rs
@@ -123,6 +123,8 @@ pub struct GoalPlanArtifact {
     #[serde(default)]
     pub classification: Option<String>,
     #[serde(default)]
+    pub work: Option<WorkPlan>,
+    #[serde(default)]
     pub source: GoalPlanSource,
     pub goal: GoalPlanGoal,
     #[serde(default)]

--- a/crates/syu-task-model/src/lib.rs
+++ b/crates/syu-task-model/src/lib.rs
@@ -4,6 +4,10 @@ use std::collections::BTreeMap;
 pub use syu_domain::{GitRange, LanguageName, SpecId, SpecKind, WorkspaceRoot};
 use syu_domain::{Issue, Severity, TraceReference};
 
+mod work;
+
+pub use work::*;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearchResult {

--- a/crates/syu-task-model/src/work.rs
+++ b/crates/syu-task-model/src/work.rs
@@ -487,6 +487,7 @@ pub fn goal_plan_from_work_plan(
         request_path: Some(request_path.to_string()),
         request: Some(request.to_string()),
         classification: Some(format!("{:?}", plan.intent.kind).to_lowercase()),
+        work: Some(plan.clone()),
         source: GoalPlanSource {
             mode: GoalPlanSourceMode::RequestDriven,
             request_artifact: Some(request_path.to_string()),

--- a/crates/syu-task-model/src/work.rs
+++ b/crates/syu-task-model/src/work.rs
@@ -1,0 +1,570 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+type ProfileParts = (
+    &'static [WorkSurface],
+    &'static [WorkSurface],
+    &'static [WorkSurface],
+    &'static [&'static str],
+    bool,
+    bool,
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkKind {
+    Deliver,
+    Specify,
+    Govern,
+    Restructure,
+    Verify,
+    Repair,
+    Maintain,
+    Retire,
+    Review,
+    Adopt,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkOperation {
+    Create,
+    Modify,
+    Delete,
+    Rename,
+    Move,
+    Relink,
+    Split,
+    Merge,
+    Promote,
+    Demote,
+    Supersede,
+    Validate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkSurface {
+    Philosophy,
+    Policy,
+    Requirement,
+    Feature,
+    Implementation,
+    Test,
+    Trace,
+    Config,
+    Documentation,
+    Tooling,
+    GeneratedArtifact,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkMode {
+    PlanAndExecute,
+    PlanOnly,
+    ReviewOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactRole {
+    Seed,
+    DirectChange,
+    Context,
+    FollowUp,
+    Blocker,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkSeed {
+    pub id: String,
+    pub surface: WorkSurface,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkConstraints {
+    #[serde(default)]
+    pub forbidden_surfaces: BTreeSet<WorkSurface>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkIntent {
+    pub kind: WorkKind,
+    pub operation: WorkOperation,
+    pub mode: WorkMode,
+    #[serde(default)]
+    pub seeds: Vec<WorkSeed>,
+    #[serde(default)]
+    pub requested_surfaces: BTreeSet<WorkSurface>,
+    #[serde(default)]
+    pub constraints: WorkConstraints,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImpactedItem {
+    pub id: String,
+    pub surface: WorkSurface,
+    pub role: ImpactRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImpactedEdge {
+    pub from: String,
+    pub to: String,
+    pub role: ImpactRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryImpact {
+    pub path: String,
+    pub role: ImpactRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TestImpact {
+    pub reference: String,
+    pub role: ImpactRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiagnosticImpact {
+    pub rule: String,
+    pub role: ImpactRole,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalSplitSuggestion {
+    pub reason: String,
+    pub item_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkImpact {
+    #[serde(default)]
+    pub items: Vec<ImpactedItem>,
+    #[serde(default)]
+    pub edges: Vec<ImpactedEdge>,
+    #[serde(default)]
+    pub repository: Vec<RepositoryImpact>,
+    #[serde(default)]
+    pub tests: Vec<TestImpact>,
+    #[serde(default)]
+    pub diagnostics: Vec<DiagnosticImpact>,
+    #[serde(default)]
+    pub split_suggestions: Vec<GoalSplitSuggestion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkMutation {
+    SpecItem {
+        id: String,
+        operation: WorkOperation,
+    },
+    SpecEdge {
+        from: String,
+        to: String,
+        operation: WorkOperation,
+    },
+    Trace {
+        reference: String,
+        operation: WorkOperation,
+    },
+    Repository {
+        path: String,
+        operation: WorkOperation,
+    },
+    Config {
+        path: String,
+        operation: WorkOperation,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkVerification {
+    pub required_surfaces: BTreeSet<WorkSurface>,
+    pub completion_commands: Vec<String>,
+    pub cargo_test_fallback: bool,
+    pub mutation_forbidden: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkPlan {
+    pub intent: WorkIntent,
+    pub impact: WorkImpact,
+    pub mutations: Vec<WorkMutation>,
+    pub verification: WorkVerification,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkKindProfile {
+    pub kind: WorkKind,
+    pub direct_surfaces: BTreeSet<WorkSurface>,
+    pub required_surfaces: BTreeSet<WorkSurface>,
+    pub forbidden_surfaces: BTreeSet<WorkSurface>,
+    pub default_completion: Vec<String>,
+    pub cargo_test_fallback: bool,
+    pub mutation_forbidden: bool,
+}
+
+pub fn resolve_work_intent(
+    request: &str,
+    explicit_kind: Option<WorkKind>,
+    explicit_operation: Option<WorkOperation>,
+    explicit_mode: Option<WorkMode>,
+    seeds: Vec<WorkSeed>,
+) -> WorkIntent {
+    let text = request.to_lowercase();
+    let mode = explicit_mode.unwrap_or_else(|| {
+        if contains_any(
+            &text,
+            &["review", "audit", "investigate", "調査", "レビュー", "分析"],
+        ) {
+            WorkMode::ReviewOnly
+        } else {
+            WorkMode::PlanAndExecute
+        }
+    });
+    let kind = explicit_kind.unwrap_or_else(|| infer_kind(&text, mode));
+    let operation = explicit_operation.unwrap_or_else(|| infer_operation(&text, kind));
+    let requested_surfaces = infer_surfaces(&text, &seeds);
+    let mut constraints = WorkConstraints::default();
+    constraints
+        .forbidden_surfaces
+        .extend(work_kind_profile(kind).forbidden_surfaces);
+    WorkIntent {
+        kind,
+        operation,
+        mode,
+        seeds,
+        requested_surfaces,
+        constraints,
+    }
+}
+
+pub fn work_kind_profile(kind: WorkKind) -> WorkKindProfile {
+    use WorkSurface as S;
+    let (direct, required, forbidden, completion, fallback, mutation_forbidden): ProfileParts =
+        match kind {
+            WorkKind::Deliver => (
+                &[S::Implementation, S::Test],
+                &[S::Implementation],
+                &[],
+                &["syu validate .", "syu task check"],
+                true,
+                false,
+            ),
+            WorkKind::Specify => (
+                &[S::Requirement, S::Feature],
+                &[S::Requirement],
+                &[],
+                &["syu validate ."],
+                false,
+                false,
+            ),
+            WorkKind::Govern => (
+                &[S::Philosophy, S::Policy],
+                &[S::Policy],
+                &[S::Implementation],
+                &["syu validate .", "syu check graph"],
+                false,
+                false,
+            ),
+            WorkKind::Restructure => (
+                &[
+                    S::Philosophy,
+                    S::Policy,
+                    S::Requirement,
+                    S::Feature,
+                    S::Trace,
+                ],
+                &[S::Trace],
+                &[],
+                &["syu validate .", "syu check graph"],
+                false,
+                false,
+            ),
+            WorkKind::Verify => (
+                &[S::Test, S::Trace],
+                &[S::Test],
+                &[],
+                &["syu validate .", "syu check coverage"],
+                false,
+                false,
+            ),
+            WorkKind::Repair => (
+                &[S::Trace, S::Config, S::GeneratedArtifact],
+                &[],
+                &[S::Implementation],
+                &["syu validate ."],
+                false,
+                false,
+            ),
+            WorkKind::Maintain => (
+                &[S::Tooling, S::Config, S::Implementation],
+                &[S::Tooling],
+                &[S::Philosophy, S::Policy, S::Requirement, S::Feature],
+                &["syu validate ."],
+                true,
+                false,
+            ),
+            WorkKind::Retire => (
+                &[
+                    S::Requirement,
+                    S::Feature,
+                    S::Implementation,
+                    S::Test,
+                    S::Trace,
+                ],
+                &[S::Trace],
+                &[],
+                &["syu validate .", "syu check graph"],
+                true,
+                false,
+            ),
+            WorkKind::Review => (
+                &[],
+                &[],
+                &[
+                    S::Philosophy,
+                    S::Policy,
+                    S::Requirement,
+                    S::Feature,
+                    S::Implementation,
+                    S::Test,
+                    S::Trace,
+                    S::Config,
+                    S::Documentation,
+                    S::Tooling,
+                    S::GeneratedArtifact,
+                ],
+                &[],
+                false,
+                true,
+            ),
+            WorkKind::Adopt => (
+                &[S::Config, S::Documentation, S::Trace],
+                &[S::Config],
+                &[],
+                &["syu validate ."],
+                false,
+                false,
+            ),
+        };
+    WorkKindProfile {
+        kind,
+        direct_surfaces: direct.iter().copied().collect(),
+        required_surfaces: required.iter().copied().collect(),
+        forbidden_surfaces: forbidden.iter().copied().collect(),
+        default_completion: completion
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        cargo_test_fallback: fallback,
+        mutation_forbidden,
+    }
+}
+
+fn infer_kind(text: &str, mode: WorkMode) -> WorkKind {
+    if mode == WorkMode::ReviewOnly {
+        return WorkKind::Review;
+    }
+    let table = [
+        (
+            WorkKind::Deliver,
+            &["implement", "bug fix", "実装", "バグ修正"] as &[&str],
+        ),
+        (
+            WorkKind::Retire,
+            &["retire", "deprecat", "supersede", "廃止", "削除"],
+        ),
+        (
+            WorkKind::Restructure,
+            &[
+                "rename",
+                "move",
+                "relink",
+                "split",
+                "merge",
+                "promote",
+                "demote",
+                "名前変更",
+                "移動",
+                "分割",
+                "統合",
+            ],
+        ),
+        (
+            WorkKind::Govern,
+            &["policy", "philosophy", "govern", "方針", "原則"],
+        ),
+        (
+            WorkKind::Verify,
+            &[
+                "coverage",
+                "quality gate",
+                "test only",
+                "検証",
+                "テスト追加",
+            ],
+        ),
+        (
+            WorkKind::Repair,
+            &[
+                "trace",
+                "reciprocal",
+                "registry",
+                "diagnostic",
+                "整合性",
+                "修復",
+            ],
+        ),
+        (
+            WorkKind::Adopt,
+            &["bootstrap", "onboard", "migrate to syu", "導入", "初期化"],
+        ),
+        (
+            WorkKind::Maintain,
+            &["dependency", "toolchain", "ci", "refactor", "保守", "依存"],
+        ),
+        (
+            WorkKind::Specify,
+            &[
+                "requirement",
+                "feature spec",
+                "acceptance criteria",
+                "要件",
+                "仕様",
+            ],
+        ),
+    ];
+    table
+        .into_iter()
+        .find(|(_, words)| contains_any(text, words))
+        .map(|(kind, _)| kind)
+        .unwrap_or(WorkKind::Deliver)
+}
+
+fn infer_operation(text: &str, kind: WorkKind) -> WorkOperation {
+    let table = [
+        (WorkOperation::Supersede, &["supersede", "置換"] as &[&str]),
+        (WorkOperation::Rename, &["rename", "名前変更"]),
+        (WorkOperation::Relink, &["relink", "リンク修復"]),
+        (WorkOperation::Split, &["split", "分割"]),
+        (WorkOperation::Merge, &["merge", "統合"]),
+        (WorkOperation::Promote, &["promote", "昇格"]),
+        (WorkOperation::Demote, &["demote", "降格"]),
+        (WorkOperation::Move, &["move", "移動"]),
+        (WorkOperation::Delete, &["delete", "remove", "削除", "廃止"]),
+        (
+            WorkOperation::Create,
+            &["create", "add", "new", "追加", "新規"],
+        ),
+    ];
+    table
+        .into_iter()
+        .find(|(_, words)| contains_any(text, words))
+        .map(|(op, _)| op)
+        .unwrap_or(if kind == WorkKind::Review {
+            WorkOperation::Validate
+        } else {
+            WorkOperation::Modify
+        })
+}
+
+fn infer_surfaces(text: &str, seeds: &[WorkSeed]) -> BTreeSet<WorkSurface> {
+    use WorkSurface as S;
+    let mut surfaces: BTreeSet<_> = seeds.iter().map(|seed| seed.surface).collect();
+    for (surface, words) in [
+        (S::Philosophy, &["philosophy", "原則"] as &[&str]),
+        (S::Policy, &["policy", "方針"]),
+        (S::Requirement, &["requirement", "要件"]),
+        (S::Feature, &["feature", "機能"]),
+        (S::Implementation, &["implementation", "code", "実装"]),
+        (S::Test, &["test", "coverage", "テスト"]),
+        (S::Trace, &["trace", "traceability", "トレース"]),
+        (S::Config, &["config", "設定"]),
+        (S::Documentation, &["documentation", "docs", "文書"]),
+        (S::Tooling, &["tooling", "toolchain", "ci", "ツール"]),
+        (S::GeneratedArtifact, &["generated", "生成物"]),
+    ] {
+        if contains_any(text, words) {
+            surfaces.insert(surface);
+        }
+    }
+    surfaces
+}
+
+fn contains_any(text: &str, words: &[&str]) -> bool {
+    words.iter().any(|word| text.contains(word))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_kind_wins_and_axes_stay_independent() {
+        let intent = resolve_work_intent(
+            "review and split FEAT-1",
+            Some(WorkKind::Restructure),
+            None,
+            Some(WorkMode::PlanOnly),
+            vec![],
+        );
+        assert_eq!(intent.kind, WorkKind::Restructure);
+        assert_eq!(intent.operation, WorkOperation::Split);
+        assert_eq!(intent.mode, WorkMode::PlanOnly);
+    }
+
+    #[test]
+    fn review_profile_forbids_mutation_without_test_fallback() {
+        let profile = work_kind_profile(WorkKind::Review);
+        assert!(profile.mutation_forbidden);
+        assert!(!profile.cargo_test_fallback);
+        assert!(profile.default_completion.is_empty());
+    }
+
+    #[test]
+    fn classifies_representative_requests() {
+        let cases = [
+            ("implement the existing feature", WorkKind::Deliver),
+            ("change the security policy", WorkKind::Govern),
+            ("split FEAT-1", WorkKind::Restructure),
+            ("add a coverage test", WorkKind::Verify),
+            ("repair a broken trace", WorkKind::Repair),
+            ("update a dependency", WorkKind::Maintain),
+            ("retire the old feature", WorkKind::Retire),
+            ("audit the branch diff", WorkKind::Review),
+            ("bootstrap syu", WorkKind::Adopt),
+        ];
+        for (request, expected) in cases {
+            assert_eq!(
+                resolve_work_intent(request, None, None, None, vec![]).kind,
+                expected,
+                "{request}"
+            );
+        }
+    }
+}

--- a/crates/syu-task-model/src/work.rs
+++ b/crates/syu-task-model/src/work.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::path::PathBuf;
+use syu_domain::TraceReference;
 
-type ProfileParts = (
-    &'static [WorkSurface],
-    &'static [WorkSurface],
-    &'static [WorkSurface],
-    &'static [&'static str],
-    bool,
-    bool,
-);
+use crate::{
+    GoalPlanArtifact, GoalPlanCompletion, GoalPlanConfidence, GoalPlanCoverage,
+    GoalPlanCoverageMode, GoalPlanGoal, GoalPlanImplementationPlan, GoalPlanPersistentItem,
+    GoalPlanPersistentItems, GoalPlanScope, GoalPlanScopeInclude, GoalPlanSelectionMode,
+    GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSourceMode, GoalPlanSpecMapping,
+    GoalPlanTestPlan,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -68,8 +69,15 @@ pub enum WorkMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ImpactRole {
+pub enum SourceRole {
     Seed,
+    Inferred,
+    SearchCandidate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactRole {
     DirectChange,
     Context,
     FollowUp,
@@ -81,13 +89,20 @@ pub enum ImpactRole {
 pub struct WorkSeed {
     pub id: String,
     pub surface: WorkSurface,
+    pub source_role: SourceRole,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkConstraints {
     #[serde(default)]
-    pub forbidden_surfaces: BTreeSet<WorkSurface>,
+    pub target_id: Option<String>,
+    #[serde(default)]
+    pub target_surface: Option<WorkSurface>,
+    #[serde(default)]
+    pub destination_document: Option<String>,
+    #[serde(default)]
+    pub related_item_ids: Vec<String>,
     #[serde(default)]
     pub notes: Vec<String>,
 }
@@ -108,10 +123,77 @@ pub struct WorkIntent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct TraceTarget {
+    pub language: String,
+    pub file: String,
+    #[serde(default)]
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkGraphNode {
+    pub id: String,
+    pub surface: WorkSurface,
+    #[serde(default)]
+    pub document_path: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub linked_ids: Vec<String>,
+    #[serde(default)]
+    pub implementations: Vec<TraceTarget>,
+    #[serde(default)]
+    pub tests: Vec<TraceTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryChange {
+    pub path: String,
+    #[serde(default)]
+    pub owner_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkDiagnostic {
+    pub rule: String,
+    pub subject: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkPlanningInput {
+    pub request: String,
+    #[serde(default)]
+    pub explicit_kind: Option<WorkKind>,
+    #[serde(default)]
+    pub explicit_operation: Option<WorkOperation>,
+    #[serde(default)]
+    pub explicit_mode: Option<WorkMode>,
+    #[serde(default)]
+    pub seeds: Vec<WorkSeed>,
+    #[serde(default)]
+    pub search_candidates: Vec<WorkSeed>,
+    #[serde(default)]
+    pub nodes: Vec<WorkGraphNode>,
+    #[serde(default)]
+    pub repository_changes: Vec<RepositoryChange>,
+    #[serde(default)]
+    pub diagnostics: Vec<WorkDiagnostic>,
+    #[serde(default)]
+    pub constraints: WorkConstraints,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImpactedItem {
     pub id: String,
     pub surface: WorkSurface,
-    pub role: ImpactRole,
+    pub source_role: SourceRole,
+    pub impact_role: ImpactRole,
     pub reason: String,
 }
 
@@ -120,7 +202,7 @@ pub struct ImpactedItem {
 pub struct ImpactedEdge {
     pub from: String,
     pub to: String,
-    pub role: ImpactRole,
+    pub impact_role: ImpactRole,
     pub reason: String,
 }
 
@@ -128,15 +210,16 @@ pub struct ImpactedEdge {
 #[serde(deny_unknown_fields)]
 pub struct RepositoryImpact {
     pub path: String,
-    pub role: ImpactRole,
+    pub surface: WorkSurface,
+    pub impact_role: ImpactRole,
     pub reason: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TestImpact {
-    pub reference: String,
-    pub role: ImpactRole,
+    pub target: TraceTarget,
+    pub impact_role: ImpactRole,
     pub reason: String,
 }
 
@@ -144,7 +227,8 @@ pub struct TestImpact {
 #[serde(deny_unknown_fields)]
 pub struct DiagnosticImpact {
     pub rule: String,
-    pub role: ImpactRole,
+    pub subject: String,
+    pub impact_role: ImpactRole,
     pub reason: String,
 }
 
@@ -173,36 +257,166 @@ pub struct WorkImpact {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecItemDraft {
+    pub id: String,
+    pub surface: WorkSurface,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecItemPatch {
+    #[serde(default)]
+    pub requested_surfaces: BTreeSet<WorkSurface>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecEdge {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RelationshipMove {
+    pub relationship: SpecEdge,
+    pub target_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkMutation {
-    SpecItem {
-        id: String,
-        operation: WorkOperation,
+    CreateItem {
+        draft: SpecItemDraft,
     },
-    SpecEdge {
+    ModifyItem {
+        id: String,
+        patch: SpecItemPatch,
+    },
+    DeleteItem {
+        id: String,
+    },
+    RenameItem {
         from: String,
         to: String,
-        operation: WorkOperation,
     },
-    Trace {
-        reference: String,
-        operation: WorkOperation,
+    MoveItem {
+        id: String,
+        destination_document: String,
     },
-    Repository {
+    Relink {
+        remove: Vec<SpecEdge>,
+        add: Vec<SpecEdge>,
+    },
+    SplitItem {
+        source: String,
+        targets: Vec<SpecItemDraft>,
+        redistribution: Vec<RelationshipMove>,
+    },
+    MergeItems {
+        sources: Vec<String>,
+        target: String,
+    },
+    ChangeItemKind {
+        id: String,
+        target_surface: WorkSurface,
+        relink: Vec<SpecEdge>,
+    },
+    Supersede {
+        old: String,
+        replacement: String,
+    },
+    UpdateTrace {
+        target: TraceTarget,
+    },
+    RepairDiagnostic {
+        rule: String,
+        subject: String,
+    },
+    ModifyRepository {
         path: String,
-        operation: WorkOperation,
     },
-    Config {
+    ModifyConfig {
         path: String,
-        operation: WorkOperation,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationGenre {
+    Workspace,
+    Graph,
+    Delivery,
+    Trace,
+    Coverage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CompletionCheck {
+    Validate { genres: BTreeSet<ValidationGenre> },
+    GoalPlanCheck { plan_path: String, range: String },
+    TestSelection { plan_path: String },
+    Command { argv: Vec<String> },
+}
+
+impl CompletionCheck {
+    pub fn render(&self) -> String {
+        match self {
+            Self::Validate { genres } if genres.is_empty() => "syu validate .".to_string(),
+            Self::Validate { genres } => genres
+                .iter()
+                .map(|genre| format!("syu check . --genre {}", genre.label()))
+                .collect::<Vec<_>>()
+                .join(" && "),
+            Self::GoalPlanCheck { plan_path, range } => {
+                format!("syu task check {plan_path} --range {range}")
+            }
+            Self::TestSelection { plan_path } => format!("syu task test-select {plan_path}"),
+            Self::Command { argv } => argv.join(" "),
+        }
+    }
+}
+
+impl ValidationGenre {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Graph => "graph",
+            Self::Delivery => "delivery",
+            Self::Trace => "trace",
+            Self::Coverage => "coverage",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurfaceRequirement {
+    #[serde(default)]
+    pub all_of: BTreeSet<WorkSurface>,
+    #[serde(default)]
+    pub any_of: Vec<BTreeSet<WorkSurface>>,
+    #[serde(default)]
+    pub forbidden_mutations: BTreeSet<WorkSurface>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkKindProfile {
+    pub kind: WorkKind,
+    pub surface_requirement: SurfaceRequirement,
+    pub completion: Vec<CompletionCheck>,
+    pub cargo_test_fallback: bool,
+    pub mutation_forbidden: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkVerification {
-    pub required_surfaces: BTreeSet<WorkSurface>,
-    pub completion_commands: Vec<String>,
+    pub contract: SurfaceRequirement,
+    pub completion: Vec<CompletionCheck>,
     pub cargo_test_fallback: bool,
     pub mutation_forbidden: bool,
 }
@@ -214,18 +428,140 @@ pub struct WorkPlan {
     pub impact: WorkImpact,
     pub mutations: Vec<WorkMutation>,
     pub verification: WorkVerification,
+    pub executable: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct WorkKindProfile {
-    pub kind: WorkKind,
-    pub direct_surfaces: BTreeSet<WorkSurface>,
-    pub required_surfaces: BTreeSet<WorkSurface>,
-    pub forbidden_surfaces: BTreeSet<WorkSurface>,
-    pub default_completion: Vec<String>,
-    pub cargo_test_fallback: bool,
-    pub mutation_forbidden: bool,
+pub fn goal_plan_from_work_plan(
+    request: &str,
+    request_path: &str,
+    plan: &WorkPlan,
+) -> GoalPlanArtifact {
+    let mut items = GoalPlanPersistentItems::default();
+    for item in &plan.impact.items {
+        let target = match item.surface {
+            WorkSurface::Philosophy => &mut items.philosophies,
+            WorkSurface::Policy => &mut items.policies,
+            WorkSurface::Requirement => &mut items.requirements,
+            WorkSurface::Feature => &mut items.features,
+            _ => continue,
+        };
+        target.push(GoalPlanPersistentItem::Id(item.id.clone()));
+    }
+    let include = plan
+        .impact
+        .repository
+        .iter()
+        .filter(|impact| impact.impact_role == ImpactRole::DirectChange)
+        .map(|impact| GoalPlanScopeInclude::Pattern(impact.path.clone()))
+        .collect();
+    let completion = plan
+        .verification
+        .completion
+        .iter()
+        .map(CompletionCheck::render)
+        .collect();
+    let mut required_tests = BTreeMap::<String, Vec<TraceReference>>::new();
+    for impact in &plan.impact.tests {
+        if impact.impact_role == ImpactRole::DirectChange {
+            required_tests
+                .entry(impact.target.language.clone())
+                .or_default()
+                .push(TraceReference {
+                    file: PathBuf::from(&impact.target.file),
+                    symbols: impact.target.symbols.clone(),
+                    doc_contains: Vec::new(),
+                    method: None,
+                    path: None,
+                });
+        }
+    }
+    let warnings = plan
+        .impact
+        .diagnostics
+        .iter()
+        .map(|diagnostic| format!("{}: {}", diagnostic.rule, diagnostic.reason))
+        .collect();
+    GoalPlanArtifact {
+        version: 2,
+        kind: "syu.goal_plan".to_string(),
+        request_path: Some(request_path.to_string()),
+        request: Some(request.to_string()),
+        classification: Some(format!("{:?}", plan.intent.kind).to_lowercase()),
+        source: GoalPlanSource {
+            mode: GoalPlanSourceMode::RequestDriven,
+            request_artifact: Some(request_path.to_string()),
+            classification: Some(format!("{:?}", plan.intent.kind).to_lowercase()),
+            range: None,
+            confidence: Some(if plan.executable {
+                GoalPlanConfidence::High
+            } else {
+                GoalPlanConfidence::Low
+            }),
+            evidence: Some(GoalPlanSourceEvidence::default()),
+        },
+        goal: GoalPlanGoal {
+            id: "GOAL-WORK-001".to_string(),
+            title: format!("Plan {:?} work", plan.intent.kind),
+            statement: request.to_string(),
+            non_goals: vec!["Do not create a fifth persistent spec layer".to_string()],
+            inferred: false,
+        },
+        spec_mapping: GoalPlanSpecMapping {
+            persistent_items: items,
+            spec_updates: Default::default(),
+            spec_updates_required: plan.mutations.iter().any(|mutation| {
+                !matches!(
+                    mutation,
+                    WorkMutation::ModifyRepository { .. }
+                        | WorkMutation::UpdateTrace { .. }
+                        | WorkMutation::RepairDiagnostic { .. }
+                )
+            }),
+            spec_update_reasons: plan
+                .mutations
+                .iter()
+                .map(|mutation| format!("typed mutation: {mutation:?}"))
+                .collect(),
+        },
+        implementation_plan: GoalPlanImplementationPlan {
+            confidence: Some(if plan.executable {
+                GoalPlanConfidence::High
+            } else {
+                GoalPlanConfidence::Low
+            }),
+            scope: GoalPlanScope {
+                include,
+                exclude: vec!["docs/generated/**".to_string(), "target/**".to_string()],
+            },
+            steps: plan
+                .mutations
+                .iter()
+                .map(|mutation| format!("Apply {mutation:?}"))
+                .collect(),
+        },
+        test_plan: GoalPlanTestPlan {
+            selection_mode: GoalPlanSelectionMode::Affected,
+            confidence: Some(GoalPlanConfidence::High),
+            required_tests,
+            suggested_tests: BTreeMap::new(),
+        },
+        coverage: GoalPlanCoverage {
+            mode: GoalPlanCoverageMode::ChangedLines,
+            threshold: 100,
+            include: plan
+                .impact
+                .repository
+                .iter()
+                .filter(|impact| impact.impact_role == ImpactRole::DirectChange)
+                .map(|impact| impact.path.clone())
+                .collect(),
+            exclude: Vec::new(),
+        },
+        completion: GoalPlanCompletion {
+            must_pass: completion,
+        },
+        warnings,
+    }
 }
 
 pub fn resolve_work_intent(
@@ -235,169 +571,881 @@ pub fn resolve_work_intent(
     explicit_mode: Option<WorkMode>,
     seeds: Vec<WorkSeed>,
 ) -> WorkIntent {
-    let text = request.to_lowercase();
     let mode = explicit_mode.unwrap_or_else(|| {
-        if contains_any(
-            &text,
+        if score(
+            request,
             &["review", "audit", "investigate", "調査", "レビュー", "分析"],
-        ) {
+        ) > 0
+        {
             WorkMode::ReviewOnly
         } else {
             WorkMode::PlanAndExecute
         }
     });
-    let kind = explicit_kind.unwrap_or_else(|| infer_kind(&text, mode));
-    let operation = explicit_operation.unwrap_or_else(|| infer_operation(&text, kind));
-    let requested_surfaces = infer_surfaces(&text, &seeds);
-    let mut constraints = WorkConstraints::default();
-    constraints
-        .forbidden_surfaces
-        .extend(work_kind_profile(kind).forbidden_surfaces);
+    let kind = explicit_kind.unwrap_or_else(|| infer_kind(request, mode));
+    let operation = explicit_operation.unwrap_or_else(|| infer_operation(request, kind));
     WorkIntent {
         kind,
         operation,
         mode,
+        requested_surfaces: infer_surfaces(request, &seeds),
         seeds,
-        requested_surfaces,
-        constraints,
+        constraints: WorkConstraints::default(),
     }
+}
+
+pub fn work_request_text(request: &crate::RequestArtifact) -> String {
+    std::iter::once(request.request.as_str())
+        .chain(request.context.affected_area.as_deref())
+        .chain(
+            request
+                .context
+                .repository_constraints
+                .iter()
+                .map(String::as_str),
+        )
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub fn work_kind_profile(kind: WorkKind) -> WorkKindProfile {
     use WorkSurface as S;
-    let (direct, required, forbidden, completion, fallback, mutation_forbidden): ProfileParts =
-        match kind {
-            WorkKind::Deliver => (
-                &[S::Implementation, S::Test],
-                &[S::Implementation],
-                &[],
-                &["syu validate .", "syu task check"],
-                true,
-                false,
-            ),
-            WorkKind::Specify => (
-                &[S::Requirement, S::Feature],
-                &[S::Requirement],
-                &[],
-                &["syu validate ."],
-                false,
-                false,
-            ),
-            WorkKind::Govern => (
-                &[S::Philosophy, S::Policy],
-                &[S::Policy],
-                &[S::Implementation],
-                &["syu validate .", "syu check graph"],
-                false,
-                false,
-            ),
-            WorkKind::Restructure => (
-                &[
-                    S::Philosophy,
-                    S::Policy,
-                    S::Requirement,
-                    S::Feature,
-                    S::Trace,
+    let any = |values: &[S]| vec![values.iter().copied().collect()];
+    let mut contract = SurfaceRequirement::default();
+    let (completion, fallback, forbidden) = match kind {
+        WorkKind::Deliver => {
+            contract.all_of.insert(S::Implementation);
+            (
+                vec![
+                    validate(&[ValidationGenre::Delivery, ValidationGenre::Trace]),
+                    goal_check(),
                 ],
-                &[S::Trace],
-                &[],
-                &["syu validate .", "syu check graph"],
-                false,
-                false,
-            ),
-            WorkKind::Verify => (
-                &[S::Test, S::Trace],
-                &[S::Test],
-                &[],
-                &["syu validate .", "syu check coverage"],
-                false,
-                false,
-            ),
-            WorkKind::Repair => (
-                &[S::Trace, S::Config, S::GeneratedArtifact],
-                &[],
-                &[S::Implementation],
-                &["syu validate ."],
-                false,
-                false,
-            ),
-            WorkKind::Maintain => (
-                &[S::Tooling, S::Config, S::Implementation],
-                &[S::Tooling],
-                &[S::Philosophy, S::Policy, S::Requirement, S::Feature],
-                &["syu validate ."],
                 true,
                 false,
-            ),
-            WorkKind::Retire => (
-                &[
-                    S::Requirement,
-                    S::Feature,
-                    S::Implementation,
-                    S::Test,
-                    S::Trace,
-                ],
-                &[S::Trace],
-                &[],
-                &["syu validate .", "syu check graph"],
+            )
+        }
+        WorkKind::Specify => {
+            contract.any_of = any(&[S::Requirement, S::Feature]);
+            (
+                vec![validate(&[
+                    ValidationGenre::Graph,
+                    ValidationGenre::Delivery,
+                ])],
+                false,
+                false,
+            )
+        }
+        WorkKind::Govern => {
+            contract.any_of = any(&[S::Philosophy, S::Policy]);
+            (vec![validate(&[ValidationGenre::Graph])], false, false)
+        }
+        WorkKind::Restructure => {
+            contract.any_of = any(&[
+                S::Philosophy,
+                S::Policy,
+                S::Requirement,
+                S::Feature,
+                S::Trace,
+            ]);
+            (
+                vec![validate(&[ValidationGenre::Graph, ValidationGenre::Trace])],
+                false,
+                false,
+            )
+        }
+        WorkKind::Verify => {
+            contract.any_of = any(&[S::Test, S::Trace]);
+            (
+                vec![validate(&[
+                    ValidationGenre::Coverage,
+                    ValidationGenre::Trace,
+                ])],
+                false,
+                false,
+            )
+        }
+        WorkKind::Repair => {
+            contract.any_of = any(&[S::Trace, S::Config, S::GeneratedArtifact]);
+            contract.forbidden_mutations.insert(S::Implementation);
+            (
+                vec![validate(&[ValidationGenre::Graph, ValidationGenre::Trace])],
+                false,
+                false,
+            )
+        }
+        WorkKind::Maintain => {
+            contract.any_of = any(&[S::Tooling, S::Config, S::Implementation]);
+            contract.forbidden_mutations.extend([
+                S::Philosophy,
+                S::Policy,
+                S::Requirement,
+                S::Feature,
+            ]);
+            (
+                vec![validate(&[
+                    ValidationGenre::Workspace,
+                    ValidationGenre::Delivery,
+                ])],
                 true,
                 false,
-            ),
-            WorkKind::Review => (
-                &[],
-                &[],
-                &[
-                    S::Philosophy,
-                    S::Policy,
-                    S::Requirement,
-                    S::Feature,
-                    S::Implementation,
-                    S::Test,
-                    S::Trace,
-                    S::Config,
-                    S::Documentation,
-                    S::Tooling,
-                    S::GeneratedArtifact,
-                ],
-                &[],
-                false,
+            )
+        }
+        WorkKind::Retire => {
+            contract.any_of = any(&[S::Requirement, S::Feature, S::Implementation]);
+            (
+                vec![validate(&[
+                    ValidationGenre::Graph,
+                    ValidationGenre::Trace,
+                    ValidationGenre::Delivery,
+                ])],
                 true,
-            ),
-            WorkKind::Adopt => (
-                &[S::Config, S::Documentation, S::Trace],
-                &[S::Config],
-                &[],
-                &["syu validate ."],
+                false,
+            )
+        }
+        WorkKind::Review => {
+            contract.forbidden_mutations.extend(all_surfaces());
+            (Vec::new(), false, true)
+        }
+        WorkKind::Adopt => {
+            contract.any_of = any(&[S::Config, S::Documentation, S::Trace]);
+            (
+                vec![validate(&[
+                    ValidationGenre::Workspace,
+                    ValidationGenre::Graph,
+                ])],
                 false,
                 false,
-            ),
-        };
+            )
+        }
+    };
     WorkKindProfile {
         kind,
-        direct_surfaces: direct.iter().copied().collect(),
-        required_surfaces: required.iter().copied().collect(),
-        forbidden_surfaces: forbidden.iter().copied().collect(),
-        default_completion: completion
-            .iter()
-            .map(|value| (*value).to_string())
-            .collect(),
+        surface_requirement: contract,
+        completion,
         cargo_test_fallback: fallback,
-        mutation_forbidden,
+        mutation_forbidden: forbidden,
     }
 }
 
-fn infer_kind(text: &str, mode: WorkMode) -> WorkKind {
+fn validate(genres: &[ValidationGenre]) -> CompletionCheck {
+    CompletionCheck::Validate {
+        genres: genres.iter().copied().collect(),
+    }
+}
+fn goal_check() -> CompletionCheck {
+    CompletionCheck::GoalPlanCheck {
+        plan_path: ".syu/tasks/current.yaml".to_string(),
+        range: "origin/main...HEAD".to_string(),
+    }
+}
+
+pub fn plan_work(mut input: WorkPlanningInput) -> WorkPlan {
+    input.seeds.sort_by(|a, b| a.id.cmp(&b.id));
+    input.seeds.dedup_by(|a, b| a.id == b.id);
+    let mut intent = resolve_work_intent(
+        &input.request,
+        input.explicit_kind,
+        input.explicit_operation,
+        input.explicit_mode,
+        input.seeds.clone(),
+    );
+    intent.constraints = input.constraints.clone();
+    let profile = work_kind_profile(intent.kind);
+    let nodes: BTreeMap<_, _> = input
+        .nodes
+        .into_iter()
+        .map(|node| (node.id.clone(), node))
+        .collect();
+    let mut impact = WorkImpact::default();
+    let mut visited = BTreeMap::<String, SourceRole>::new();
+    let mut queue = VecDeque::new();
+    for seed in &intent.seeds {
+        if let Some(node) = nodes.get(&seed.id) {
+            if node.surface != seed.surface {
+                blocker(
+                    &mut impact,
+                    "WORK_SEED_KIND_MISMATCH",
+                    &seed.id,
+                    "seed prefix does not match the workspace Item kind",
+                );
+                continue;
+            }
+            if node
+                .status
+                .as_deref()
+                .is_some_and(|status| matches!(status, "retired" | "superseded"))
+                && intent.kind != WorkKind::Retire
+            {
+                blocker(
+                    &mut impact,
+                    "WORK_RETIRED_SEED",
+                    &seed.id,
+                    "retired or superseded Items require Retire work",
+                );
+                continue;
+            }
+            visited.insert(seed.id.clone(), seed.source_role);
+            queue.push_back(seed.id.clone());
+        } else if intent.operation != WorkOperation::Create {
+            blocker(
+                &mut impact,
+                "WORK_UNKNOWN_SEED",
+                &seed.id,
+                "seed ID does not exist in the workspace",
+            );
+        } else {
+            impact.items.push(ImpactedItem {
+                id: seed.id.clone(),
+                surface: seed.surface,
+                source_role: seed.source_role,
+                impact_role: ImpactRole::DirectChange,
+                reason: "new explicit Item seed".to_string(),
+            });
+        }
+    }
+    for candidate in &input.search_candidates {
+        if nodes.contains_key(&candidate.id) {
+            visited
+                .entry(candidate.id.clone())
+                .or_insert(SourceRole::SearchCandidate);
+        }
+    }
+    while let Some(id) = queue.pop_front() {
+        let Some(node) = nodes.get(&id) else { continue };
+        for linked in neighbors(intent.kind, node, &nodes) {
+            if !visited.contains_key(&linked) {
+                visited.insert(linked.clone(), SourceRole::Inferred);
+                queue.push_back(linked.clone());
+            }
+            impact.edges.push(ImpactedEdge {
+                from: id.clone(),
+                to: linked,
+                impact_role: edge_role(intent.kind),
+                reason: "expanded by the WorkKind traversal policy".to_string(),
+            });
+        }
+    }
+    for (id, source_role) in &visited {
+        let node = &nodes[id];
+        let impact_role = item_role(intent.kind, node.surface, *source_role);
+        impact.items.push(ImpactedItem {
+            id: id.clone(),
+            surface: node.surface,
+            source_role: *source_role,
+            impact_role,
+            reason: role_reason(intent.kind, impact_role).to_string(),
+        });
+        add_owned_impacts(intent.kind, node, &mut impact);
+    }
+    for change in input.repository_changes {
+        impact.repository.push(RepositoryImpact {
+            path: change.path,
+            surface: repository_surface(intent.kind),
+            impact_role: if intent.kind == WorkKind::Review {
+                ImpactRole::Context
+            } else {
+                ImpactRole::DirectChange
+            },
+            reason: "changed repository path".to_string(),
+        });
+    }
+    for diagnostic in input.diagnostics {
+        impact.diagnostics.push(DiagnosticImpact {
+            rule: diagnostic.rule,
+            subject: diagnostic.subject,
+            impact_role: if intent.kind == WorkKind::Review {
+                ImpactRole::Context
+            } else {
+                ImpactRole::DirectChange
+            },
+            reason: diagnostic.message,
+        });
+    }
+    if intent.kind == WorkKind::Govern {
+        let features = impact
+            .items
+            .iter()
+            .filter(|item| item.surface == WorkSurface::Feature)
+            .map(|item| item.id.clone())
+            .collect::<Vec<_>>();
+        if features.len() > 1 {
+            impact.split_suggestions.push(GoalSplitSuggestion {
+                reason: "governance work affects independent downstream feature branches"
+                    .to_string(),
+                item_ids: features,
+            });
+        }
+    }
+    validate_operation_payload(&intent, &mut impact);
+    let mut mutations = build_mutations(&intent, &nodes, &impact);
+    if profile.mutation_forbidden || intent.mode == WorkMode::ReviewOnly {
+        mutations.clear();
+    }
+    validate_contract(&profile.surface_requirement, &mut impact, &mut mutations);
+    sort_impact(&mut impact);
+    let executable = !impact
+        .diagnostics
+        .iter()
+        .any(|item| item.impact_role == ImpactRole::Blocker);
+    WorkPlan {
+        intent,
+        impact,
+        mutations,
+        verification: WorkVerification {
+            contract: profile.surface_requirement,
+            completion: profile.completion,
+            cargo_test_fallback: profile.cargo_test_fallback,
+            mutation_forbidden: profile.mutation_forbidden,
+        },
+        executable,
+    }
+}
+
+fn validate_operation_payload(intent: &WorkIntent, impact: &mut WorkImpact) {
+    let missing = match intent.operation {
+        WorkOperation::Rename | WorkOperation::Supersede
+            if intent.constraints.target_id.is_none() =>
+        {
+            Some("target_id")
+        }
+        WorkOperation::Move if intent.constraints.destination_document.is_none() => {
+            Some("destination_document")
+        }
+        WorkOperation::Split if intent.constraints.related_item_ids.is_empty() => {
+            Some("related_item_ids")
+        }
+        WorkOperation::Relink if intent.constraints.related_item_ids.is_empty() => {
+            Some("related_item_ids")
+        }
+        WorkOperation::Merge
+            if intent.constraints.target_id.is_none()
+                || intent.constraints.related_item_ids.is_empty() =>
+        {
+            Some("target_id and related_item_ids")
+        }
+        WorkOperation::Promote | WorkOperation::Demote
+            if intent.constraints.target_surface.is_none() =>
+        {
+            Some("target surface")
+        }
+        _ => None,
+    };
+    if let Some(field) = missing {
+        blocker(
+            impact,
+            "WORK_OPERATION_PAYLOAD",
+            field,
+            "operation requires additional typed payload",
+        );
+    }
+}
+
+fn neighbors(
+    kind: WorkKind,
+    node: &WorkGraphNode,
+    nodes: &BTreeMap<String, WorkGraphNode>,
+) -> Vec<String> {
+    let allowed = |from: WorkSurface, to: WorkSurface| match kind {
+        WorkKind::Deliver => matches!(
+            (from, to),
+            (WorkSurface::Feature, WorkSurface::Requirement)
+                | (WorkSurface::Requirement, WorkSurface::Policy)
+                | (WorkSurface::Policy, WorkSurface::Philosophy)
+        ),
+        WorkKind::Specify => matches!(
+            (from, to),
+            (WorkSurface::Requirement, WorkSurface::Feature)
+                | (WorkSurface::Feature, WorkSurface::Requirement)
+                | (WorkSurface::Requirement, WorkSurface::Policy)
+                | (WorkSurface::Policy, WorkSurface::Philosophy)
+        ),
+        WorkKind::Govern => matches!(
+            (from, to),
+            (WorkSurface::Philosophy, WorkSurface::Policy)
+                | (WorkSurface::Policy, WorkSurface::Requirement)
+                | (WorkSurface::Requirement, WorkSurface::Feature)
+        ),
+        WorkKind::Restructure => true,
+        WorkKind::Retire => true,
+        _ => matches!(
+            (from, to),
+            (WorkSurface::Feature, WorkSurface::Requirement)
+                | (WorkSurface::Requirement, WorkSurface::Policy)
+                | (WorkSurface::Policy, WorkSurface::Philosophy)
+        ),
+    };
+    let mut result = node
+        .linked_ids
+        .iter()
+        .filter(|id| {
+            nodes
+                .get(*id)
+                .is_some_and(|target| allowed(node.surface, target.surface))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    for candidate in nodes.values() {
+        if candidate.linked_ids.contains(&node.id) && allowed(node.surface, candidate.surface) {
+            result.push(candidate.id.clone());
+        }
+    }
+    result.sort();
+    result.dedup();
+    result
+}
+
+fn item_role(kind: WorkKind, surface: WorkSurface, source: SourceRole) -> ImpactRole {
+    if source == SourceRole::SearchCandidate {
+        return ImpactRole::Context;
+    }
+    match kind {
+        WorkKind::Specify if matches!(surface, WorkSurface::Requirement | WorkSurface::Feature) => {
+            ImpactRole::DirectChange
+        }
+        WorkKind::Govern if matches!(surface, WorkSurface::Philosophy | WorkSurface::Policy) => {
+            ImpactRole::DirectChange
+        }
+        WorkKind::Govern => ImpactRole::FollowUp,
+        WorkKind::Restructure | WorkKind::Retire if source == SourceRole::Seed => {
+            ImpactRole::DirectChange
+        }
+        WorkKind::Review
+        | WorkKind::Deliver
+        | WorkKind::Verify
+        | WorkKind::Repair
+        | WorkKind::Maintain
+        | WorkKind::Adopt => ImpactRole::Context,
+        _ => ImpactRole::Context,
+    }
+}
+
+fn add_owned_impacts(kind: WorkKind, node: &WorkGraphNode, impact: &mut WorkImpact) {
+    let repository_role = if matches!(kind, WorkKind::Deliver | WorkKind::Retire) {
+        ImpactRole::DirectChange
+    } else {
+        ImpactRole::Context
+    };
+    for target in &node.implementations {
+        impact.repository.push(RepositoryImpact {
+            path: target.file.clone(),
+            surface: WorkSurface::Implementation,
+            impact_role: repository_role,
+            reason: format!("owned by {}", node.id),
+        });
+    }
+    let test_role = if matches!(
+        kind,
+        WorkKind::Deliver | WorkKind::Verify | WorkKind::Retire
+    ) {
+        ImpactRole::DirectChange
+    } else {
+        ImpactRole::Context
+    };
+    for target in &node.tests {
+        impact.tests.push(TestImpact {
+            target: target.clone(),
+            impact_role: test_role,
+            reason: format!("declared by {}", node.id),
+        });
+    }
+}
+
+fn build_mutations(
+    intent: &WorkIntent,
+    nodes: &BTreeMap<String, WorkGraphNode>,
+    impact: &WorkImpact,
+) -> Vec<WorkMutation> {
+    let direct = impact
+        .items
+        .iter()
+        .filter(|item| item.impact_role == ImpactRole::DirectChange)
+        .collect::<Vec<_>>();
+    let mut out = Vec::new();
+    if intent.kind == WorkKind::Deliver {
+        out.extend(
+            impact
+                .repository
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::ModifyRepository {
+                    path: item.path.clone(),
+                }),
+        );
+        out.extend(
+            impact
+                .tests
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::UpdateTrace {
+                    target: item.target.clone(),
+                }),
+        );
+        return out;
+    }
+    if intent.kind == WorkKind::Verify {
+        out.extend(
+            impact
+                .tests
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::ModifyRepository {
+                    path: item.target.file.clone(),
+                }),
+        );
+        return out;
+    }
+    if intent.kind == WorkKind::Repair {
+        out.extend(
+            impact
+                .diagnostics
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::RepairDiagnostic {
+                    rule: item.rule.clone(),
+                    subject: item.subject.clone(),
+                }),
+        );
+        return out;
+    }
+    if intent.kind == WorkKind::Maintain {
+        out.extend(
+            impact
+                .repository
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::ModifyRepository {
+                    path: item.path.clone(),
+                }),
+        );
+        return out;
+    }
+    if intent.kind == WorkKind::Adopt {
+        out.extend(
+            impact
+                .repository
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| WorkMutation::ModifyConfig {
+                    path: item.path.clone(),
+                }),
+        );
+        return out;
+    }
+    for item in direct {
+        match intent.operation {
+            WorkOperation::Create => out.push(WorkMutation::CreateItem {
+                draft: SpecItemDraft {
+                    id: item.id.clone(),
+                    surface: item.surface,
+                },
+            }),
+            WorkOperation::Modify => out.push(WorkMutation::ModifyItem {
+                id: item.id.clone(),
+                patch: SpecItemPatch {
+                    requested_surfaces: intent.requested_surfaces.clone(),
+                },
+            }),
+            WorkOperation::Delete => out.push(WorkMutation::DeleteItem {
+                id: item.id.clone(),
+            }),
+            WorkOperation::Rename => {
+                if let Some(to) = &intent.constraints.target_id {
+                    out.push(WorkMutation::RenameItem {
+                        from: item.id.clone(),
+                        to: to.clone(),
+                    });
+                }
+            }
+            WorkOperation::Move => {
+                if let Some(destination) = &intent.constraints.destination_document {
+                    out.push(WorkMutation::MoveItem {
+                        id: item.id.clone(),
+                        destination_document: destination.clone(),
+                    });
+                }
+            }
+            WorkOperation::Relink => out.push(WorkMutation::Relink {
+                remove: nodes
+                    .get(&item.id)
+                    .map(|node| {
+                        node.linked_ids
+                            .iter()
+                            .map(|to| SpecEdge {
+                                from: item.id.clone(),
+                                to: to.clone(),
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                add: intent
+                    .constraints
+                    .related_item_ids
+                    .iter()
+                    .map(|to| SpecEdge {
+                        from: item.id.clone(),
+                        to: to.clone(),
+                    })
+                    .collect(),
+            }),
+            WorkOperation::Split => {
+                let targets = intent
+                    .constraints
+                    .related_item_ids
+                    .iter()
+                    .filter_map(|id| {
+                        surface_from_id(id).map(|surface| SpecItemDraft {
+                            id: id.clone(),
+                            surface,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let redistribution = nodes
+                    .get(&item.id)
+                    .into_iter()
+                    .flat_map(|node| node.linked_ids.iter())
+                    .enumerate()
+                    .filter_map(|(index, linked)| {
+                        targets
+                            .get(index % targets.len().max(1))
+                            .map(|target| RelationshipMove {
+                                relationship: SpecEdge {
+                                    from: item.id.clone(),
+                                    to: linked.clone(),
+                                },
+                                target_id: target.id.clone(),
+                            })
+                    })
+                    .collect();
+                out.push(WorkMutation::SplitItem {
+                    source: item.id.clone(),
+                    targets,
+                    redistribution,
+                });
+            }
+            WorkOperation::Merge => out.push(WorkMutation::MergeItems {
+                sources: std::iter::once(item.id.clone())
+                    .chain(intent.constraints.related_item_ids.clone())
+                    .collect(),
+                target: intent
+                    .constraints
+                    .target_id
+                    .clone()
+                    .unwrap_or_else(|| item.id.clone()),
+            }),
+            WorkOperation::Promote | WorkOperation::Demote => {
+                if let Some(surface) = intent.constraints.target_surface {
+                    out.push(WorkMutation::ChangeItemKind {
+                        id: item.id.clone(),
+                        target_surface: surface,
+                        relink: Vec::new(),
+                    });
+                }
+            }
+            WorkOperation::Supersede => {
+                if let Some(replacement) = &intent.constraints.target_id {
+                    out.push(WorkMutation::Supersede {
+                        old: item.id.clone(),
+                        replacement: replacement.clone(),
+                    });
+                }
+            }
+            WorkOperation::Validate => {}
+        }
+    }
+    out
+}
+
+fn validate_contract(
+    contract: &SurfaceRequirement,
+    impact: &mut WorkImpact,
+    mutations: &mut Vec<WorkMutation>,
+) {
+    let present = direct_surfaces(impact);
+    for surface in contract.all_of.difference(&present) {
+        blocker(
+            impact,
+            "WORK_REQUIRED_SURFACE",
+            &format!("{surface:?}"),
+            "required direct-change surface is missing",
+        );
+    }
+    for group in &contract.any_of {
+        if group.is_disjoint(&present) {
+            blocker(
+                impact,
+                "WORK_REQUIRED_SURFACE",
+                "work contract",
+                "none of the required alternative direct-change surfaces are present",
+            );
+        }
+    }
+    let forbidden = mutation_surfaces(mutations);
+    for surface in contract.forbidden_mutations.intersection(&forbidden) {
+        blocker(
+            impact,
+            "WORK_FORBIDDEN_MUTATION",
+            &format!("{surface:?}"),
+            "WorkKind forbids mutation on this surface",
+        );
+    }
+    if impact
+        .diagnostics
+        .iter()
+        .any(|item| item.impact_role == ImpactRole::Blocker)
+    {
+        mutations.clear();
+    }
+}
+
+fn direct_surfaces(impact: &WorkImpact) -> BTreeSet<WorkSurface> {
+    impact
+        .items
+        .iter()
+        .filter(|item| item.impact_role == ImpactRole::DirectChange)
+        .map(|item| item.surface)
+        .chain(
+            impact
+                .repository
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|item| item.surface),
+        )
+        .chain(
+            impact
+                .tests
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|_| WorkSurface::Test),
+        )
+        .chain(
+            impact
+                .diagnostics
+                .iter()
+                .filter(|item| item.impact_role == ImpactRole::DirectChange)
+                .map(|_| WorkSurface::Trace),
+        )
+        .collect()
+}
+
+fn mutation_surfaces(mutations: &[WorkMutation]) -> BTreeSet<WorkSurface> {
+    mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+            WorkMutation::CreateItem { draft } => Some(draft.surface),
+            WorkMutation::ModifyItem { id, .. }
+            | WorkMutation::DeleteItem { id }
+            | WorkMutation::RenameItem { from: id, .. }
+            | WorkMutation::MoveItem { id, .. }
+            | WorkMutation::SplitItem { source: id, .. }
+            | WorkMutation::ChangeItemKind { id, .. }
+            | WorkMutation::Supersede { old: id, .. } => surface_from_id(id),
+            WorkMutation::ModifyRepository { .. } => Some(WorkSurface::Implementation),
+            WorkMutation::UpdateTrace { .. } | WorkMutation::Relink { .. } => {
+                Some(WorkSurface::Trace)
+            }
+            WorkMutation::RepairDiagnostic { .. } => Some(WorkSurface::Trace),
+            WorkMutation::ModifyConfig { .. } => Some(WorkSurface::Config),
+            WorkMutation::MergeItems { target, .. } => surface_from_id(target),
+        })
+        .collect()
+}
+
+fn blocker(impact: &mut WorkImpact, rule: &str, subject: &str, reason: &str) {
+    impact.diagnostics.push(DiagnosticImpact {
+        rule: rule.to_string(),
+        subject: subject.to_string(),
+        impact_role: ImpactRole::Blocker,
+        reason: reason.to_string(),
+    });
+}
+fn edge_role(kind: WorkKind) -> ImpactRole {
+    if matches!(kind, WorkKind::Restructure | WorkKind::Retire) {
+        ImpactRole::DirectChange
+    } else {
+        ImpactRole::Context
+    }
+}
+fn role_reason(kind: WorkKind, role: ImpactRole) -> &'static str {
+    match role {
+        ImpactRole::DirectChange => "selected as a direct change by the WorkKind profile",
+        ImpactRole::Context => "required context for the selected work",
+        ImpactRole::FollowUp if kind == WorkKind::Govern => {
+            "downstream contract affected by governance work"
+        }
+        ImpactRole::FollowUp => "linked work should be handled as a follow-up",
+        ImpactRole::Blocker => "work cannot proceed",
+    }
+}
+fn repository_surface(kind: WorkKind) -> WorkSurface {
+    match kind {
+        WorkKind::Adopt => WorkSurface::Config,
+        WorkKind::Maintain => WorkSurface::Tooling,
+        _ => WorkSurface::Implementation,
+    }
+}
+fn surface_from_id(id: &str) -> Option<WorkSurface> {
+    if id.starts_with("PHIL-") {
+        Some(WorkSurface::Philosophy)
+    } else if id.starts_with("POL-") {
+        Some(WorkSurface::Policy)
+    } else if id.starts_with("REQ-") {
+        Some(WorkSurface::Requirement)
+    } else if id.starts_with("FEAT-") {
+        Some(WorkSurface::Feature)
+    } else {
+        None
+    }
+}
+fn all_surfaces() -> BTreeSet<WorkSurface> {
+    use WorkSurface as S;
+    [
+        S::Philosophy,
+        S::Policy,
+        S::Requirement,
+        S::Feature,
+        S::Implementation,
+        S::Test,
+        S::Trace,
+        S::Config,
+        S::Documentation,
+        S::Tooling,
+        S::GeneratedArtifact,
+    ]
+    .into_iter()
+    .collect()
+}
+fn sort_impact(impact: &mut WorkImpact) {
+    impact.items.sort_by(|a, b| a.id.cmp(&b.id));
+    impact
+        .edges
+        .sort_by(|a, b| (&a.from, &a.to).cmp(&(&b.from, &b.to)));
+    impact.repository.sort_by(|a, b| a.path.cmp(&b.path));
+    impact
+        .repository
+        .dedup_by(|a, b| a.path == b.path && a.impact_role == b.impact_role);
+    impact.tests.sort_by(|a, b| {
+        (&a.target.file, &a.target.symbols).cmp(&(&b.target.file, &b.target.symbols))
+    });
+    impact
+        .tests
+        .dedup_by(|a, b| a.target == b.target && a.impact_role == b.impact_role);
+    impact
+        .diagnostics
+        .sort_by(|a, b| (&a.rule, &a.subject).cmp(&(&b.rule, &b.subject)));
+}
+
+fn infer_kind(request: &str, mode: WorkMode) -> WorkKind {
     if mode == WorkMode::ReviewOnly {
         return WorkKind::Review;
     }
-    let table = [
+    let candidates = [
         (
             WorkKind::Deliver,
             &["implement", "bug fix", "実装", "バグ修正"] as &[&str],
         ),
         (
             WorkKind::Retire,
-            &["retire", "deprecat", "supersede", "廃止", "削除"],
+            &["retire", "deprecate", "supersede", "remove old", "廃止"],
         ),
         (
             WorkKind::Restructure,
@@ -432,9 +1480,9 @@ fn infer_kind(text: &str, mode: WorkMode) -> WorkKind {
         (
             WorkKind::Repair,
             &[
-                "trace",
+                "broken trace",
                 "reciprocal",
-                "registry",
+                "registry inconsistency",
                 "diagnostic",
                 "整合性",
                 "修復",
@@ -459,16 +1507,20 @@ fn infer_kind(text: &str, mode: WorkMode) -> WorkKind {
             ],
         ),
     ];
-    table
+    candidates
         .into_iter()
-        .find(|(_, words)| contains_any(text, words))
+        .max_by_key(|(_, words)| score(request, words))
+        .filter(|(_, words)| score(request, words) > 0)
         .map(|(kind, _)| kind)
         .unwrap_or(WorkKind::Deliver)
 }
 
-fn infer_operation(text: &str, kind: WorkKind) -> WorkOperation {
-    let table = [
-        (WorkOperation::Supersede, &["supersede", "置換"] as &[&str]),
+fn infer_operation(request: &str, kind: WorkKind) -> WorkOperation {
+    let candidates = [
+        (
+            WorkOperation::Supersede,
+            &["supersede", "retire", "deprecate", "置換", "廃止"] as &[&str],
+        ),
         (WorkOperation::Rename, &["rename", "名前変更"]),
         (WorkOperation::Relink, &["relink", "リンク修復"]),
         (WorkOperation::Split, &["split", "分割"]),
@@ -476,16 +1528,27 @@ fn infer_operation(text: &str, kind: WorkKind) -> WorkOperation {
         (WorkOperation::Promote, &["promote", "昇格"]),
         (WorkOperation::Demote, &["demote", "降格"]),
         (WorkOperation::Move, &["move", "移動"]),
-        (WorkOperation::Delete, &["delete", "remove", "削除", "廃止"]),
+        (WorkOperation::Delete, &["delete", "remove", "削除"]),
         (
             WorkOperation::Create,
-            &["create", "add", "new", "追加", "新規"],
+            &[
+                "create",
+                "add",
+                "new",
+                "bootstrap",
+                "onboard",
+                "追加",
+                "新規",
+                "導入",
+                "初期化",
+            ],
         ),
     ];
-    table
+    candidates
         .into_iter()
-        .find(|(_, words)| contains_any(text, words))
-        .map(|(op, _)| op)
+        .max_by_key(|(_, words)| score(request, words))
+        .filter(|(_, words)| score(request, words) > 0)
+        .map(|(operation, _)| operation)
         .unwrap_or(if kind == WorkKind::Review {
             WorkOperation::Validate
         } else {
@@ -493,9 +1556,12 @@ fn infer_operation(text: &str, kind: WorkKind) -> WorkOperation {
         })
 }
 
-fn infer_surfaces(text: &str, seeds: &[WorkSeed]) -> BTreeSet<WorkSurface> {
+fn infer_surfaces(request: &str, seeds: &[WorkSeed]) -> BTreeSet<WorkSurface> {
     use WorkSurface as S;
-    let mut surfaces: BTreeSet<_> = seeds.iter().map(|seed| seed.surface).collect();
+    let mut out = seeds
+        .iter()
+        .map(|seed| seed.surface)
+        .collect::<BTreeSet<_>>();
     for (surface, words) in [
         (S::Philosophy, &["philosophy", "原則"] as &[&str]),
         (S::Policy, &["policy", "方針"]),
@@ -509,62 +1575,384 @@ fn infer_surfaces(text: &str, seeds: &[WorkSeed]) -> BTreeSet<WorkSurface> {
         (S::Tooling, &["tooling", "toolchain", "ci", "ツール"]),
         (S::GeneratedArtifact, &["generated", "生成物"]),
     ] {
-        if contains_any(text, words) {
-            surfaces.insert(surface);
+        if score(request, words) > 0 {
+            out.insert(surface);
         }
     }
-    surfaces
+    out
 }
 
-fn contains_any(text: &str, words: &[&str]) -> bool {
-    words.iter().any(|word| text.contains(word))
+fn score(text: &str, keywords: &[&str]) -> usize {
+    let lower = text.to_lowercase();
+    let tokens = lower
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .filter(|token| !token.is_empty())
+        .collect::<BTreeSet<_>>();
+    keywords
+        .iter()
+        .map(|keyword| {
+            let key = keyword.to_lowercase();
+            if key.chars().any(char::is_whitespace) {
+                if lower.contains(&key) { 4 } else { 0 }
+            } else if key.is_ascii() {
+                if tokens.contains(key.as_str()) { 3 } else { 0 }
+            } else if lower.contains(&key) {
+                3
+            } else {
+                0
+            }
+        })
+        .sum()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn explicit_kind_wins_and_axes_stay_independent() {
-        let intent = resolve_work_intent(
-            "review and split FEAT-1",
-            Some(WorkKind::Restructure),
-            None,
-            Some(WorkMode::PlanOnly),
-            vec![],
-        );
-        assert_eq!(intent.kind, WorkKind::Restructure);
-        assert_eq!(intent.operation, WorkOperation::Split);
-        assert_eq!(intent.mode, WorkMode::PlanOnly);
-    }
-
-    #[test]
-    fn review_profile_forbids_mutation_without_test_fallback() {
-        let profile = work_kind_profile(WorkKind::Review);
-        assert!(profile.mutation_forbidden);
-        assert!(!profile.cargo_test_fallback);
-        assert!(profile.default_completion.is_empty());
-    }
-
-    #[test]
-    fn classifies_representative_requests() {
-        let cases = [
-            ("implement the existing feature", WorkKind::Deliver),
-            ("change the security policy", WorkKind::Govern),
-            ("split FEAT-1", WorkKind::Restructure),
-            ("add a coverage test", WorkKind::Verify),
-            ("repair a broken trace", WorkKind::Repair),
-            ("update a dependency", WorkKind::Maintain),
-            ("retire the old feature", WorkKind::Retire),
-            ("audit the branch diff", WorkKind::Review),
-            ("bootstrap syu", WorkKind::Adopt),
-        ];
-        for (request, expected) in cases {
-            assert_eq!(
-                resolve_work_intent(request, None, None, None, vec![]).kind,
-                expected,
-                "{request}"
-            );
+    fn seed(id: &str, surface: WorkSurface) -> WorkSeed {
+        WorkSeed {
+            id: id.to_string(),
+            surface,
+            source_role: SourceRole::Seed,
         }
+    }
+    fn node(id: &str, surface: WorkSurface, links: &[&str]) -> WorkGraphNode {
+        WorkGraphNode {
+            id: id.to_string(),
+            surface,
+            document_path: None,
+            status: None,
+            linked_ids: links.iter().map(|s| s.to_string()).collect(),
+            implementations: Vec::new(),
+            tests: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn classifier_respects_tokens_and_infers_all_axes() {
+        assert_eq!(
+            resolve_work_intent("change a specific requirement", None, None, None, vec![]).kind,
+            WorkKind::Specify
+        );
+        let retire = resolve_work_intent("retire old feature", None, None, None, vec![]);
+        assert_eq!(
+            (retire.kind, retire.operation),
+            (WorkKind::Retire, WorkOperation::Supersede)
+        );
+        let adopt = resolve_work_intent("bootstrap syu", None, None, None, vec![]);
+        assert_eq!(
+            (adopt.kind, adopt.operation),
+            (WorkKind::Adopt, WorkOperation::Create)
+        );
+    }
+    #[test]
+    fn govern_traverses_philosophy_to_features_with_queue() {
+        let nodes = vec![
+            node("PHIL-1", WorkSurface::Philosophy, &["POL-1"]),
+            node("POL-1", WorkSurface::Policy, &["REQ-1"]),
+            node("REQ-1", WorkSurface::Requirement, &["FEAT-1"]),
+            node("FEAT-1", WorkSurface::Feature, &[]),
+        ];
+        let input = WorkPlanningInput {
+            request: "govern philosophy".into(),
+            seeds: vec![seed("PHIL-1", WorkSurface::Philosophy)],
+            nodes: nodes.clone(),
+            ..Default::default()
+        };
+        let plan = plan_work(input);
+        assert!(plan.executable);
+        assert_eq!(plan.impact.items.len(), 4);
+        assert!(
+            plan.impact
+                .items
+                .iter()
+                .any(|i| i.id == "FEAT-1" && i.impact_role == ImpactRole::FollowUp)
+        );
+        let policy_plan = plan_work(WorkPlanningInput {
+            request: "govern policy".into(),
+            seeds: vec![seed("POL-1", WorkSurface::Policy)],
+            nodes,
+            ..Default::default()
+        });
+        assert!(policy_plan.executable);
+        assert!(
+            policy_plan
+                .impact
+                .items
+                .iter()
+                .any(|item| item.id == "FEAT-1")
+        );
+    }
+    #[test]
+    fn deliver_changes_owned_code_and_tests_not_feature_spec() {
+        let mut feature = node("FEAT-1", WorkSurface::Feature, &["REQ-1"]);
+        feature.implementations.push(TraceTarget {
+            language: "rust".into(),
+            file: "src/lib.rs".into(),
+            symbols: vec!["run".into()],
+        });
+        let mut req = node("REQ-1", WorkSurface::Requirement, &[]);
+        req.tests.push(TraceTarget {
+            language: "rust".into(),
+            file: "tests/run.rs".into(),
+            symbols: vec!["runs".into()],
+        });
+        let plan = plan_work(WorkPlanningInput {
+            request: "implement FEAT-1".into(),
+            seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+            nodes: vec![feature, req],
+            ..Default::default()
+        });
+        assert!(plan.executable);
+        assert!(
+            plan.impact
+                .items
+                .iter()
+                .all(|i| i.impact_role == ImpactRole::Context)
+        );
+        assert!(
+            plan.mutations
+                .iter()
+                .any(|m| matches!(m,WorkMutation::ModifyRepository{path} if path=="src/lib.rs"))
+        );
+        assert!(
+            !plan
+                .mutations
+                .iter()
+                .any(|m| matches!(m, WorkMutation::ModifyItem { .. }))
+        );
+    }
+    #[test]
+    fn unknown_seed_and_missing_contract_are_blockers() {
+        let plan = plan_work(WorkPlanningInput {
+            request: "implement REQ-MISSING".into(),
+            seeds: vec![seed("REQ-MISSING", WorkSurface::Requirement)],
+            ..Default::default()
+        });
+        assert!(!plan.executable);
+        assert!(
+            plan.impact
+                .diagnostics
+                .iter()
+                .all(|d| d.impact_role == ImpactRole::Blocker)
+        );
+    }
+    #[test]
+    fn completion_commands_render_valid_cli_shapes() {
+        for kind in [
+            WorkKind::Deliver,
+            WorkKind::Specify,
+            WorkKind::Govern,
+            WorkKind::Restructure,
+            WorkKind::Verify,
+            WorkKind::Repair,
+            WorkKind::Maintain,
+            WorkKind::Retire,
+            WorkKind::Review,
+            WorkKind::Adopt,
+        ] {
+            for check in work_kind_profile(kind).completion {
+                let command = check.render();
+                assert!(!command.contains("syu check graph"));
+                assert!(!command.contains("syu task check\n"));
+            }
+        }
+    }
+    #[test]
+    fn serialization_is_deterministic() {
+        let input = WorkPlanningInput {
+            request: "review".into(),
+            explicit_kind: Some(WorkKind::Review),
+            nodes: vec![
+                node("REQ-B", WorkSurface::Requirement, &[]),
+                node("REQ-A", WorkSurface::Requirement, &[]),
+            ],
+            search_candidates: vec![
+                seed("REQ-B", WorkSurface::Requirement),
+                seed("REQ-A", WorkSurface::Requirement),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_string(&plan_work(input.clone())).unwrap(),
+            serde_json::to_string(&plan_work(input)).unwrap()
+        );
+    }
+
+    #[test]
+    fn every_work_kind_applies_its_surface_contract() {
+        let cases = [
+            (
+                WorkKind::Specify,
+                WorkPlanningInput {
+                    request: "specify".into(),
+                    explicit_kind: Some(WorkKind::Specify),
+                    seeds: vec![seed("REQ-1", WorkSurface::Requirement)],
+                    nodes: vec![node("REQ-1", WorkSurface::Requirement, &[])],
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Govern,
+                WorkPlanningInput {
+                    request: "govern".into(),
+                    explicit_kind: Some(WorkKind::Govern),
+                    seeds: vec![seed("POL-1", WorkSurface::Policy)],
+                    nodes: vec![node("POL-1", WorkSurface::Policy, &[])],
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Restructure,
+                WorkPlanningInput {
+                    request: "restructure".into(),
+                    explicit_kind: Some(WorkKind::Restructure),
+                    explicit_operation: Some(WorkOperation::Modify),
+                    seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+                    nodes: vec![node("FEAT-1", WorkSurface::Feature, &[])],
+                    ..Default::default()
+                },
+            ),
+            (WorkKind::Verify, {
+                let mut requirement = node("REQ-1", WorkSurface::Requirement, &[]);
+                requirement.tests.push(TraceTarget {
+                    language: "rust".into(),
+                    file: "tests/verify.rs".into(),
+                    symbols: vec!["verifies".into()],
+                });
+                WorkPlanningInput {
+                    request: "verify".into(),
+                    explicit_kind: Some(WorkKind::Verify),
+                    seeds: vec![seed("REQ-1", WorkSurface::Requirement)],
+                    nodes: vec![requirement],
+                    ..Default::default()
+                }
+            }),
+            (
+                WorkKind::Repair,
+                WorkPlanningInput {
+                    request: "repair".into(),
+                    explicit_kind: Some(WorkKind::Repair),
+                    diagnostics: vec![WorkDiagnostic {
+                        rule: "trace".into(),
+                        subject: "REQ-1".into(),
+                        message: "broken trace".into(),
+                    }],
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Maintain,
+                WorkPlanningInput {
+                    request: "maintain".into(),
+                    explicit_kind: Some(WorkKind::Maintain),
+                    repository_changes: vec![RepositoryChange {
+                        path: "Cargo.toml".into(),
+                        owner_ids: Vec::new(),
+                    }],
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Retire,
+                WorkPlanningInput {
+                    request: "retire".into(),
+                    explicit_kind: Some(WorkKind::Retire),
+                    explicit_operation: Some(WorkOperation::Delete),
+                    seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+                    nodes: vec![node("FEAT-1", WorkSurface::Feature, &[])],
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Review,
+                WorkPlanningInput {
+                    request: "review".into(),
+                    explicit_kind: Some(WorkKind::Review),
+                    explicit_mode: Some(WorkMode::ReviewOnly),
+                    ..Default::default()
+                },
+            ),
+            (
+                WorkKind::Adopt,
+                WorkPlanningInput {
+                    request: "adopt".into(),
+                    explicit_kind: Some(WorkKind::Adopt),
+                    repository_changes: vec![RepositoryChange {
+                        path: "syu.yaml".into(),
+                        owner_ids: Vec::new(),
+                    }],
+                    ..Default::default()
+                },
+            ),
+        ];
+        for (kind, input) in cases {
+            let plan = plan_work(input);
+            assert!(plan.executable, "{kind:?}: {:?}", plan.impact.diagnostics);
+            if kind == WorkKind::Review {
+                assert!(plan.mutations.is_empty());
+            } else {
+                assert!(!plan.mutations.is_empty(), "{kind:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn deliver_excludes_sibling_features() {
+        let mut feature = node("FEAT-1", WorkSurface::Feature, &["REQ-1"]);
+        feature.implementations.push(TraceTarget {
+            language: "rust".into(),
+            file: "src/one.rs".into(),
+            symbols: Vec::new(),
+        });
+        let plan = plan_work(WorkPlanningInput {
+            request: "implement FEAT-1".into(),
+            seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+            nodes: vec![
+                feature,
+                node("REQ-1", WorkSurface::Requirement, &["FEAT-1", "FEAT-2"]),
+                node("FEAT-2", WorkSurface::Feature, &["REQ-1"]),
+            ],
+            ..Default::default()
+        });
+        assert!(!plan.impact.items.iter().any(|item| item.id == "FEAT-2"));
+    }
+
+    #[test]
+    fn operation_payload_and_forbidden_surface_fail_closed() {
+        let rename = plan_work(WorkPlanningInput {
+            request: "rename FEAT-1".into(),
+            explicit_kind: Some(WorkKind::Restructure),
+            seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+            nodes: vec![node("FEAT-1", WorkSurface::Feature, &[])],
+            ..Default::default()
+        });
+        assert!(!rename.executable);
+        assert!(rename.mutations.is_empty());
+
+        let maintain = plan_work(WorkPlanningInput {
+            request: "maintain FEAT-1".into(),
+            explicit_kind: Some(WorkKind::Maintain),
+            seeds: vec![seed("FEAT-1", WorkSurface::Feature)],
+            nodes: vec![node("FEAT-1", WorkSurface::Feature, &[])],
+            ..Default::default()
+        });
+        assert!(!maintain.executable);
+        assert!(maintain.mutations.is_empty());
+    }
+
+    #[test]
+    fn create_accepts_a_new_typed_seed() {
+        let plan = plan_work(WorkPlanningInput {
+            request: "create requirement".into(),
+            explicit_kind: Some(WorkKind::Specify),
+            explicit_operation: Some(WorkOperation::Create),
+            seeds: vec![seed("REQ-NEW", WorkSurface::Requirement)],
+            ..Default::default()
+        });
+        assert!(plan.executable);
+        assert!(matches!(
+            plan.mutations.as_slice(),
+            [WorkMutation::CreateItem { .. }]
+        ));
     }
 }

--- a/crates/syu-workbench-server/src/lib.rs
+++ b/crates/syu-workbench-server/src/lib.rs
@@ -30,14 +30,12 @@ use syu_core::{
 };
 use syu_domain::Issue;
 use syu_task_model::{
-    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanCompletion,
-    GoalPlanConfidence, GoalPlanCoverage, GoalPlanCoverageMode, GoalPlanGoal,
-    GoalPlanImplementationPlan, GoalPlanPersistentItem, GoalPlanPersistentItemDetails,
-    GoalPlanPersistentItems, GoalPlanScope, GoalPlanScopeInclude, GoalPlanSelectionMode,
-    GoalPlanSource, GoalPlanSourceEvidence, GoalPlanSourceMode, GoalPlanSpecMapping,
-    GoalPlanTestPlan, RequestArtifact, RequestClassification, ScaffoldAction, ScaffoldPlan,
-    ScaffoldUpdate, ScaffoldUpdateKind, ScopeFeatureCandidate, ScopeOutcome, ScopeSignals,
-    SearchResult, TaskTestSelectionCommand, TaskTestSelectionEscalation, TaskTestSelectionPlan,
+    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, RequestArtifact,
+    RequestClassification, ScaffoldAction, ScaffoldPlan, ScaffoldUpdate, ScaffoldUpdateKind,
+    ScopeFeatureCandidate, ScopeOutcome, ScopeSignals, SearchResult, SourceRole,
+    TaskTestSelectionCommand, TaskTestSelectionEscalation, TaskTestSelectionPlan, TraceTarget,
+    WorkConstraints, WorkGraphNode, WorkKind, WorkMode, WorkOperation, WorkPlan, WorkPlanningInput,
+    WorkSeed, WorkSurface, goal_plan_from_work_plan, plan_work,
 };
 use tokio::{
     sync::{RwLock, broadcast, mpsc},
@@ -738,6 +736,14 @@ pub struct RequestPlanRequest {
     pub request: RequestArtifact,
     #[serde(default)]
     pub request_path: Option<String>,
+    #[serde(default)]
+    pub kind: Option<WorkKind>,
+    #[serde(default)]
+    pub operation: Option<WorkOperation>,
+    #[serde(default)]
+    pub mode: Option<WorkMode>,
+    #[serde(default)]
+    pub constraints: WorkConstraints,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1099,7 +1105,7 @@ async fn request_plan(
     State(server): State<WorkbenchServer>,
     Json(request): Json<RequestPlanRequest>,
 ) -> Json<GoalPlanArtifact> {
-    let plan = goal_plan_from_request(&server, &request).await;
+    let plan = build_shared_goal_plan(&server, &request).await;
     server
         .inner
         .events
@@ -1572,122 +1578,152 @@ async fn scaffold_request(server: &WorkbenchServer, request: &RequestArtifact) -
     }
 }
 
-async fn goal_plan_from_request(
+async fn build_shared_goal_plan(
     server: &WorkbenchServer,
     request: &RequestPlanRequest,
 ) -> GoalPlanArtifact {
-    let classification = classify_request(server, &request.request).await;
-    let scope = scope_request(server, &request.request).await;
-    let explicit_ids = request.request.explicit_ids();
     let request_path = request
         .request_path
         .clone()
         .unwrap_or_else(|| "request.yaml".to_string());
-    GoalPlanArtifact {
-        version: 1,
-        kind: "syu.goal_plan".to_string(),
-        request_path: Some(request_path.clone()),
-        request: Some(request.request.request.clone()),
-        classification: Some(classification.classification.label().to_string()),
-        source: GoalPlanSource {
-            mode: GoalPlanSourceMode::RequestDriven,
-            request_artifact: Some(request_path),
-            classification: Some(classification.classification.label().to_string()),
-            range: None,
-            confidence: Some(GoalPlanConfidence::Medium),
-            evidence: Some(GoalPlanSourceEvidence {
-                changed_files: Vec::new(),
-                traced_requirements: explicit_ids.clone(),
-                traced_features: Vec::new(),
-                traced_policies: Vec::new(),
-                traced_philosophies: Vec::new(),
-            }),
-        },
-        goal: GoalPlanGoal {
-            id: "GOAL-001".to_string(),
-            title: "Plan the requested Workbench change".to_string(),
-            statement: request.request.request.clone(),
-            non_goals: vec!["Do not create a persistent spec layer".to_string()],
-            inferred: false,
-        },
-        spec_mapping: GoalPlanSpecMapping {
-            persistent_items: GoalPlanPersistentItems {
-                requirements: scope
-                    .requirements
+    let plan = shared_work_plan_with_options(server, request).await;
+    goal_plan_from_work_plan(&request.request.request, &request_path, &plan)
+}
+
+#[cfg(test)]
+async fn shared_work_plan(server: &WorkbenchServer, request: &RequestArtifact) -> WorkPlan {
+    shared_work_plan_input(
+        server,
+        request,
+        None,
+        None,
+        None,
+        WorkConstraints::default(),
+    )
+    .await
+}
+
+async fn shared_work_plan_with_options(
+    server: &WorkbenchServer,
+    request: &RequestPlanRequest,
+) -> WorkPlan {
+    shared_work_plan_input(
+        server,
+        &request.request,
+        request.kind,
+        request.operation,
+        request.mode,
+        request.constraints.clone(),
+    )
+    .await
+}
+
+async fn shared_work_plan_input(
+    server: &WorkbenchServer,
+    request: &RequestArtifact,
+    explicit_kind: Option<WorkKind>,
+    explicit_operation: Option<WorkOperation>,
+    explicit_mode: Option<WorkMode>,
+    constraints: WorkConstraints,
+) -> WorkPlan {
+    let search_candidates = search_request_items(server, request)
+        .await
+        .into_iter()
+        .filter_map(|item| {
+            work_surface_from_label(&item.kind).map(|surface| WorkSeed {
+                id: item.id,
+                surface,
+                source_role: SourceRole::SearchCandidate,
+            })
+        })
+        .collect();
+    let workspace = server.inner.browser_workspace.read().await;
+    let seeds = request
+        .explicit_ids()
+        .into_iter()
+        .map(|id| WorkSeed {
+            surface: work_surface_from_id(&id),
+            id,
+            source_role: SourceRole::Seed,
+        })
+        .collect();
+    let nodes = workspace
+        .sections
+        .iter()
+        .flat_map(|section| section.documents.iter())
+        .flat_map(|document| {
+            document.items.iter().map(|item| WorkGraphNode {
+                id: item.id.clone(),
+                surface: work_surface_from_section(item.kind),
+                document_path: Some(document.path.clone()),
+                status: item.status.clone(),
+                linked_ids: item
+                    .linked_philosophies
                     .iter()
-                    .map(|item| {
-                        GoalPlanPersistentItem::Item(GoalPlanPersistentItemDetails {
-                            id: item.id.clone(),
-                            title: Some(item.title.clone()),
-                            document_path: None,
-                        })
-                    })
+                    .chain(&item.linked_policies)
+                    .chain(&item.linked_requirements)
+                    .chain(&item.linked_features)
+                    .cloned()
                     .collect(),
-                features: scope
-                    .features
-                    .iter()
-                    .map(|item| {
-                        GoalPlanPersistentItem::Item(GoalPlanPersistentItemDetails {
-                            id: item.id.clone(),
-                            title: Some(item.title.clone()),
-                            document_path: None,
-                        })
-                    })
-                    .collect(),
-                policies: scope
-                    .policies
-                    .iter()
-                    .map(|item| {
-                        GoalPlanPersistentItem::Item(GoalPlanPersistentItemDetails {
-                            id: item.id.clone(),
-                            title: Some(item.title.clone()),
-                            document_path: None,
-                        })
-                    })
-                    .collect(),
-                philosophies: scope
-                    .philosophies
-                    .iter()
-                    .map(|item| {
-                        GoalPlanPersistentItem::Item(GoalPlanPersistentItemDetails {
-                            id: item.id.clone(),
-                            title: Some(item.title.clone()),
-                            document_path: None,
-                        })
-                    })
-                    .collect(),
-            },
-            spec_updates: Default::default(),
-            spec_updates_required: false,
-            spec_update_reasons: Vec::new(),
-        },
-        implementation_plan: GoalPlanImplementationPlan {
-            confidence: Some(GoalPlanConfidence::Medium),
-            scope: GoalPlanScope {
-                include: vec![GoalPlanScopeInclude::Pattern("src/**".to_string())],
-                exclude: vec!["docs/generated/**".to_string()],
-            },
-            steps: vec![
-                "Review the request".to_string(),
-                "Update the smallest typed surface".to_string(),
-            ],
-        },
-        test_plan: GoalPlanTestPlan {
-            selection_mode: GoalPlanSelectionMode::Minimal,
-            confidence: Some(GoalPlanConfidence::Medium),
-            required_tests: BTreeMap::new(),
-            suggested_tests: BTreeMap::new(),
-        },
-        coverage: GoalPlanCoverage {
-            mode: GoalPlanCoverageMode::ChangedLines,
-            threshold: 100,
-            include: Vec::new(),
-            exclude: Vec::new(),
-        },
-        completion: GoalPlanCompletion {
-            must_pass: vec!["syu validate .".to_string()],
-        },
-        warnings: Vec::new(),
+                implementations: browser_trace_targets(&item.implementations),
+                tests: browser_trace_targets(&item.tests),
+            })
+        })
+        .collect();
+    plan_work(WorkPlanningInput {
+        request: syu_task_model::work_request_text(request),
+        explicit_kind,
+        explicit_operation,
+        explicit_mode,
+        seeds,
+        search_candidates,
+        nodes,
+        constraints,
+        ..Default::default()
+    })
+}
+
+fn browser_trace_targets(groups: &[syu_core::BrowserTraceGroup]) -> Vec<TraceTarget> {
+    groups
+        .iter()
+        .flat_map(|group| {
+            group.references.iter().map(|reference| TraceTarget {
+                language: group.language.clone(),
+                file: reference.file.clone(),
+                symbols: reference.symbols.clone(),
+            })
+        })
+        .collect()
+}
+
+fn work_surface_from_section(section: SectionKind) -> WorkSurface {
+    match section {
+        SectionKind::Philosophy => WorkSurface::Philosophy,
+        SectionKind::Policies => WorkSurface::Policy,
+        SectionKind::Requirements => WorkSurface::Requirement,
+        SectionKind::Features => WorkSurface::Feature,
+    }
+}
+
+fn work_surface_from_label(label: &str) -> Option<WorkSurface> {
+    match label {
+        "philosophy" => Some(WorkSurface::Philosophy),
+        "policy" => Some(WorkSurface::Policy),
+        "requirement" => Some(WorkSurface::Requirement),
+        "feature" => Some(WorkSurface::Feature),
+        _ => None,
+    }
+}
+
+fn work_surface_from_id(id: &str) -> WorkSurface {
+    if id.starts_with("PHIL-") {
+        WorkSurface::Philosophy
+    } else if id.starts_with("POL-") {
+        WorkSurface::Policy
+    } else if id.starts_with("FEAT-") {
+        WorkSurface::Feature
+    } else {
+        WorkSurface::Requirement
     }
 }
 
@@ -1854,11 +1890,15 @@ async fn execute_action(
         }
         "request.plan" => {
             let request = request.context("request artifact required")?;
-            let plan = goal_plan_from_request(
+            let plan = build_shared_goal_plan(
                 server,
                 &RequestPlanRequest {
                     request,
                     request_path: None,
+                    kind: None,
+                    operation: None,
+                    mode: None,
+                    constraints: WorkConstraints::default(),
                 },
             )
             .await;
@@ -2241,7 +2281,31 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["kind"], "syu.goal_plan");
-        assert_eq!(json["goal"]["id"], "GOAL-001");
+        assert_eq!(json["goal"]["id"], "GOAL-WORK-001");
+        assert_eq!(json["classification"], "verify");
+        assert!(
+            json["test_plan"]["required_tests"]
+                .as_object()
+                .is_some_and(|tests| !tests.is_empty())
+        );
+        assert_ne!(
+            json["implementation_plan"]["scope"]["include"],
+            serde_json::json!(["src/**"])
+        );
+
+        let work_plan = shared_work_plan(
+            &server,
+            &RequestArtifact {
+                version: 1,
+                request: "Add Workbench planning coverage".to_string(),
+                context: syu_task_model::RequestArtifactContext {
+                    linked_ids: vec!["REQ-WORKBENCH-006".to_string()],
+                    ..Default::default()
+                },
+            },
+        )
+        .await;
+        assert!(!work_plan.impact.tests.is_empty());
     }
 
     #[tokio::test]
@@ -2311,7 +2375,7 @@ mod tests {
     #[tokio::test]
     async fn goal_check_endpoint_returns_report() {
         let server = test_server();
-        let plan = goal_plan_from_request(
+        let plan = build_shared_goal_plan(
             &server,
             &RequestPlanRequest {
                 request: RequestArtifact {
@@ -2320,6 +2384,10 @@ mod tests {
                     context: Default::default(),
                 },
                 request_path: Some("request.yaml".to_string()),
+                kind: None,
+                operation: None,
+                mode: None,
+                constraints: WorkConstraints::default(),
             },
         )
         .await;
@@ -2361,7 +2429,7 @@ mod tests {
     #[tokio::test]
     async fn goal_test_select_endpoint_records_evidence() {
         let server = test_server();
-        let plan = goal_plan_from_request(
+        let plan = build_shared_goal_plan(
             &server,
             &RequestPlanRequest {
                 request: RequestArtifact {
@@ -2370,6 +2438,10 @@ mod tests {
                     context: Default::default(),
                 },
                 request_path: Some("request.yaml".to_string()),
+                kind: None,
+                operation: None,
+                mode: None,
+                constraints: WorkConstraints::default(),
             },
         )
         .await;

--- a/crates/syu-workbench-server/src/lib.rs
+++ b/crates/syu-workbench-server/src/lib.rs
@@ -2282,6 +2282,8 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["kind"], "syu.goal_plan");
         assert_eq!(json["goal"]["id"], "GOAL-WORK-001");
+        assert!(json["work"].is_object());
+        assert_eq!(json["work"]["executable"], true);
         assert_eq!(json["classification"], "verify");
         assert!(
             json["test_plan"]["required_tests"]

--- a/crates/syu-workbench/src/lib.rs
+++ b/crates/syu-workbench/src/lib.rs
@@ -2436,6 +2436,7 @@ mod tests {
                 request_path: None,
                 request: None,
                 classification: None,
+                work: None,
                 source: Default::default(),
                 goal: syu_task_model::GoalPlanGoal {
                     id: "goal-1".to_string(),
@@ -2485,6 +2486,7 @@ mod tests {
                 request_path: None,
                 request: None,
                 classification: None,
+                work: None,
                 source: Default::default(),
                 goal: syu_task_model::GoalPlanGoal {
                     id: "goal-1".to_string(),

--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -202,7 +202,7 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
           - syu task test-select goal-plan.yaml
 - **id**: FEAT-TASK-007
   - **title**: Shared typed Work planner
-  - **summary**: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+  - **summary**: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through one UI-independent engine shared by CLI, automation, diff inference, and Workbench adapters.
   - **status**: implemented
   - **linked_requirements**:
     - REQ-CORE-034
@@ -214,16 +214,34 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
           - WorkOperation
           - WorkSurface
           - WorkMode
+          - SourceRole
           - ImpactRole
           - WorkIntent
           - WorkImpact
           - WorkMutation
           - WorkKindProfile
+          - SurfaceRequirement
+          - CompletionCheck
           - resolve_work_intent
+          - work_request_text
           - work_kind_profile
+          - plan_work
+          - goal_plan_from_work_plan
       - **file**: crates/syu-actions/src/lib.rs
         - **symbols**:
           - plan_request_work
+          - plan_request_work_with_constraints
+          - plan_item_work
+      - **file**: src/command/task.rs
+        - **symbols**:
+          - build_shared_request_work_plan
+          - build_goal_plan
+          - build_diff_inferred_goal_plan
+      - **file**: crates/syu-workbench-server/src/lib.rs
+        - **symbols**:
+          - shared_work_plan_with_options
+          - shared_work_plan_input
+          - build_shared_goal_plan
 
 ## Source YAML
 
@@ -417,7 +435,7 @@ features:
             - syu task test-select goal-plan.yaml
   - id: FEAT-TASK-007
     title: Shared typed Work planner
-    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through one UI-independent engine shared by CLI, automation, diff inference, and Workbench adapters.
     status: implemented
     linked_requirements:
       - REQ-CORE-034
@@ -429,14 +447,32 @@ features:
             - WorkOperation
             - WorkSurface
             - WorkMode
+            - SourceRole
             - ImpactRole
             - WorkIntent
             - WorkImpact
             - WorkMutation
             - WorkKindProfile
+            - SurfaceRequirement
+            - CompletionCheck
             - resolve_work_intent
+            - work_request_text
             - work_kind_profile
+            - plan_work
+            - goal_plan_from_work_plan
         - file: crates/syu-actions/src/lib.rs
           symbols:
             - plan_request_work
+            - plan_request_work_with_constraints
+            - plan_item_work
+        - file: src/command/task.rs
+          symbols:
+            - build_shared_request_work_plan
+            - build_goal_plan
+            - build_diff_inferred_goal_plan
+        - file: crates/syu-workbench-server/src/lib.rs
+          symbols:
+            - shared_work_plan_with_options
+            - shared_work_plan_input
+            - build_shared_goal_plan
 ```

--- a/docs/generated/site-spec/features/cli/task.md
+++ b/docs/generated/site-spec/features/cli/task.md
@@ -200,6 +200,30 @@ description: "Generated reference for docs/syu/features/cli/task.yaml"
       - **file**: docs/guide/command-card.md
         - **symbols**:
           - syu task test-select goal-plan.yaml
+- **id**: FEAT-TASK-007
+  - **title**: Shared typed Work planner
+  - **summary**: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+  - **status**: implemented
+  - **linked_requirements**:
+    - REQ-CORE-034
+  - **implementations**:
+    - **rust**:
+      - **file**: crates/syu-task-model/src/work.rs
+        - **symbols**:
+          - WorkKind
+          - WorkOperation
+          - WorkSurface
+          - WorkMode
+          - ImpactRole
+          - WorkIntent
+          - WorkImpact
+          - WorkMutation
+          - WorkKindProfile
+          - resolve_work_intent
+          - work_kind_profile
+      - **file**: crates/syu-actions/src/lib.rs
+        - **symbols**:
+          - plan_request_work
 
 ## Source YAML
 
@@ -391,4 +415,28 @@ features:
         - file: docs/guide/command-card.md
           symbols:
             - syu task test-select goal-plan.yaml
+  - id: FEAT-TASK-007
+    title: Shared typed Work planner
+    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-034
+    implementations:
+      rust:
+        - file: crates/syu-task-model/src/work.rs
+          symbols:
+            - WorkKind
+            - WorkOperation
+            - WorkSurface
+            - WorkMode
+            - ImpactRole
+            - WorkIntent
+            - WorkImpact
+            - WorkMutation
+            - WorkKindProfile
+            - resolve_work_intent
+            - work_kind_profile
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - plan_request_work
 ```

--- a/docs/generated/site-spec/policies/policies.md
+++ b/docs/generated/site-spec/policies/policies.md
@@ -49,6 +49,7 @@ description: "Generated reference for docs/syu/policies/policies.yaml"
     - REQ-CORE-031
     - REQ-CORE-032
     - REQ-CORE-033
+    - REQ-CORE-034
 - **id**: POL-002
   - **title**: Validation should explain the current state instead of only failing
   - **summary**: Errors, reports, and browsing should make the layered model legible even when the workspace is broken.
@@ -251,6 +252,7 @@ policies:
       - REQ-CORE-031
       - REQ-CORE-032
       - REQ-CORE-033
+      - REQ-CORE-034
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -890,16 +890,20 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
   - **title**: Plan typed work consistently across automation entry points
   - **description**:
     - |
-      The reusable action layer MUST represent planned work with independent,
+      The shared planning engine MUST represent planned work with independent,
       typed kind, operation, surface, mode, impact-role, mutation, and
       verification axes. It MUST support Deliver, Specify, Govern,
       Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
       MUST prefer explicit intent over inferred intent, and MUST expand Item
       seeds through the specification graph without including unrelated sibling
       branches. Each WorkKind MUST control its mutation constraints, required
-      surfaces, completion commands, and broad cargo-test fallback. Review work
-      MUST be mutation-free. The shared API MUST remain independent of
-      Workbench and other user-interface code.
+      surfaces, typed completion checks, and broad cargo-test fallback. It MUST
+      keep seed provenance separate from direct/context/follow-up/blocker impact,
+      MUST reject unknown seeds and incomplete operation payloads, and MUST
+      produce typed repository, test, edge, diagnostic, and split impacts.
+      Review work MUST be mutation-free. CLI request planning, diff inference,
+      automation, and Workbench request planning MUST use the same engine while
+      the engine remains independent of user-interface code.
   - **priority**: high
   - **status**: implemented
   - **linked_policies**:
@@ -910,13 +914,23 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
     - **rust**:
       - **file**: crates/syu-task-model/src/work.rs
         - **symbols**:
-          - explicit_kind_wins_and_axes_stay_independent
-          - review_profile_forbids_mutation_without_test_fallback
-          - classifies_representative_requests
+          - classifier_respects_tokens_and_infers_all_axes
+          - govern_traverses_philosophy_to_features_with_queue
+          - deliver_changes_owned_code_and_tests_not_feature_spec
+          - deliver_excludes_sibling_features
+          - unknown_seed_and_missing_contract_are_blockers
+          - operation_payload_and_forbidden_surface_fail_closed
+          - every_work_kind_applies_its_surface_contract
+          - completion_commands_render_valid_cli_shapes
+          - serialization_is_deterministic
       - **file**: crates/syu-actions/src/lib.rs
         - **symbols**:
           - request_planner_expands_item_seed_through_the_spec_graph
           - review_override_produces_evidence_only_plan
+          - item_and_request_entry_points_have_planner_parity
+      - **file**: crates/syu-workbench-server/src/lib.rs
+        - **symbols**:
+          - request_plan_endpoint_returns_goal_plan
 
 ## Source YAML
 
@@ -1778,16 +1792,20 @@ requirements:
   - id: REQ-CORE-034
     title: Plan typed work consistently across automation entry points
     description: |
-      The reusable action layer MUST represent planned work with independent,
+      The shared planning engine MUST represent planned work with independent,
       typed kind, operation, surface, mode, impact-role, mutation, and
       verification axes. It MUST support Deliver, Specify, Govern,
       Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
       MUST prefer explicit intent over inferred intent, and MUST expand Item
       seeds through the specification graph without including unrelated sibling
       branches. Each WorkKind MUST control its mutation constraints, required
-      surfaces, completion commands, and broad cargo-test fallback. Review work
-      MUST be mutation-free. The shared API MUST remain independent of
-      Workbench and other user-interface code.
+      surfaces, typed completion checks, and broad cargo-test fallback. It MUST
+      keep seed provenance separate from direct/context/follow-up/blocker impact,
+      MUST reject unknown seeds and incomplete operation payloads, and MUST
+      produce typed repository, test, edge, diagnostic, and split impacts.
+      Review work MUST be mutation-free. CLI request planning, diff inference,
+      automation, and Workbench request planning MUST use the same engine while
+      the engine remains independent of user-interface code.
     priority: high
     status: implemented
     linked_policies:
@@ -1798,11 +1816,21 @@ requirements:
       rust:
         - file: crates/syu-task-model/src/work.rs
           symbols:
-            - explicit_kind_wins_and_axes_stay_independent
-            - review_profile_forbids_mutation_without_test_fallback
-            - classifies_representative_requests
+            - classifier_respects_tokens_and_infers_all_axes
+            - govern_traverses_philosophy_to_features_with_queue
+            - deliver_changes_owned_code_and_tests_not_feature_spec
+            - deliver_excludes_sibling_features
+            - unknown_seed_and_missing_contract_are_blockers
+            - operation_payload_and_forbidden_surface_fail_closed
+            - every_work_kind_applies_its_surface_contract
+            - completion_commands_render_valid_cli_shapes
+            - serialization_is_deterministic
         - file: crates/syu-actions/src/lib.rs
           symbols:
             - request_planner_expands_item_seed_through_the_spec_graph
             - review_override_produces_evidence_only_plan
+            - item_and_request_entry_points_have_planner_parity
+        - file: crates/syu-workbench-server/src/lib.rs
+          symbols:
+            - request_plan_endpoint_returns_goal_plan
 ```

--- a/docs/generated/site-spec/requirements/core/workspace.md
+++ b/docs/generated/site-spec/requirements/core/workspace.md
@@ -886,6 +886,37 @@ description: "Generated reference for docs/syu/requirements/core/workspace.yaml"
       - **file**: docs/guide/command-card.md
         - **symbols**:
           - syu task test-select goal-plan.yaml
+- **id**: REQ-CORE-034
+  - **title**: Plan typed work consistently across automation entry points
+  - **description**:
+    - |
+      The reusable action layer MUST represent planned work with independent,
+      typed kind, operation, surface, mode, impact-role, mutation, and
+      verification axes. It MUST support Deliver, Specify, Govern,
+      Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
+      MUST prefer explicit intent over inferred intent, and MUST expand Item
+      seeds through the specification graph without including unrelated sibling
+      branches. Each WorkKind MUST control its mutation constraints, required
+      surfaces, completion commands, and broad cargo-test fallback. Review work
+      MUST be mutation-free. The shared API MUST remain independent of
+      Workbench and other user-interface code.
+  - **priority**: high
+  - **status**: implemented
+  - **linked_policies**:
+    - POL-001
+  - **linked_features**:
+    - FEAT-TASK-007
+  - **tests**:
+    - **rust**:
+      - **file**: crates/syu-task-model/src/work.rs
+        - **symbols**:
+          - explicit_kind_wins_and_axes_stay_independent
+          - review_profile_forbids_mutation_without_test_fallback
+          - classifies_representative_requests
+      - **file**: crates/syu-actions/src/lib.rs
+        - **symbols**:
+          - request_planner_expands_item_seed_through_the_spec_graph
+          - review_override_produces_evidence_only_plan
 
 ## Source YAML
 
@@ -1744,4 +1775,34 @@ requirements:
         - file: docs/guide/command-card.md
           symbols:
             - syu task test-select goal-plan.yaml
+  - id: REQ-CORE-034
+    title: Plan typed work consistently across automation entry points
+    description: |
+      The reusable action layer MUST represent planned work with independent,
+      typed kind, operation, surface, mode, impact-role, mutation, and
+      verification axes. It MUST support Deliver, Specify, Govern,
+      Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
+      MUST prefer explicit intent over inferred intent, and MUST expand Item
+      seeds through the specification graph without including unrelated sibling
+      branches. Each WorkKind MUST control its mutation constraints, required
+      surfaces, completion commands, and broad cargo-test fallback. Review work
+      MUST be mutation-free. The shared API MUST remain independent of
+      Workbench and other user-interface code.
+    priority: high
+    status: implemented
+    linked_policies:
+      - POL-001
+    linked_features:
+      - FEAT-TASK-007
+    tests:
+      rust:
+        - file: crates/syu-task-model/src/work.rs
+          symbols:
+            - explicit_kind_wins_and_axes_stay_independent
+            - review_profile_forbids_mutation_without_test_fallback
+            - classifies_representative_requests
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - request_planner_expands_item_seed_through_the_spec_graph
+            - review_override_produces_evidence_only_plan
 ```

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -14,8 +14,8 @@
 
 ## Traceability
 
-- Requirement-to-test traceability: 182/182
-- Feature-to-implementation traceability: 210/210
+- Requirement-to-test traceability: 183/183
+- Feature-to-implementation traceability: 212/212
 
 ## Issues
 

--- a/docs/generated/syu-report.md
+++ b/docs/generated/syu-report.md
@@ -9,13 +9,13 @@
 
 - Philosophies: 3
 - Policies: 8
-- Requirements: 39
-- Features: 54
+- Requirements: 40
+- Features: 55
 
 ## Traceability
 
-- Requirement-to-test traceability: 180/180
-- Feature-to-implementation traceability: 208/208
+- Requirement-to-test traceability: 182/182
+- Feature-to-implementation traceability: 210/210
 
 ## Issues
 

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -185,3 +185,27 @@ features:
         - file: docs/guide/command-card.md
           symbols:
             - syu task test-select goal-plan.yaml
+  - id: FEAT-TASK-007
+    title: Shared typed Work planner
+    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+    status: implemented
+    linked_requirements:
+      - REQ-CORE-034
+    implementations:
+      rust:
+        - file: crates/syu-task-model/src/work.rs
+          symbols:
+            - WorkKind
+            - WorkOperation
+            - WorkSurface
+            - WorkMode
+            - ImpactRole
+            - WorkIntent
+            - WorkImpact
+            - WorkMutation
+            - WorkKindProfile
+            - resolve_work_intent
+            - work_kind_profile
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - plan_request_work

--- a/docs/syu/features/cli/task.yaml
+++ b/docs/syu/features/cli/task.yaml
@@ -187,7 +187,7 @@ features:
             - syu task test-select goal-plan.yaml
   - id: FEAT-TASK-007
     title: Shared typed Work planner
-    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through a UI-independent action API.
+    summary: Resolve typed Work intent, graph impact, mutation previews, and WorkKind-specific verification through one UI-independent engine shared by CLI, automation, diff inference, and Workbench adapters.
     status: implemented
     linked_requirements:
       - REQ-CORE-034
@@ -199,13 +199,31 @@ features:
             - WorkOperation
             - WorkSurface
             - WorkMode
+            - SourceRole
             - ImpactRole
             - WorkIntent
             - WorkImpact
             - WorkMutation
             - WorkKindProfile
+            - SurfaceRequirement
+            - CompletionCheck
             - resolve_work_intent
+            - work_request_text
             - work_kind_profile
+            - plan_work
+            - goal_plan_from_work_plan
         - file: crates/syu-actions/src/lib.rs
           symbols:
             - plan_request_work
+            - plan_request_work_with_constraints
+            - plan_item_work
+        - file: src/command/task.rs
+          symbols:
+            - build_shared_request_work_plan
+            - build_goal_plan
+            - build_diff_inferred_goal_plan
+        - file: crates/syu-workbench-server/src/lib.rs
+          symbols:
+            - shared_work_plan_with_options
+            - shared_work_plan_input
+            - build_shared_goal_plan

--- a/docs/syu/policies/policies.yaml
+++ b/docs/syu/policies/policies.yaml
@@ -30,6 +30,7 @@ policies:
       - REQ-CORE-031
       - REQ-CORE-032
       - REQ-CORE-033
+      - REQ-CORE-034
 
   - id: POL-002
     title: Validation should explain the current state instead of only failing

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -852,3 +852,33 @@ requirements:
         - file: docs/guide/command-card.md
           symbols:
             - syu task test-select goal-plan.yaml
+  - id: REQ-CORE-034
+    title: Plan typed work consistently across automation entry points
+    description: |
+      The reusable action layer MUST represent planned work with independent,
+      typed kind, operation, surface, mode, impact-role, mutation, and
+      verification axes. It MUST support Deliver, Specify, Govern,
+      Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
+      MUST prefer explicit intent over inferred intent, and MUST expand Item
+      seeds through the specification graph without including unrelated sibling
+      branches. Each WorkKind MUST control its mutation constraints, required
+      surfaces, completion commands, and broad cargo-test fallback. Review work
+      MUST be mutation-free. The shared API MUST remain independent of
+      Workbench and other user-interface code.
+    priority: high
+    status: implemented
+    linked_policies:
+      - POL-001
+    linked_features:
+      - FEAT-TASK-007
+    tests:
+      rust:
+        - file: crates/syu-task-model/src/work.rs
+          symbols:
+            - explicit_kind_wins_and_axes_stay_independent
+            - review_profile_forbids_mutation_without_test_fallback
+            - classifies_representative_requests
+        - file: crates/syu-actions/src/lib.rs
+          symbols:
+            - request_planner_expands_item_seed_through_the_spec_graph
+            - review_override_produces_evidence_only_plan

--- a/docs/syu/requirements/core/workspace.yaml
+++ b/docs/syu/requirements/core/workspace.yaml
@@ -855,16 +855,20 @@ requirements:
   - id: REQ-CORE-034
     title: Plan typed work consistently across automation entry points
     description: |
-      The reusable action layer MUST represent planned work with independent,
+      The shared planning engine MUST represent planned work with independent,
       typed kind, operation, surface, mode, impact-role, mutation, and
       verification axes. It MUST support Deliver, Specify, Govern,
       Restructure, Verify, Repair, Maintain, Retire, Review, and Adopt work,
       MUST prefer explicit intent over inferred intent, and MUST expand Item
       seeds through the specification graph without including unrelated sibling
       branches. Each WorkKind MUST control its mutation constraints, required
-      surfaces, completion commands, and broad cargo-test fallback. Review work
-      MUST be mutation-free. The shared API MUST remain independent of
-      Workbench and other user-interface code.
+      surfaces, typed completion checks, and broad cargo-test fallback. It MUST
+      keep seed provenance separate from direct/context/follow-up/blocker impact,
+      MUST reject unknown seeds and incomplete operation payloads, and MUST
+      produce typed repository, test, edge, diagnostic, and split impacts.
+      Review work MUST be mutation-free. CLI request planning, diff inference,
+      automation, and Workbench request planning MUST use the same engine while
+      the engine remains independent of user-interface code.
     priority: high
     status: implemented
     linked_policies:
@@ -875,10 +879,20 @@ requirements:
       rust:
         - file: crates/syu-task-model/src/work.rs
           symbols:
-            - explicit_kind_wins_and_axes_stay_independent
-            - review_profile_forbids_mutation_without_test_fallback
-            - classifies_representative_requests
+            - classifier_respects_tokens_and_infers_all_axes
+            - govern_traverses_philosophy_to_features_with_queue
+            - deliver_changes_owned_code_and_tests_not_feature_spec
+            - deliver_excludes_sibling_features
+            - unknown_seed_and_missing_contract_are_blockers
+            - operation_payload_and_forbidden_surface_fail_closed
+            - every_work_kind_applies_its_surface_contract
+            - completion_commands_render_valid_cli_shapes
+            - serialization_is_deterministic
         - file: crates/syu-actions/src/lib.rs
           symbols:
             - request_planner_expands_item_seed_through_the_spec_graph
             - review_override_produces_evidence_only_plan
+            - item_and_request_entry_points_have_planner_parity
+        - file: crates/syu-workbench-server/src/lib.rs
+          symbols:
+            - request_plan_endpoint_returns_goal_plan

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -18,12 +18,14 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use regex::Regex;
 use serde::Serialize;
 use syu_task_model::{
-    ClassificationOutcome, GoalPlanArtifact, GoalPlanCheckReport, GoalPlanConfidence,
-    GoalPlanScope, GoalPlanScopeInclude, GoalPlanSelectionMode, GoalPlanSourceMode,
-    RequestArtifact, RequestArtifactContext, RequestClassification as RequirementAction,
-    ScaffoldAction, ScaffoldPlan, ScaffoldUpdate, ScaffoldUpdateKind, ScopeFeatureCandidate,
-    ScopeOutcome, ScopeSignals, SearchResult as TaskSearchResult, TaskTestSelectionCommand,
-    TaskTestSelectionEscalation, TaskTestSelectionPlan,
+    ClassificationOutcome, CompletionCheck, GoalPlanArtifact, GoalPlanCheckReport,
+    GoalPlanConfidence, GoalPlanScope, GoalPlanScopeInclude, GoalPlanSelectionMode,
+    GoalPlanSourceMode, RequestArtifact, RequestArtifactContext,
+    RequestClassification as RequirementAction, ScaffoldAction, ScaffoldPlan, ScaffoldUpdate,
+    ScaffoldUpdateKind, ScopeFeatureCandidate, ScopeOutcome, ScopeSignals,
+    SearchResult as TaskSearchResult, SourceRole, TaskTestSelectionCommand,
+    TaskTestSelectionEscalation, TaskTestSelectionPlan, TraceTarget, WorkGraphNode,
+    WorkPlanningInput, WorkSeed, WorkSurface, plan_work,
 };
 
 use crate::{
@@ -127,6 +129,7 @@ pub struct JsonTaskPlanOutput {
     request_path: String,
     request: String,
     classification: String,
+    work: syu_task_model::WorkPlan,
     source: JsonTaskPlanSource,
     goal: JsonTaskPlanGoal,
     spec_mapping: JsonTaskPlanSpecMapping,
@@ -570,17 +573,31 @@ pub fn build_goal_plan(
     request_path: &Path,
     output_path: Option<&Path>,
 ) -> Result<JsonTaskPlanOutput> {
+    let work_plan = build_shared_request_work_plan(workspace, outcome, explicit_ids, &[]);
     let lookup = WorkspaceLookup::new(workspace);
     let persistent_items = collect_task_plan_persistent_items(&lookup, outcome)?;
     let spec_update_reasons = determine_spec_update_reasons(outcome, &persistent_items);
     let spec_updates_required = !spec_update_reasons.is_empty();
-    let scope_include = collect_task_plan_scope_entries(
+    let mut scope_include = collect_task_plan_scope_entries(
         workspace,
         &lookup,
         &persistent_items,
         outcome,
         explicit_ids,
     )?;
+    let direct_work_scope = work_plan
+        .impact
+        .repository
+        .iter()
+        .filter(|impact| impact.impact_role == syu_task_model::ImpactRole::DirectChange)
+        .map(|impact| JsonTaskPlanScopeEntry {
+            file: impact.path.clone(),
+            symbols: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    if !direct_work_scope.is_empty() {
+        scope_include = direct_work_scope;
+    }
     let test_plan = collect_task_plan_tests(&lookup, &persistent_items, outcome)?;
 
     let source_confidence = if outcome.classification.explicit_items.is_empty()
@@ -599,11 +616,12 @@ pub fn build_goal_plan(
         kind: "syu.goal_plan".to_string(),
         request_path: request_path.display().to_string(),
         request: outcome.classification.request.clone(),
-        classification: outcome.classification.classification.label().to_string(),
+        classification: format!("{:?}", work_plan.intent.kind).to_lowercase(),
+        work: work_plan.clone(),
         source: JsonTaskPlanSource {
             mode: "request_driven".to_string(),
             request_artifact: Some(request_path.display().to_string()),
-            classification: Some(outcome.classification.classification.label().to_string()),
+            classification: Some(format!("{:?}", work_plan.intent.kind).to_lowercase()),
             range: None,
             confidence: source_confidence.to_string(),
             evidence: None,
@@ -640,21 +658,163 @@ pub fn build_goal_plan(
             threshold: 100,
         },
         completion: JsonTaskPlanCompletion {
-            must_pass: task_plan_completion_checks(output_path),
+            must_pass: render_work_completion(&work_plan, output_path),
         },
-        warnings: collect_task_plan_warnings(outcome),
+        warnings: collect_task_plan_warnings(outcome)
+            .into_iter()
+            .chain(
+                work_plan
+                    .impact
+                    .diagnostics
+                    .iter()
+                    .map(|diagnostic| format!("{}: {}", diagnostic.rule, diagnostic.reason)),
+            )
+            .collect(),
     })
 }
 
-fn task_plan_completion_checks(output_path: Option<&Path>) -> Vec<String> {
+fn build_shared_request_work_plan(
+    workspace: &crate::workspace::Workspace,
+    outcome: &ScopeOutcome,
+    explicit_ids: &[String],
+    changed_files: &[PathBuf],
+) -> syu_task_model::WorkPlan {
+    let seeds = explicit_ids
+        .iter()
+        .map(|id| WorkSeed {
+            id: id.clone(),
+            surface: work_surface_from_id(id),
+            source_role: SourceRole::Seed,
+        })
+        .collect();
+    let search_candidates = outcome
+        .classification
+        .related_items
+        .iter()
+        .filter_map(|item| {
+            work_surface_from_label(&item.kind).map(|surface| WorkSeed {
+                id: item.id.clone(),
+                surface,
+                source_role: SourceRole::SearchCandidate,
+            })
+        })
+        .collect();
+    let nodes = workspace
+        .philosophies
+        .iter()
+        .map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Philosophy,
+            document_path: None,
+            status: None,
+            linked_ids: item.linked_policies.clone(),
+            implementations: Vec::new(),
+            tests: Vec::new(),
+        })
+        .chain(workspace.policies.iter().map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Policy,
+            document_path: None,
+            status: None,
+            linked_ids: item.linked_requirements.clone(),
+            implementations: Vec::new(),
+            tests: Vec::new(),
+        }))
+        .chain(workspace.requirements.iter().map(|item| {
+            WorkGraphNode {
+                id: item.id.clone(),
+                surface: WorkSurface::Requirement,
+                document_path: None,
+                status: Some(item.status.clone()),
+                linked_ids: item
+                    .linked_policies
+                    .iter()
+                    .chain(&item.linked_features)
+                    .cloned()
+                    .collect(),
+                implementations: Vec::new(),
+                tests: task_trace_targets(&item.tests),
+            }
+        }))
+        .chain(workspace.features.iter().map(|item| WorkGraphNode {
+            id: item.id.clone(),
+            surface: WorkSurface::Feature,
+            document_path: None,
+            status: Some(item.status.clone()),
+            linked_ids: item.linked_requirements.clone(),
+            implementations: task_trace_targets(&item.implementations),
+            tests: Vec::new(),
+        }))
+        .collect();
+    plan_work(WorkPlanningInput {
+        request: outcome.classification.request.clone(),
+        seeds,
+        search_candidates,
+        nodes,
+        repository_changes: changed_files
+            .iter()
+            .map(|path| syu_task_model::RepositoryChange {
+                path: path_label(path),
+                owner_ids: Vec::new(),
+            })
+            .collect(),
+        ..Default::default()
+    })
+}
+
+fn task_trace_targets(map: &BTreeMap<String, Vec<syu_domain::TraceReference>>) -> Vec<TraceTarget> {
+    map.iter()
+        .flat_map(|(language, references)| {
+            references.iter().map(move |reference| TraceTarget {
+                language: language.clone(),
+                file: reference.file.display().to_string(),
+                symbols: reference.symbols.clone(),
+            })
+        })
+        .collect()
+}
+
+fn work_surface_from_id(id: &str) -> WorkSurface {
+    if id.starts_with("PHIL-") {
+        WorkSurface::Philosophy
+    } else if id.starts_with("POL-") {
+        WorkSurface::Policy
+    } else if id.starts_with("FEAT-") {
+        WorkSurface::Feature
+    } else {
+        WorkSurface::Requirement
+    }
+}
+
+fn work_surface_from_label(label: &str) -> Option<WorkSurface> {
+    match label {
+        "philosophy" => Some(WorkSurface::Philosophy),
+        "policy" => Some(WorkSurface::Policy),
+        "requirement" => Some(WorkSurface::Requirement),
+        "feature" => Some(WorkSurface::Feature),
+        _ => None,
+    }
+}
+
+fn render_work_completion(
+    plan: &syu_task_model::WorkPlan,
+    output_path: Option<&Path>,
+) -> Vec<String> {
     let plan_path = output_path
         .map(|path| path.display().to_string())
         .unwrap_or_else(|| ".syu/tasks/current.yaml".to_string());
-
-    vec![
-        format!("syu task check {plan_path} --range origin/main...HEAD"),
-        "syu validate .".to_string(),
-    ]
+    plan.verification
+        .completion
+        .iter()
+        .map(|check| match check {
+            CompletionCheck::GoalPlanCheck { range, .. } => CompletionCheck::GoalPlanCheck {
+                plan_path: plan_path.clone(),
+                range: range.clone(),
+            }
+            .render(),
+            _ => check.render(),
+        })
+        .collect()
 }
 
 fn inferred_goal_plan_completion_checks(range: &str, output_path: Option<&Path>) -> Vec<String> {
@@ -1311,6 +1471,15 @@ pub fn build_diff_inferred_goal_plan(
 ) -> Result<JsonTaskPlanOutput> {
     let lookup = WorkspaceLookup::new(workspace);
     let inference = infer_diff_plan(workspace, &lookup, range, changed_files)?;
+    let direct_ids = inference
+        .scope
+        .classification
+        .explicit_items
+        .iter()
+        .map(|item| item.id.clone())
+        .collect::<Vec<_>>();
+    let work_plan =
+        build_shared_request_work_plan(workspace, &inference.scope, &direct_ids, changed_files);
     let persistent_items = collect_task_plan_persistent_items(&lookup, &inference.scope)?;
     let spec_update_reasons = determine_spec_update_reasons(&inference.scope, &persistent_items);
     let spec_updates_required = !spec_update_reasons.is_empty();
@@ -1330,12 +1499,8 @@ pub fn build_diff_inferred_goal_plan(
         kind: "syu.goal_plan".to_string(),
         request_path: range.to_string(),
         request: format!("git diff {range}"),
-        classification: inference
-            .scope
-            .classification
-            .classification
-            .label()
-            .to_string(),
+        classification: format!("{:?}", work_plan.intent.kind).to_lowercase(),
+        work: work_plan.clone(),
         source: JsonTaskPlanSource {
             mode: "diff_inferred".to_string(),
             request_artifact: None,
@@ -1371,7 +1536,17 @@ pub fn build_diff_inferred_goal_plan(
         completion: JsonTaskPlanCompletion {
             must_pass: inferred_goal_plan_completion_checks(range, output_path),
         },
-        warnings: inference.warnings,
+        warnings: inference
+            .warnings
+            .into_iter()
+            .chain(
+                work_plan
+                    .impact
+                    .diagnostics
+                    .iter()
+                    .map(|diagnostic| format!("{}: {}", diagnostic.rule, diagnostic.reason)),
+            )
+            .collect(),
     })
 }
 

--- a/src/command/task.rs
+++ b/src/command/task.rs
@@ -4328,6 +4328,7 @@ mod tests {
                 request_path: Some("request.yaml".to_string()),
                 request: Some("Keep temporary planning explicit".to_string()),
                 classification: Some("request_driven".to_string()),
+                work: None,
                 warnings: vec!["inferred from request text".to_string()],
                 source: GoalPlanSource {
                     mode: GoalPlanSourceMode::DiffInferred,


### PR DESCRIPTION
Summary:
- Add a typed, UI-independent Work planning engine with independent kind, operation, surface, mode, source provenance, impact role, mutation, and verification models.
- Route CLI request plans, CLI diff inference, automation request/Item entry points, and Workbench `/api/request/plan` through the same queue-based planner.
- Generate directional graph, repository, test, edge, diagnostic, and split impacts while excluding unrelated sibling branches.
- Replace generic mutations and raw completion strings with operation-specific payloads and typed completion checks.
- Enforce required/alternative/forbidden surface contracts, unknown/retired seed validation, and operation payload validation through blocker diagnostics.
- Replace the Workbench server's fixed `src/**` / empty-tests Goal Plan builder with a shared planner adapter.
- Add full WorkKind matrix, traversal, classifier, contract, parity, and deterministic serialization tests.

Validation:
- `cargo test -p syu-task-model -p syu-actions -p syu-workbench-server -p syu-workbench -p syu-app-ui --no-fail-fast`
- `cargo test --test task_command --quiet`
- `cargo clippy -p syu -p syu-task-model -p syu-actions -p syu-workbench-server --all-targets -- -D warnings`
- `bash scripts/ci/check-workbench.sh`
- `bash scripts/ci/check-generated-docs-freshness.sh`
- `target/debug/syu validate .`
- `git diff --check`

Notes:
- The full local pre-push gate reaches two unrelated environment-sensitive failures in existing report tests and macOS `script -c` incompatibility in interactive add-command tests. Focused planner, CLI, Workbench, clippy, docs, and validation checks pass; remote CI is authoritative for the full gate.
